### PR TITLE
E2E devnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ e2e/.e2e-state.json
 e2e/test-results/
 e2e/playwright-report/
 
+# o1js compilation cache
+cache/
+
 # misc
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ui/out/
 .env
 .env.*
 !.env.example
+!.env.*.example
 
 # editor / OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ cd backend && bun run dev
 bun run --filter contracts test
 ```
 
+## E2E Testing
+
+Full end-to-end tests live in `e2e/` and exercise the deploy → propose → approve → execute lifecycle against a real Mina network. See [e2e/README.md](e2e/README.md) for setup details.
+
+```bash
+# Quick start with local lightnet (default)
+cd e2e && bun install && bun test
+
+# Against Mina devnet (requires funded accounts in e2e/.env.devnet)
+cd e2e && NETWORK=devnet bun test
+```
+
 ## Build
 
 ```bash

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -87,10 +87,13 @@ export class MinaGuardIndexer {
 
       if (toHeight >= fromHeight) {
         await this.syncKnownContracts(fromHeight, toHeight);
-        await this.deriveExpiredProposals(latestHeight);
         await this.setIndexedHeight(toHeight);
         this.status.indexedHeight = toHeight;
       }
+
+      // Check for expired proposals on every tick, even when no new blocks
+      // were ingested — the chain height may already be past the expiry.
+      await this.deriveExpiredProposals(latestHeight);
 
       this.status.lastSuccessfulRunAt = new Date().toISOString();
       this.status.lastError = null;

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "mina-guard",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "e2e": "^0.0.8",
+      },
     },
     "backend": {
       "name": "backend",
@@ -524,7 +528,7 @@
 
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
-    "@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
@@ -1412,7 +1416,7 @@
 
     "ui": ["ui@workspace:ui"],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
 
@@ -1544,6 +1548,8 @@
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "contracts/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
+
     "dev-helpers/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
     "eslint/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -1642,33 +1648,7 @@
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "@jest/console/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/core/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/environment/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/fake-timers/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/pattern/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@jest/reporters/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "@jest/reporters/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
-    "@jest/types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/body-parser/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/connect/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/cors/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/express-serve-static-core/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/send/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@types/serve-static/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@typescript-eslint/eslint-plugin/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1680,39 +1660,21 @@
 
     "@typescript-eslint/utils/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
-    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "c12/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
-    "dev-helpers/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "contracts/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "eslint/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "istanbul-lib-source-maps/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "jest-circus/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "jest-config/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
-    "jest-environment-node/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "jest-haste-map/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "jest-mock/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "jest-runner/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "jest-runtime/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "jest-runtime/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
-    "jest-util/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "jest-watcher/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "jest-worker/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "ui/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/e2e/.env.devnet.example
+++ b/e2e/.env.devnet.example
@@ -1,0 +1,14 @@
+NETWORK=devnet
+
+# Funded devnet test accounts (3 required)
+# Fund these via the Mina faucet: https://faucet.minaprotocol.com
+DEVNET_ACCOUNT_1_PK=
+DEVNET_ACCOUNT_1_SK=
+DEVNET_ACCOUNT_2_PK=
+DEVNET_ACCOUNT_2_SK=
+DEVNET_ACCOUNT_3_PK=
+DEVNET_ACCOUNT_3_SK=
+
+# Optional: override default devnet endpoints
+# DEVNET_MINA_ENDPOINT=https://api.minascan.io/node/devnet/v1/graphql
+# DEVNET_ARCHIVE_ENDPOINT=https://api.minascan.io/archive/devnet/v1/graphql

--- a/e2e/.env.devnet.example
+++ b/e2e/.env.devnet.example
@@ -9,6 +9,6 @@ DEVNET_ACCOUNT_2_SK=
 DEVNET_ACCOUNT_3_PK=
 DEVNET_ACCOUNT_3_SK=
 
-# Optional: override default devnet endpoints
+# Optional: override default devnet endpoints (must have CORS enabled for browser worker)
 # DEVNET_MINA_ENDPOINT=https://api.minascan.io/node/devnet/v1/graphql
 # DEVNET_ARCHIVE_ENDPOINT=https://api.minascan.io/archive/devnet/v1/graphql

--- a/e2e/.env.devnet.example
+++ b/e2e/.env.devnet.example
@@ -12,3 +12,7 @@ DEVNET_ACCOUNT_3_SK=
 # Optional: override default devnet endpoints (must have CORS enabled for browser worker)
 # DEVNET_MINA_ENDPOINT=https://api.minascan.io/node/devnet/v1/graphql
 # DEVNET_ARCHIVE_ENDPOINT=https://api.minascan.io/archive/devnet/v1/graphql
+
+# Optional: skip vk hash compilation by providing it directly.
+# If omitted, the setup auto-compiles the contract to extract the hash.
+# MINAGUARD_VK_HASH=

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -70,6 +70,22 @@ NETWORK=devnet bun test
 
 Devnet tests are significantly slower (~45 min) due to ~3-minute block times and real proof generation.
 
+### Verification key hash
+
+On devnet the backend needs the MinaGuard verification key hash (`MINAGUARD_VK_HASH`) to filter out unrelated contracts. The setup **automatically compiles** the contract to extract this hash before starting the backend. The first compilation is slow (~2-5 min), but subsequent runs use a cache.
+
+To skip the compilation step, set the hash explicitly in `.env.devnet`:
+
+```
+MINAGUARD_VK_HASH=12345...
+```
+
+You can obtain the hash manually with:
+
+```bash
+bun run dev-helpers/cli.ts vk-hash compile
+```
+
 ## Configuration
 
 All timing and endpoint settings are centralised in [network-config.ts](network-config.ts). Key differences between modes:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,121 @@
+# E2E Tests
+
+End-to-end tests for MinaGuard using [Playwright](https://playwright.dev/). The test suite exercises the full lifecycle — deploy, propose, approve, execute — against a real Mina network through the UI with a mock wallet.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) installed
+- Contracts built: `bun run --filter contracts build` (from monorepo root)
+- Playwright browsers installed: `bunx playwright install` (from `e2e/`)
+
+For **lightnet** mode you also need the `zkapp-cli` (`zk`) installed globally:
+
+```bash
+npm install -g zkapp-cli
+```
+
+## Quick start (lightnet)
+
+Lightnet is the default mode. The test harness automatically starts a local Mina network, backend, and frontend, then tears everything down when done.
+
+```bash
+cd e2e
+bun install
+bun test
+```
+
+This will:
+
+1. Start a local lightnet (`zk lightnet start`)
+2. Acquire 3 funded test accounts from the lightnet account manager
+3. Reset the backend database and start the backend + frontend
+4. Run the Playwright tests
+5. Stop all services on teardown
+
+## Running against devnet
+
+Set `NETWORK=devnet` and provide 3 funded devnet accounts.
+
+### 1. Create your env file
+
+```bash
+cp .env.devnet.example .env.devnet
+```
+
+Edit `.env.devnet` and fill in the keys for 3 funded accounts. You can fund accounts via the [Mina faucet](https://faucet.minaprotocol.com).
+
+```
+NETWORK=devnet
+
+DEVNET_ACCOUNT_1_PK=B62q...
+DEVNET_ACCOUNT_1_SK=EKE...
+DEVNET_ACCOUNT_2_PK=B62q...
+DEVNET_ACCOUNT_2_SK=EKE...
+DEVNET_ACCOUNT_3_PK=B62q...
+DEVNET_ACCOUNT_3_SK=EKE...
+```
+
+You can optionally override the Mina and archive endpoints:
+
+```
+DEVNET_MINA_ENDPOINT=https://api.minascan.io/node/devnet/v1/graphql
+DEVNET_ARCHIVE_ENDPOINT=https://api.minascan.io/archive/devnet/v1/graphql
+```
+
+### 2. Run
+
+```bash
+NETWORK=devnet bun test
+```
+
+Devnet tests are significantly slower (~45 min) due to ~3-minute block times and real proof generation.
+
+## Configuration
+
+All timing and endpoint settings are centralised in [network-config.ts](network-config.ts). Key differences between modes:
+
+|                       | Lightnet       | Devnet           |
+| --------------------- | -------------- | ---------------- |
+| Block time            | ~3 s           | ~3 min           |
+| Proof generation      | Skipped        | Real             |
+| Test timeout          | 15 min         | 45 min           |
+| Accounts              | Auto-acquired  | Manual (3 keys)  |
+| Services              | Auto-managed   | Auto-managed     |
+
+## Project structure
+
+```
+e2e/
+├── playwright.config.ts      # Playwright configuration
+├── network-config.ts         # Network mode, endpoints, and timing
+├── global-setup.ts           # Starts lightnet/backend/frontend before tests
+├── global-teardown.ts        # Stops all services after tests
+├── helpers.ts                # Wallet mock, API helpers, indexer polling
+├── mina-guard-flow.test.ts   # Main test suite
+├── .env.devnet.example       # Template for devnet account keys
+└── .env.devnet               # Your local devnet config (git-ignored)
+```
+
+## CI
+
+In CI (`CI=true`), the global setup skips starting lightnet, backend, and frontend — those are expected to be running already (e.g. via Docker services or prior workflow steps). The setup still acquires test accounts and waits for services to be healthy.
+
+## Verbose mode
+
+By default, `bun test` inside `e2e/` runs Playwright through the workspace filter which suppresses real-time output. To see full setup logs, test progress, and service output as they happen, run from the **monorepo root**:
+
+```bash
+# Lightnet
+bun run test:e2e:verbose
+
+# Devnet
+NETWORK=devnet bun run test:e2e:verbose
+```
+
+This invokes Playwright directly and streams all `[e2e-setup]`, `[e2e]`, and `[e2e-teardown]` logs to your terminal.
+
+## Debugging
+
+- Playwright HTML report is generated at `e2e/playwright-report/` (run `bunx playwright show-report` to view)
+- Traces and screenshots are captured on failure (in `e2e/test-results/`)
+- Logs are prefixed with `[e2e-setup]`, `[e2e-teardown]`, and `[e2e]` for easy filtering

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -189,6 +189,32 @@ export default async function globalSetup() {
     });
     log('Database schema pushed');
 
+    // -----------------------------------------------------------------------
+    // Verification key hash — compile the contract to get the vk hash so
+    // the backend indexer only picks up MinaGuard contracts on devnet.
+    // Skipped when MINAGUARD_VK_HASH is already set or in lightnet mode.
+    // -----------------------------------------------------------------------
+    let vkHash = process.env.MINAGUARD_VK_HASH ?? null;
+    if (!vkHash && config.mode === 'devnet') {
+      log('Compiling MinaGuard contract to extract vk hash (uses cache if available)...');
+      try {
+        const output = execSync('bun run dev-helpers/cli.ts vk-hash compile', {
+          cwd: ROOT,
+          stdio: 'pipe',
+          timeout: 600_000, // 10 min — first compile is slow
+        }).toString();
+        const match = output.match(/vkHash:\s*(\S+)/);
+        if (match) {
+          vkHash = match[1];
+          log(`  Extracted vk hash: ${vkHash.slice(0, 20)}...`);
+        } else {
+          log('  Warning: could not parse vk hash from compile output');
+        }
+      } catch (err) {
+        log(`  Warning: vk hash compilation failed: ${err}`);
+      }
+    }
+
     // Start backend
     log('Starting backend...');
     const backendEnv: Record<string, string> = {
@@ -200,6 +226,9 @@ export default async function globalSetup() {
     };
     if (config.accountManagerUrl) {
       backendEnv.LIGHTNET_ACCOUNT_MANAGER = config.accountManagerUrl;
+    }
+    if (vkHash) {
+      backendEnv.MINAGUARD_VK_HASH = vkHash;
     }
     const backendChild = spawnService(
       'bun',

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,21 +1,14 @@
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { getNetworkConfig, getDevnetAccounts, type TestAccount } from './network-config';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const STATE_FILE = resolve(import.meta.dirname, '.e2e-state.json');
-const ACCOUNT_MANAGER = 'http://127.0.0.1:8181';
-const BACKEND_URL = 'http://localhost:4000';
-const FRONTEND_URL = 'http://localhost:3000';
 
 // In CI, lightnet/backend/frontend are started externally (GitHub Actions services + steps).
 // Locally, we manage the full lifecycle ourselves.
 const IS_CI = process.env.CI === 'true';
-
-interface TestAccount {
-  publicKey: string;
-  privateKey: string;
-}
 
 interface E2eState {
   accounts: TestAccount[];
@@ -49,8 +42,8 @@ async function waitForUrl(
   throw new Error(`Timed out waiting for ${label} at ${url}`);
 }
 
-async function acquireAccount(): Promise<TestAccount> {
-  const res = await fetch(`${ACCOUNT_MANAGER}/acquire-account`);
+async function acquireAccount(accountManagerUrl: string): Promise<TestAccount> {
+  const res = await fetch(`${accountManagerUrl}/acquire-account`);
   if (!res.ok) {
     throw new Error(
       `Account manager returned ${res.status}: ${await res.text()}`
@@ -89,54 +82,79 @@ function spawnService(
   return child;
 }
 
+async function waitForPortFree(port: number, timeoutMs = 10_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const out = execSync(`lsof -ti:${port} 2>/dev/null || true`, { stdio: 'pipe' }).toString().trim();
+      if (!out) return;
+    } catch {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  log(`Warning: port ${port} still in use after ${timeoutMs / 1000}s`);
+}
+
 export default async function globalSetup() {
-  log(`=== E2E Global Setup (${IS_CI ? 'CI' : 'local'}) ===`);
+  const config = getNetworkConfig();
+  log(`=== E2E Global Setup (${IS_CI ? 'CI' : 'local'}, network=${config.mode}) ===`);
 
   // -----------------------------------------------------------------------
   // Lightnet — only managed locally; in CI it's a Docker service
+  // Skipped entirely when running against devnet.
   // -----------------------------------------------------------------------
-  if (!IS_CI) {
-    log('Stopping any existing lightnet...');
-    try {
-      execSync('zk lightnet stop', { cwd: ROOT, stdio: 'pipe', timeout: 30_000 });
-      log('Previous lightnet stopped');
-    } catch {
-      log('No existing lightnet to stop');
+  if (config.mode === 'lightnet') {
+    if (!IS_CI) {
+      log('Stopping any existing lightnet...');
+      try {
+        execSync('zk lightnet stop', { cwd: ROOT, stdio: 'pipe', timeout: 30_000 });
+        log('Previous lightnet stopped');
+      } catch {
+        log('No existing lightnet to stop');
+      }
+
+      log('Starting lightnet (this may take 1-2 minutes)...');
+      try {
+        execSync('zk lightnet start', {
+          cwd: ROOT,
+          stdio: 'inherit',
+          timeout: 300_000,
+        });
+      } catch (err) {
+        throw new Error(`Failed to start lightnet: ${err}`);
+      }
     }
 
-    log('Starting lightnet (this may take 1-2 minutes)...');
-    try {
-      execSync('zk lightnet start', {
-        cwd: ROOT,
-        stdio: 'inherit',
-        timeout: 300_000,
-      });
-    } catch (err) {
-      throw new Error(`Failed to start lightnet: ${err}`);
-    }
+    // Wait for lightnet services (both CI and local)
+    log('Waiting for lightnet services...');
+    await waitForUrl(
+      config.minaEndpoint,
+      'Mina daemon',
+      60_000
+    ).catch(() => {
+      log('Daemon GET failed, assuming it is up (GraphQL needs POST)');
+    });
+    await waitForUrl(config.accountManagerUrl!, 'Account manager', 60_000);
   }
-
-  // Wait for lightnet services (both CI and local)
-  log('Waiting for lightnet services...');
-  await waitForUrl(
-    'http://127.0.0.1:8080/graphql',
-    'Mina daemon',
-    60_000
-  ).catch(() => {
-    log('Daemon GET failed, assuming it is up (GraphQL needs POST)');
-  });
-  await waitForUrl(ACCOUNT_MANAGER, 'Account manager', 60_000);
 
   // -----------------------------------------------------------------------
   // Test accounts
   // -----------------------------------------------------------------------
-  log('Acquiring 3 funded test accounts...');
-  const accounts: TestAccount[] = [];
-  for (let i = 0; i < 3; i++) {
-    const acc = await acquireAccount();
-    accounts.push(acc);
-    log(`  Account ${i + 1}: ${acc.publicKey}`);
+  let accounts: TestAccount[];
+
+  if (config.mode === 'devnet') {
+    log('Loading hardcoded devnet accounts...');
+    accounts = getDevnetAccounts();
+  } else {
+    log('Acquiring 3 funded test accounts from lightnet...');
+    accounts = [];
+    for (let i = 0; i < 3; i++) {
+      const acc = await acquireAccount(config.accountManagerUrl!);
+      accounts.push(acc);
+    }
   }
+  accounts.forEach((a, i) => log(`  Account ${i + 1}: ${a.publicKey}`));
 
   // -----------------------------------------------------------------------
   // Backend + Frontend — only managed locally; in CI they're started by the workflow
@@ -145,7 +163,7 @@ export default async function globalSetup() {
   let frontendPid = 0;
 
   if (!IS_CI) {
-    // Kill stale processes on our ports
+    // Kill stale processes on our ports and wait for them to release
     log('Killing any stale processes on ports 3000 and 4000...');
     try {
       execSync('lsof -ti:3000 | xargs kill -9 2>/dev/null || true', { stdio: 'pipe' });
@@ -153,6 +171,9 @@ export default async function globalSetup() {
     } catch {
       // fine
     }
+    // Wait until ports are actually free
+    await waitForPortFree(4000);
+    await waitForPortFree(3000);
 
     // Reset database
     log('Resetting backend database...');
@@ -170,17 +191,20 @@ export default async function globalSetup() {
 
     // Start backend
     log('Starting backend...');
+    const backendEnv: Record<string, string> = {
+      INDEX_POLL_INTERVAL_MS: String(config.indexerPollIntervalMs),
+      MINA_ENDPOINT: config.minaEndpoint,
+      ARCHIVE_ENDPOINT: config.archiveEndpoint,
+      DATABASE_URL: 'file:./dev.db',
+      PORT: '4000',
+    };
+    if (config.accountManagerUrl) {
+      backendEnv.LIGHTNET_ACCOUNT_MANAGER = config.accountManagerUrl;
+    }
     const backendChild = spawnService(
       'bun',
       ['run', 'dev:backend'],
-      {
-        INDEX_POLL_INTERVAL_MS: '5000',
-        MINA_ENDPOINT: 'http://127.0.0.1:8080/graphql',
-        ARCHIVE_ENDPOINT: 'http://127.0.0.1:8282',
-        LIGHTNET_ACCOUNT_MANAGER: ACCOUNT_MANAGER,
-        DATABASE_URL: 'file:./dev.db',
-        PORT: '4000',
-      },
+      backendEnv,
       'backend'
     );
 
@@ -190,9 +214,9 @@ export default async function globalSetup() {
       'bun',
       ['run', 'dev'],
       {
-        NEXT_PUBLIC_API_BASE_URL: BACKEND_URL,
-        NEXT_PUBLIC_MINA_ENDPOINT: 'http://127.0.0.1:8080/graphql',
-        NEXT_PUBLIC_ARCHIVE_ENDPOINT: 'http://127.0.0.1:8282',
+        NEXT_PUBLIC_API_BASE_URL: config.backendUrl,
+        NEXT_PUBLIC_MINA_ENDPOINT: config.minaEndpoint,
+        NEXT_PUBLIC_ARCHIVE_ENDPOINT: config.archiveEndpoint,
       },
       'frontend'
     );
@@ -205,8 +229,8 @@ export default async function globalSetup() {
   }
 
   // Wait for services (both CI and local)
-  await waitForUrl(`${BACKEND_URL}/health`, 'Backend');
-  await waitForUrl(FRONTEND_URL, 'Frontend');
+  await waitForUrl(`${config.backendUrl}/health`, 'Backend');
+  await waitForUrl(config.frontendUrl, 'Frontend');
 
   // Write state for tests and teardown
   const state: E2eState = {

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, unlinkSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { getNetworkConfig } from './network-config';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const STATE_FILE = resolve(import.meta.dirname, '.e2e-state.json');
@@ -39,8 +40,8 @@ export default async function globalTeardown() {
     log('State file cleaned up');
   }
 
-  // Stop lightnet (only locally — in CI it's a Docker service)
-  if (!IS_CI) {
+  // Stop lightnet (only locally and only when using lightnet mode)
+  if (!IS_CI && getNetworkConfig().mode === 'lightnet') {
     log('Stopping lightnet...');
     try {
       execSync('zk lightnet stop', { cwd: ROOT, stdio: 'pipe', timeout: 30_000 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -9,6 +9,7 @@ import {
   AccountUpdate,
   fetchAccount,
 } from 'o1js';
+import { getNetworkConfig } from './network-config';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,7 +48,7 @@ export function loadState(): E2eState {
 // Backend API helpers
 // ---------------------------------------------------------------------------
 
-const API = 'http://localhost:4000';
+const API = getNetworkConfig().backendUrl;
 
 export async function apiGet<T>(path: string): Promise<T | null> {
   try {
@@ -129,9 +130,12 @@ export async function getApprovals(
 export async function waitForIndexer(
   description: string,
   check: () => Promise<boolean>,
-  timeoutMs = 240_000,
-  intervalMs = 5_000
+  timeoutMs?: number,
+  intervalMs?: number,
 ): Promise<void> {
+  const config = getNetworkConfig();
+  timeoutMs ??= config.indexerTimeoutMs;
+  intervalMs ??= config.indexerPollIntervalMs;
   log(`Waiting: ${description}`);
   const start = Date.now();
   let dots = 0;
@@ -168,10 +172,11 @@ export async function fundContract(
   amountMina: number = 10
 ): Promise<void> {
   if (!minaNetworkConfigured) {
+    const config = getNetworkConfig();
     Mina.setActiveInstance(
       Mina.Network({
-        mina: 'http://127.0.0.1:8080/graphql',
-        archive: 'http://127.0.0.1:8282',
+        mina: config.minaEndpoint,
+        archive: config.archiveEndpoint,
       })
     );
     minaNetworkConfigured = true;
@@ -198,8 +203,36 @@ export async function fundContract(
       ? (result.hash as () => string)()
       : result.hash;
   log(`  Fund tx sent: ${hash}`);
-  // Wait for inclusion so the next step doesn't hit Insufficient_replace_fee
-  await result.wait();
+  // Poll the contract's on-chain balance to confirm inclusion.
+  // result.wait() can hang indefinitely on devnet, so we check the actual
+  // outcome instead: the target account's balance increasing.
+  const config = getNetworkConfig();
+  const timeoutMs = config.indexerTimeoutMs; // 240s lightnet, 900s devnet
+  const pollMs = config.indexerPollIntervalMs;
+  const start = Date.now();
+
+  // Snapshot balance before (account may not exist yet → 0)
+  const before = await fetchAccount({ publicKey: target });
+  const balanceBefore = before.account
+    ? BigInt(before.account.balance.toBigInt())
+    : 0n;
+  log(`  Contract balance before: ${balanceBefore} nanomina`);
+
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, pollMs));
+    const acct = await fetchAccount({ publicKey: target });
+    const bal = acct.account ? BigInt(acct.account.balance.toBigInt()) : 0n;
+    if (bal > balanceBefore) {
+      log(`  Fund tx confirmed — balance: ${bal} nanomina (+${bal - balanceBefore})`);
+      return;
+    }
+    if ((Date.now() - start) % (pollMs * 5) < pollMs) {
+      log(`  Still waiting for fund tx inclusion... (${((Date.now() - start) / 1000).toFixed(0)}s)`);
+    }
+  }
+  throw new Error(
+    `Fund tx not confirmed after ${(timeoutMs / 1000).toFixed(0)}s — contract balance did not increase`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -305,6 +338,7 @@ export async function activateTestKey(
   page: Page,
   account: TestAccount
 ): Promise<void> {
+  const config = getNetworkConfig();
   log(`Setting test key for account ${account.publicKey.slice(0, 12)}...`);
   // Wait for the worker to be initialized (the __e2eSetTestKey global)
   await page.waitForFunction(
@@ -315,9 +349,11 @@ export async function activateTestKey(
     async (pk: string) => (window as any).__e2eSetTestKey(pk),
     account.privateKey
   );
-  await page.evaluate(
-    async () => (window as any).__e2eSetSkipProofs(true)
-  );
+  if (config.skipProofs) {
+    await page.evaluate(
+      async () => (window as any).__e2eSetSkipProofs(true)
+    );
+  }
 }
 
 /**
@@ -352,8 +388,9 @@ export async function switchAccount(
 export async function waitForBanner(
   page: Page,
   type: 'success' | 'error' = 'success',
-  timeoutMs = 600_000
+  timeoutMs?: number
 ): Promise<string> {
+  timeoutMs ??= getNetworkConfig().bannerTimeoutMs;
   // Dismiss any stale banner by clicking its close button
   const closeBtn = page.locator('button:has-text("×")');
   if (await closeBtn.first().isVisible().catch(() => false)) {
@@ -399,7 +436,7 @@ export async function waitForOperationDone(
  */
 export async function checkTxStatus(txHash: string): Promise<string> {
   try {
-    const res = await fetch('http://127.0.0.1:8080/graphql', {
+    const res = await fetch(getNetworkConfig().minaEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -428,7 +465,7 @@ export async function checkTxStatus(txHash: string): Promise<string> {
       }
     }
     // Check if it's still in the mempool
-    const poolRes = await fetch('http://127.0.0.1:8080/graphql', {
+    const poolRes = await fetch(getNetworkConfig().minaEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/e2e/mina-guard-flow.test.ts
+++ b/e2e/mina-guard-flow.test.ts
@@ -20,6 +20,11 @@ import {
   dumpState,
   type TestAccount,
 } from './helpers';
+import { getNetworkConfig } from './network-config';
+
+const netConfig = getNetworkConfig();
+const SETTLE_WAIT = netConfig.settlementWaitMs;
+const SHORT_WAIT = netConfig.mode === 'devnet' ? 10_000 : 3_000;
 
 // ---------------------------------------------------------------------------
 // Shared state across sequential tests
@@ -43,7 +48,7 @@ test.beforeAll(async ({ browser }) => {
   );
 
   // Create a single page that will be reused for all tests
-  sharedContext = await browser.newContext({ baseURL: 'http://localhost:3000' });
+  sharedContext = await browser.newContext({ baseURL: netConfig.frontendUrl });
   sharedPage = await sharedContext.newPage();
 
   // Capture browser console for diagnostics
@@ -92,6 +97,20 @@ async function gotoWithWallet(
       await page.waitForTimeout(300);
     }
     await navigateTo(page, path);
+  }
+
+  // On devnet the indexer discovers old contracts from previous runs,
+  // so the sidebar dropdown may default to the wrong one.
+  if (contractAddress && netConfig.mode === 'devnet') {
+    const selector = page.locator('select');
+    if (await selector.isVisible().catch(() => false)) {
+      const currentVal = await selector.inputValue();
+      if (currentVal !== contractAddress) {
+        log(`Switching contract selector to ${contractAddress.slice(0, 12)}...`);
+        await selector.selectOption(contractAddress);
+        await page.waitForTimeout(2_000);
+      }
+    }
   }
 }
 
@@ -175,9 +194,7 @@ test('2. Setup contract (account1 as owner, threshold=1/1)', async () => { const
   log('=== Step 2: Setup contract ===');
   await gotoWithWallet('/', accounts[0]);
 
-  // Select the deployed contract if needed
-  // The dashboard might auto-select the only contract, or we may need to select it
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Click "Setup Contract" button
   log('Clicking Setup Contract...');
@@ -254,7 +271,7 @@ test('2. Setup contract (account1 as owner, threshold=1/1)', async () => { const
 test('3. Propose add owner (account2)', async () => { const page = sharedPage;
   log('=== Step 3: Propose add owner ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Click "New Proposal"
   log('Clicking New Proposal...');
@@ -320,7 +337,7 @@ test('4. Execute add owner proposal', async () => { const page = sharedPage;
   log('=== Step 4: Execute add owner ===');
   const proposalHash = proposalHashes[0];
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Click "Execute Proposal"
   log('Clicking Execute Proposal...');
@@ -448,7 +465,7 @@ test('6. Execute threshold change', async () => { const page = sharedPage;
   log('=== Step 6: Execute threshold change ===');
   const proposalHash = proposalHashes[1];
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking Execute Proposal...');
   const executeBtn = page.getByRole('button', { name: /execute proposal/i });
@@ -479,7 +496,7 @@ test('6. Execute threshold change', async () => { const page = sharedPage;
 test('7. Propose send MINA to account3', async () => { const page = sharedPage;
   log('=== Step 7: Propose MINA transfer ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Open proposal modal from dashboard
   log('Clicking New Proposal...');
@@ -546,7 +563,7 @@ test('8. Approve transfer (account2)', async () => { const page = sharedPage;
 
   // Navigate as account2
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[1]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Click "Approve Proposal"
   log('Clicking Approve Proposal...');
@@ -590,11 +607,11 @@ test('9. Execute transfer (account2)', async () => { const page = sharedPage;
   // before attempting execute. The on-chain approvalRoot must reflect
   // the new approval, otherwise the Merkle witness will be invalid.
   log('Waiting for on-chain state to settle after approval...');
-  await new Promise((r) => setTimeout(r, 30_000));
+  await new Promise((r) => setTimeout(r, SETTLE_WAIT));
 
   // Navigate as account2
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[1]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Click "Execute Proposal"
   log('Clicking Execute Proposal...');
@@ -610,7 +627,7 @@ test('9. Execute transfer (account2)', async () => { const page = sharedPage;
   if (txHashMatch) {
     log(`Execute tx hash: ${txHashMatch[0]}`);
     // Give the node time to process, then check status
-    await new Promise((r) => setTimeout(r, 30_000));
+    await new Promise((r) => setTimeout(r, SETTLE_WAIT));
     await checkTxStatus(txHashMatch[0]);
   }
 
@@ -648,7 +665,7 @@ test('9. Execute transfer (account2)', async () => { const page = sharedPage;
 test('10. Verify Settings page', async () => { const page = sharedPage;
   log('=== Step 10: Verify Settings page ===');
   await gotoWithWallet('/settings', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Verify "Required Confirmations" section exists
   await expect(page.locator('text=Required Confirmations')).toBeVisible({ timeout: 10_000 });
@@ -672,7 +689,7 @@ test('10. Verify Settings page', async () => { const page = sharedPage;
 test('11. Verify Transactions page filtering', async () => { const page = sharedPage;
   log('=== Step 11: Verify Transactions page filtering ===');
   await gotoWithWallet('/transactions', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // After steps 1-9: 3 proposals total (addOwner=executed, changeThreshold=executed, transfer=executed)
   // All tab should show 3
@@ -706,7 +723,7 @@ test('11. Verify Transactions page filtering', async () => { const page = shared
 test('12. Propose threshold change to 1/2', async () => { const page = sharedPage;
   log('=== Step 12: Propose threshold change to 1/2 ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking New Proposal...');
   const newProposalBtn = page.getByRole('button', { name: /new proposal/i });
@@ -777,7 +794,7 @@ test('13. Approve threshold change (account2)', async () => { const page = share
   const proposalHash = proposalHashes[3];
 
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[1]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking Approve Proposal...');
   const approveBtn = page.getByRole('button', { name: /approve proposal/i });
@@ -809,7 +826,7 @@ test('14. Execute threshold change to 1/2', async () => { const page = sharedPag
   const proposalHash = proposalHashes[3];
 
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking Execute Proposal...');
   const executeBtn = page.getByRole('button', { name: /execute proposal/i });
@@ -839,7 +856,7 @@ test('14. Execute threshold change to 1/2', async () => { const page = sharedPag
 test('15. Propose remove owner (account2)', async () => { const page = sharedPage;
   log('=== Step 15: Propose remove owner ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking New Proposal...');
   const newProposalBtn = page.getByRole('button', { name: /new proposal/i });
@@ -902,7 +919,7 @@ test('16. Execute remove owner', async () => { const page = sharedPage;
   const proposalHash = proposalHashes[4];
 
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking Execute Proposal...');
   const executeBtn = page.getByRole('button', { name: /execute proposal/i });
@@ -948,7 +965,7 @@ test('16. Execute remove owner', async () => { const page = sharedPage;
 test('17. Verify state after owner removal', async () => { const page = sharedPage;
   log('=== Step 17: Verify state after owner removal ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Dashboard delegate card should show "None"
   await expect(page.locator('text=Block Producer Delegate')).toBeVisible({ timeout: 10_000 });
@@ -963,7 +980,7 @@ test('17. Verify state after owner removal', async () => { const page = sharedPa
 test('18. Propose set delegate (account3)', async () => { const page = sharedPage;
   log('=== Step 18: Propose set delegate ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking New Proposal...');
   const newProposalBtn = page.getByRole('button', { name: /new proposal/i });
@@ -1024,7 +1041,7 @@ test('19. Execute set delegate', async () => { const page = sharedPage;
   const proposalHash = proposalHashes[5];
 
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking Execute Proposal...');
   const executeBtn = page.getByRole('button', { name: /execute proposal/i });
@@ -1062,7 +1079,7 @@ test('19. Execute set delegate', async () => { const page = sharedPage;
 test('20. Verify delegate card shows delegate', async () => { const page = sharedPage;
   log('=== Step 20: Verify delegate card ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // The delegate card should show the account3 address (truncated)
   await expect(page.locator('text=Block Producer Delegate')).toBeVisible({ timeout: 10_000 });
@@ -1078,7 +1095,7 @@ test('20. Verify delegate card shows delegate', async () => { const page = share
 test('21. Propose undelegate', async () => { const page = sharedPage;
   log('=== Step 21: Propose undelegate ===');
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking New Proposal...');
   const newProposalBtn = page.getByRole('button', { name: /new proposal/i });
@@ -1140,7 +1157,7 @@ test('22. Execute undelegate', async () => { const page = sharedPage;
   const proposalHash = proposalHashes[6];
 
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking Execute Proposal...');
   const executeBtn = page.getByRole('button', { name: /execute proposal/i });
@@ -1182,11 +1199,11 @@ test('23. Propose transfer with near-future expiry', async () => { const page = 
   // Get current block height from indexer status
   const status = await getIndexerStatus();
   const currentHeight = status?.latestChainHeight ?? status?.indexedHeight ?? 0;
-  const expiryBlock = currentHeight + 2; // expires in ~40s (20s slot time)
+  const expiryBlock = currentHeight + netConfig.expiryBlockOffset;
   log(`Current block height: ${currentHeight}, setting expiry: ${expiryBlock}`);
 
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   log('Clicking New Proposal...');
   const newProposalBtn = page.getByRole('button', { name: /new proposal/i });
@@ -1254,8 +1271,8 @@ test('24. Verify proposal expires and execute button is hidden', async () => { c
       const proposal = await getProposal(contractAddress, proposalHash);
       return proposal?.status === 'expired';
     },
-    180_000, // 3 min — need to wait for blocks to pass the expiry
-    5_000
+    netConfig.mode === 'devnet' ? 2_400_000 : 180_000, // devnet: 40 min, lightnet: 3 min
+    netConfig.indexerPollIntervalMs
   );
 
   const proposal = await getProposal(contractAddress, proposalHash);
@@ -1264,7 +1281,7 @@ test('24. Verify proposal expires and execute button is hidden', async () => { c
 
   // Navigate to the proposal detail page
   await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   // Verify status badge shows "Expired" (red)
   const expiredBadge = page.locator('text=expired').or(page.locator('text=Expired'));
@@ -1291,19 +1308,19 @@ test('25. Verify final state', async () => { const page = sharedPage;
 
   // Dashboard — delegate card should show contract self (undelegated)
   await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
   await expect(page.locator('text=Block Producer Delegate')).toBeVisible({ timeout: 10_000 });
   log('Delegate card visible on dashboard');
 
   // Settings — 1 owner
   await navigateTo(page, '/settings');
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
   await expect(page.locator('text=Owners (1)')).toBeVisible({ timeout: 10_000 });
   log('Settings shows 1 owner');
 
   // Transactions — all proposals should be executed
   await navigateTo(page, '/transactions');
-  await page.waitForTimeout(3_000);
+  await page.waitForTimeout(SHORT_WAIT);
 
   const executedTab = page.locator('button', { hasText: /Executed/i }).first();
   const executedText = await executedTab.textContent();

--- a/e2e/network-config.ts
+++ b/e2e/network-config.ts
@@ -1,0 +1,122 @@
+/**
+ * Centralised network configuration for E2E tests.
+ *
+ * Set NETWORK=devnet to run against Mina devnet instead of a local lightnet.
+ * When using devnet, provide funded account keys in e2e/.env.devnet or as
+ * environment variables: DEVNET_ACCOUNT_{1,2,3}_{PK,SK}
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Only load e2e/.env.devnet when NETWORK=devnet is explicitly set.
+// Variables already set in the environment take precedence.
+const envDevnetPath = resolve(import.meta.dirname, '.env.devnet');
+if (process.env.NETWORK === 'devnet' && existsSync(envDevnetPath)) {
+  const content = readFileSync(envDevnetPath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    // Don't override existing env vars
+    if (process.env[key] === undefined && value) {
+      process.env[key] = value;
+    }
+  }
+}
+
+export type NetworkMode = 'lightnet' | 'devnet';
+
+export interface TestAccount {
+  publicKey: string;
+  privateKey: string;
+}
+
+export interface NetworkConfig {
+  mode: NetworkMode;
+  minaEndpoint: string;
+  archiveEndpoint: string;
+  accountManagerUrl: string | null;
+  backendUrl: string;
+  frontendUrl: string;
+  // Timing
+  blockTimeMs: number;
+  indexerPollIntervalMs: number;
+  indexerTimeoutMs: number;
+  bannerTimeoutMs: number;
+  testStepTimeoutMs: number;
+  settlementWaitMs: number;
+  expiryBlockOffset: number;
+  skipProofs: boolean;
+}
+
+const LIGHTNET_CONFIG: NetworkConfig = {
+  mode: 'lightnet',
+  minaEndpoint: 'http://127.0.0.1:8080/graphql',
+  archiveEndpoint: 'http://127.0.0.1:8282',
+  accountManagerUrl: 'http://127.0.0.1:8181',
+  backendUrl: 'http://localhost:4000',
+  frontendUrl: 'http://localhost:3000',
+  blockTimeMs: 3_000,
+  indexerPollIntervalMs: 5_000,
+  indexerTimeoutMs: 240_000,
+  bannerTimeoutMs: 600_000,
+  testStepTimeoutMs: 15 * 60 * 1_000,
+  settlementWaitMs: 30_000,
+  expiryBlockOffset: 2,
+  skipProofs: true,
+};
+
+function buildDevnetConfig(): NetworkConfig {
+  return {
+    mode: 'devnet',
+    minaEndpoint:
+      process.env.DEVNET_MINA_ENDPOINT ??
+      'https://api.minascan.io/node/devnet/v1/graphql',
+    archiveEndpoint:
+      process.env.DEVNET_ARCHIVE_ENDPOINT ??
+      'https://api.minascan.io/archive/devnet/v1/graphql',
+    accountManagerUrl: null,
+    backendUrl: 'http://localhost:4000',
+    frontendUrl: 'http://localhost:3000',
+    blockTimeMs: 180_000,
+    indexerPollIntervalMs: 15_000,
+    indexerTimeoutMs: 900_000,
+    bannerTimeoutMs: 1_800_000,
+    testStepTimeoutMs: 45 * 60 * 1_000,
+    settlementWaitMs: 300_000,
+    expiryBlockOffset: 10,
+    skipProofs: false,
+    };
+}
+
+let _config: NetworkConfig | null = null;
+
+export function getNetworkConfig(): NetworkConfig {
+  if (_config) return _config;
+  const mode = (process.env.NETWORK ?? 'lightnet') as NetworkMode;
+  if (mode !== 'lightnet' && mode !== 'devnet') {
+    throw new Error(`Invalid NETWORK value: ${mode}. Use "lightnet" or "devnet".`);
+  }
+  _config = mode === 'devnet' ? buildDevnetConfig() : { ...LIGHTNET_CONFIG };
+  return _config;
+}
+
+export function getDevnetAccounts(): TestAccount[] {
+  const accounts: TestAccount[] = [];
+  for (let i = 1; i <= 3; i++) {
+    const pk = process.env[`DEVNET_ACCOUNT_${i}_PK`];
+    const sk = process.env[`DEVNET_ACCOUNT_${i}_SK`];
+    if (!pk || !sk) {
+      throw new Error(
+        `Missing env var DEVNET_ACCOUNT_${i}_PK or DEVNET_ACCOUNT_${i}_SK. ` +
+          'Provide 3 funded devnet accounts in e2e/.env.devnet or as env vars.',
+      );
+    }
+    accounts.push({ publicKey: pk, privateKey: sk });
+  }
+  return accounts;
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,18 +1,21 @@
 import { defineConfig } from '@playwright/test';
+import { getNetworkConfig } from './network-config';
+
+const config = getNetworkConfig();
 
 export default defineConfig({
   testDir: '.',
   testMatch: '*.test.ts',
-  timeout: 15 * 60 * 1000, // 15 min per test step (proof generation is slow)
+  timeout: config.testStepTimeoutMs,
   retries: 0,
   workers: 1,
   globalSetup: './global-setup.ts',
   globalTeardown: './global-teardown.ts',
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: config.frontendUrl,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
-    actionTimeout: 30_000,
+    actionTimeout: config.mode === 'devnet' ? 60_000 : 30_000,
   },
 });

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,15 @@
     "test": "bun run --filter contracts test",
     "test:proofs": "bun run --filter contracts test:proofs",
     "test:e2e": "bun run --filter e2e test",
+    "test:e2e:verbose": "node e2e/node_modules/@playwright/test/cli.js test --config e2e/playwright.config.ts",
     "dev": "bun run --filter ui dev",
     "dev:backend": "bun run --filter backend dev",
     "build": "bun run --filter contracts --filter ui build",
     "build:backend": "bun run --filter backend build",
     "typecheck": "bun run --filter contracts typecheck && bun run --filter backend build"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "e2e": "workspace:*"
   }
 }

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -46,10 +46,8 @@ type SignFieldsFn = (
 /** Callback type for reporting step-based progress to the main thread. */
 type ProgressFn = (step: string) => void;
 
-// const MINA_ENDPOINT = process.env.NEXT_PUBLIC_MINA_ENDPOINT ?? 'https://api.minascan.io/node/devnet/v1/graphql';
-// const ARCHIVE_ENDPOINT = process.env.NEXT_PUBLIC_ARCHIVE_ENDPOINT ?? 'https://api.minascan.io/archive/devnet/v1/graphql';
-const MINA_ENDPOINT = 'http://127.0.0.1:8080/graphql';
-const ARCHIVE_ENDPOINT = 'http://127.0.0.1:8282';
+const MINA_ENDPOINT = process.env.NEXT_PUBLIC_MINA_ENDPOINT ?? 'https://api.minascan.io/node/devnet/v1/graphql';
+const ARCHIVE_ENDPOINT = process.env.NEXT_PUBLIC_ARCHIVE_ENDPOINT ?? 'https://api.minascan.io/archive/devnet/v1/graphql';
 
 let compilePromise: Promise<void> | null = null;
 


### PR DESCRIPTION
Makes E2E tests work on devnet (in addition to lightnet).

- New `e2e/network-config.ts` — set `NETWORK=devnet` to switch modes
- Timing/waits now come from config instead of being hardcoded
- Worker picks up Mina/archive endpoints from env vars
- E2E setup auto-compiles the contract to get `MINAGUARD_VK_HASH` on devnet (can also be set manually)
- `test:e2e:verbose` script for full log output
- `e2e/README.md` with instructions for both modes
- Fix: expired proposals weren't detected when indexer was caught up
- Gitignore o1js `cache/` dir