### PR TITLE
Merge deploy and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,17 @@ bun run --filter contracts test
 
 Full end-to-end tests live in `e2e/` and exercise the deploy → propose → approve → execute lifecycle against a real Mina network. See [e2e/README.md](e2e/README.md) for setup details.
 
+**Important:** The contracts must be built before running E2E tests — the test harness does not build them automatically.
+
 ```bash
+# Build contracts first
+bun run --filter contracts build
+
 # Quick start with local lightnet (default)
-cd e2e && bun install && bun test
+bun run test:e2e
 
 # Against Mina devnet (requires funded accounts in e2e/.env.devnet)
-cd e2e && NETWORK=devnet bun test
+NETWORK=devnet bun run test:e2e
 ```
 
 ## Build

--- a/contracts/src/MinaGuard.ts
+++ b/contracts/src/MinaGuard.ts
@@ -315,8 +315,9 @@ export class MinaGuard extends SmartContract {
     networkId: Field,
     initialOwners: SetupOwnersInput
   ) {
-    const currentCommitment = this.ownersCommitment.getAndRequireEquals();
-    currentCommitment.assertEquals(Field(0), 'Already initialized');
+    // Use requireEquals instead of getAndRequireEquals so deploy+setup can
+    // be combined in a single transaction (no account cache read needed).
+    this.ownersCommitment.requireEquals(Field(0));
 
     threshold.assertGreaterThan(Field(0), 'Threshold must be > 0');
     numOwners.assertGreaterThanOrEqual(

--- a/contracts/src/tests/setup.test.ts
+++ b/contracts/src/tests/setup.test.ts
@@ -58,7 +58,7 @@ describe('MinaGuard - Setup', () => {
       });
       await txn.prove();
       await txn.sign([ctx.deployerKey]).send();
-    }).toThrow('Already initialized');
+    }).toThrow();
   });
 
   it('should reject threshold = 0', async () => {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -391,12 +391,29 @@ export async function waitForBanner(
   timeoutMs?: number
 ): Promise<string> {
   timeoutMs ??= getNetworkConfig().bannerTimeoutMs;
-  // Dismiss any stale banner by clicking its close button
+
+  // Dismiss any stale banner, then wait for it to leave the DOM before
+  // polling for the new result.  This prevents a race where a fast operation
+  // (e.g. offchain approve) completes and shows its banner before we finish
+  // dismissing the old one — causing us to accidentally close the real result.
   const closeBtn = page.locator('button:has-text("×")');
   if (await closeBtn.first().isVisible().catch(() => false)) {
     await closeBtn.first().click().catch(() => {});
     log('Dismissed stale banner');
-    await page.waitForTimeout(500);
+    // Wait until the old banner is actually gone from the DOM
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button')).filter(
+          (b) => b.textContent?.trim() === '×'
+        );
+        const hasBanner = btns.some((btn) => {
+          const cls = btn.parentElement?.className ?? '';
+          return cls.includes('text-safe-green') || cls.includes('text-red-400');
+        });
+        return !hasBanner;
+      },
+      { timeout: 5_000 }
+    ).catch(() => {});
   }
 
   log('Waiting for operation banner...');

--- a/e2e/offchain-flow.test.ts
+++ b/e2e/offchain-flow.test.ts
@@ -7,19 +7,18 @@
  *   - Approve: instant (sign + API call, no proof)
  *   - Execute: on-chain batch transaction (compile + prove + send)
  *
- * Coverage (mirrors onchain-flow.test.ts scope):
+ * Coverage:
  *   1.  Deploy + setup a MinaGuard contract (2 owners, threshold 2)
- *   2.  Fund the contract
- *   3.  Transfer: propose (owner1) → approve (owner2) → execute → verify
- *   4.  Add owner (accounts[2]): propose → approve → execute → verify
- *   5.  Change threshold to 1: propose → approve → execute → verify
- *   6.  Remove owner (accounts[2]): propose (threshold=1) → execute → verify
- *   7.  Set delegate: propose → execute → verify dashboard
- *   8.  Undelegate: propose → execute → verify
- *   9.  Propose transfer with expiry → wait for expiry → verify expired UI
- *   10. Verify Settings page
- *   11. Verify Transactions page filtering
- *   12. Verify final state
+ *   2.  Transfer: propose (owner1) → approve (owner2) → execute → verify
+ *   3.  Add owner (accounts[2]): propose → approve → execute → verify
+ *   4.  Change threshold to 1: propose → approve → execute → verify
+ *   5.  Remove owner (accounts[2]): propose (threshold=1) → execute → verify
+ *   6.  Set delegate: propose → execute → verify dashboard
+ *   7.  Undelegate: propose → execute → verify
+ *   8.  Propose transfer with expiry → wait for expiry → verify expired UI
+ *   9.  Verify Settings page
+ *   10. Verify Transactions page filtering
+ *   11. Verify final state
  */
 
 import { test, expect, type Page, type BrowserContext } from '@playwright/test';
@@ -32,7 +31,6 @@ import {
   navigateTo,
   waitForBanner,
   waitForIndexer,
-  getContracts,
   getContract,
   getOwners,
   getProposals,
@@ -131,12 +129,12 @@ test.afterEach(async ({}, testInfo) => {
 });
 
 // ---------------------------------------------------------------------------
-// 1. Deploy MinaGuard contract
+// 1. Deploy + setup MinaGuard contract (2 owners, threshold=2)
 // ---------------------------------------------------------------------------
 
-test('1. Deploy MinaGuard contract', async () => {
+test('1. Deploy + setup MinaGuard contract', async () => {
   const page = sharedPage;
-  log('=== Step 1: Deploy MinaGuard contract ===');
+  log('=== Step 1: Deploy + setup MinaGuard contract ===');
   await gotoWithWallet('/deploy', accounts[0]);
 
   await page.waitForFunction(
@@ -152,103 +150,66 @@ test('1. Deploy MinaGuard contract', async () => {
     { timeout: 60_000 }
   );
 
-  const addressEl = page
-    .locator('text=Contract Address')
-    .locator('..')
-    .locator('.font-mono');
+  const addressEl = page.locator('p.break-all.font-mono');
   await addressEl.waitFor({ state: 'visible', timeout: 10_000 });
   contractAddress = (await addressEl.textContent())?.trim() ?? '';
   expect(contractAddress).toMatch(/^B62/);
   log(`Contract address: ${contractAddress}`);
 
-  log('Clicking Deploy...');
-  const deployBtn = page.getByRole('button', { name: /deploy minaguard/i });
-  await deployBtn.click();
+  // The first owner field is pre-filled with the connected wallet address.
+  // Add a second owner and set threshold to 2.
+  log('Filling setup form on deploy page...');
 
-  log('Waiting for deploy transaction...');
-  await waitForBanner(page, 'success');
-
-  await waitForIndexer('indexer discovers deployed contract', async () => {
-    const contracts = await getContracts();
-    return contracts.some((c: any) => c.address === contractAddress);
-  });
-
-  const contract = await getContract(contractAddress);
-  expect(contract).not.toBeNull();
-  log(`Contract discovered by indexer: ${contract.address}`);
-
-  await fundContract(contractAddress, accounts[0], 10);
-});
-
-// ---------------------------------------------------------------------------
-// 2. Setup contract (2 owners, threshold=2)
-// ---------------------------------------------------------------------------
-
-test('2. Setup contract (2 owners, threshold=2)', async () => {
-  const page = sharedPage;
-  log('=== Step 2: Setup contract ===');
-  await gotoWithWallet('/', accounts[0]);
-  await page.waitForTimeout(SHORT_WAIT);
-
-  log('Clicking Setup Contract...');
-  const setupBtn = page.getByRole('button', { name: /setup contract/i });
-  await setupBtn.waitFor({ state: 'visible', timeout: 30_000 });
-  await setupBtn.click();
-
-  log('Filling setup form...');
-
+  // Fill first owner (may be empty if wallet address wasn't available at render)
   const owner1Input = page.locator('input[placeholder*="Owner"]').first();
-  await owner1Input.waitFor({ state: 'visible', timeout: 10_000 });
+  await owner1Input.waitFor({ state: 'visible', timeout: 5_000 });
   await owner1Input.fill(accounts[0].publicKey);
 
+  // Add second owner
   const addOwnerBtn = page.getByRole('button', { name: /add owner/i });
-  if (await addOwnerBtn.isVisible().catch(() => false)) {
-    await addOwnerBtn.click();
-    await page.waitForTimeout(500);
-  }
+  await addOwnerBtn.click();
+
+  // Wait for second owner input to appear
   const owner2Input = page.locator('input[placeholder*="Owner"]').nth(1);
+  await owner2Input.waitFor({ state: 'visible', timeout: 5_000 });
   await owner2Input.fill(accounts[1].publicKey);
 
   const thresholdInput = page.locator('input[type="number"]').first();
   await thresholdInput.fill('2');
 
-  const allInputs = page.locator('.fixed input, dialog input, [class*="modal"] input');
-  const allCount = await allInputs.count();
-  if (allCount >= 4) {
-    const lastInput = allInputs.nth(allCount - 1);
-    await lastInput.fill('1');
-  }
+  log('Clicking Deploy MinaGuard...');
+  const deployBtn = page.getByRole('button', { name: /deploy minaguard/i });
+  await deployBtn.click();
 
-  log('Clicking Run Setup...');
-  const runSetupBtn = page.getByRole('button', { name: /run setup/i });
-  await runSetupBtn.click();
-
-  log('Waiting for setup transaction...');
+  log('Waiting for deploy + setup transaction...');
   await waitForBanner(page, 'success');
 
-  await waitForIndexer('indexer processes setup events', async () => {
+  await waitForIndexer('indexer discovers deployed contract with setup', async () => {
     const contract = await getContract(contractAddress);
     return contract !== null && contract.threshold === 2 && contract.numOwners === 2;
   });
 
   const contract = await getContract(contractAddress);
+  expect(contract).not.toBeNull();
   expect(contract.threshold).toBe(2);
   expect(contract.numOwners).toBe(2);
-  log(`Setup verified: threshold=${contract.threshold}, numOwners=${contract.numOwners}`);
+  log(`Contract deployed and set up: threshold=${contract.threshold}, numOwners=${contract.numOwners}`);
 
   const owners = await getOwners(contractAddress);
   const activeOwners = owners.filter((o: any) => o.active);
   expect(activeOwners).toHaveLength(2);
   log(`Owners verified: ${activeOwners.map((o: any) => o.address.slice(0, 12) + '...').join(', ')}`);
+
+  await fundContract(contractAddress, accounts[0], 10);
 });
 
 // ---------------------------------------------------------------------------
-// 3. Create offchain transfer proposal (owner1 proposes, auto-signs)
+// 2. Create offchain transfer proposal (owner1 proposes, auto-signs)
 // ---------------------------------------------------------------------------
 
-test('3. Create offchain transfer proposal', async () => {
+test('2. Create offchain transfer proposal', async () => {
   const page = sharedPage;
-  log('=== Step 3: Create offchain transfer proposal ===');
+  log('=== Step 2: Create offchain transfer proposal ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -286,12 +247,12 @@ test('3. Create offchain transfer proposal', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. Approve transfer with owner 2 (offchain)
+// 3. Approve transfer with owner 2 (offchain)
 // ---------------------------------------------------------------------------
 
-test('4. Approve transfer with owner 2 (offchain)', async () => {
+test('3. Approve transfer with owner 2 (offchain)', async () => {
   const page = sharedPage;
-  log('=== Step 4: Approve transfer with owner 2 ===');
+  log('=== Step 3: Approve transfer with owner 2 ===');
   await gotoWithWallet(`/transactions/${proposalHashes[0]}`, accounts[1]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -318,12 +279,12 @@ test('4. Approve transfer with owner 2 (offchain)', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. Execute batch transfer
+// 4. Execute batch transfer
 // ---------------------------------------------------------------------------
 
-test('5. Execute batch transfer', async () => {
+test('4. Execute batch transfer', async () => {
   const page = sharedPage;
-  log('=== Step 5: Execute batch transfer ===');
+  log('=== Step 4: Execute batch transfer ===');
   await gotoWithWallet(`/transactions/${proposalHashes[0]}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -338,11 +299,11 @@ test('5. Execute batch transfer', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Indexer reconciles transfer as executed
+// 5. Indexer reconciles transfer as executed
 // ---------------------------------------------------------------------------
 
-test('6. Indexer reconciles transfer as executed', async () => {
-  log('=== Step 6: Verify indexer reconciliation of transfer ===');
+test('5. Indexer reconciles transfer as executed', async () => {
+  log('=== Step 5: Verify indexer reconciliation of transfer ===');
 
   await waitForIndexer('indexer marks transfer as executed', async () => {
     const p = await getProposal(contractAddress, proposalHashes[0]);
@@ -358,12 +319,12 @@ test('6. Indexer reconciles transfer as executed', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. Create offchain addOwner proposal (accounts[2])
+// 6. Create offchain addOwner proposal (accounts[2])
 // ---------------------------------------------------------------------------
 
-test('7. Create offchain addOwner proposal', async () => {
+test('6. Create offchain addOwner proposal', async () => {
   const page = sharedPage;
-  log('=== Step 7: Create offchain addOwner proposal ===');
+  log('=== Step 6: Create offchain addOwner proposal ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -401,12 +362,12 @@ test('7. Create offchain addOwner proposal', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 8. Approve addOwner with owner 2
+// 7. Approve addOwner with owner 2
 // ---------------------------------------------------------------------------
 
-test('8. Approve addOwner with owner 2', async () => {
+test('7. Approve addOwner with owner 2', async () => {
   const page = sharedPage;
-  log('=== Step 8: Approve addOwner with owner 2 ===');
+  log('=== Step 7: Approve addOwner with owner 2 ===');
   await gotoWithWallet(`/transactions/${proposalHashes[1]}`, accounts[1]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -428,12 +389,12 @@ test('8. Approve addOwner with owner 2', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 9. Execute batch addOwner
+// 8. Execute batch addOwner
 // ---------------------------------------------------------------------------
 
-test('9. Execute batch addOwner', async () => {
+test('8. Execute batch addOwner', async () => {
   const page = sharedPage;
-  log('=== Step 9: Execute batch addOwner ===');
+  log('=== Step 8: Execute batch addOwner ===');
   await gotoWithWallet(`/transactions/${proposalHashes[1]}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -463,12 +424,12 @@ test('9. Execute batch addOwner', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 10. Create offchain changeThreshold proposal (2 → 1)
+// 9. Create offchain changeThreshold proposal (2 → 1)
 // ---------------------------------------------------------------------------
 
-test('10. Create offchain changeThreshold proposal (threshold=1)', async () => {
+test('9. Create offchain changeThreshold proposal (threshold=1)', async () => {
   const page = sharedPage;
-  log('=== Step 10: Create offchain changeThreshold proposal ===');
+  log('=== Step 9: Create offchain changeThreshold proposal ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -515,12 +476,12 @@ test('10. Create offchain changeThreshold proposal (threshold=1)', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 11. Approve changeThreshold with owner 2
+// 10. Approve changeThreshold with owner 2
 // ---------------------------------------------------------------------------
 
-test('11. Approve changeThreshold with owner 2', async () => {
+test('10. Approve changeThreshold with owner 2', async () => {
   const page = sharedPage;
-  log('=== Step 11: Approve changeThreshold with owner 2 ===');
+  log('=== Step 10: Approve changeThreshold with owner 2 ===');
   await gotoWithWallet(`/transactions/${proposalHashes[2]}`, accounts[1]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -542,12 +503,12 @@ test('11. Approve changeThreshold with owner 2', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 12. Execute batch changeThreshold
+// 11. Execute batch changeThreshold
 // ---------------------------------------------------------------------------
 
-test('12. Execute batch changeThreshold', async () => {
+test('11. Execute batch changeThreshold', async () => {
   const page = sharedPage;
-  log('=== Step 12: Execute batch changeThreshold ===');
+  log('=== Step 11: Execute batch changeThreshold ===');
   await gotoWithWallet(`/transactions/${proposalHashes[2]}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -575,12 +536,12 @@ test('12. Execute batch changeThreshold', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 13. Create offchain removeOwner proposal (accounts[2], threshold=1)
+// 12. Create offchain removeOwner proposal (accounts[2], threshold=1)
 // ---------------------------------------------------------------------------
 
-test('13. Create offchain removeOwner proposal', async () => {
+test('12. Create offchain removeOwner proposal', async () => {
   const page = sharedPage;
-  log('=== Step 13: Create offchain removeOwner proposal ===');
+  log('=== Step 12: Create offchain removeOwner proposal ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -626,12 +587,12 @@ test('13. Create offchain removeOwner proposal', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 14. Execute batch removeOwner
+// 13. Execute batch removeOwner
 // ---------------------------------------------------------------------------
 
-test('14. Execute batch removeOwner', async () => {
+test('13. Execute batch removeOwner', async () => {
   const page = sharedPage;
-  log('=== Step 14: Execute batch removeOwner ===');
+  log('=== Step 13: Execute batch removeOwner ===');
   await gotoWithWallet(`/transactions/${proposalHashes[3]}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -666,12 +627,12 @@ test('14. Execute batch removeOwner', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 15. Verify Settings page
+// 14. Verify Settings page
 // ---------------------------------------------------------------------------
 
-test('15. Verify Settings page', async () => {
+test('14. Verify Settings page', async () => {
   const page = sharedPage;
-  log('=== Step 15: Verify Settings page ===');
+  log('=== Step 14: Verify Settings page ===');
   await gotoWithWallet('/settings', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -688,12 +649,12 @@ test('15. Verify Settings page', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 16. Create offchain setDelegate proposal
+// 15. Create offchain setDelegate proposal
 // ---------------------------------------------------------------------------
 
-test('16. Create offchain setDelegate proposal', async () => {
+test('15. Create offchain setDelegate proposal', async () => {
   const page = sharedPage;
-  log('=== Step 16: Create offchain setDelegate proposal ===');
+  log('=== Step 15: Create offchain setDelegate proposal ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -744,12 +705,12 @@ test('16. Create offchain setDelegate proposal', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 17. Execute batch setDelegate
+// 16. Execute batch setDelegate
 // ---------------------------------------------------------------------------
 
-test('17. Execute batch setDelegate', async () => {
+test('16. Execute batch setDelegate', async () => {
   const page = sharedPage;
-  log('=== Step 17: Execute batch setDelegate ===');
+  log('=== Step 16: Execute batch setDelegate ===');
   await gotoWithWallet(`/transactions/${proposalHashes[4]}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -776,12 +737,12 @@ test('17. Execute batch setDelegate', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 18. Verify dashboard shows delegate address
+// 17. Verify dashboard shows delegate address
 // ---------------------------------------------------------------------------
 
-test('18. Verify dashboard shows delegate address', async () => {
+test('17. Verify dashboard shows delegate address', async () => {
   const page = sharedPage;
-  log('=== Step 18: Verify delegate card on dashboard ===');
+  log('=== Step 17: Verify delegate card on dashboard ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -792,12 +753,12 @@ test('18. Verify dashboard shows delegate address', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 19. Create offchain undelegate proposal
+// 18. Create offchain undelegate proposal
 // ---------------------------------------------------------------------------
 
-test('19. Create offchain undelegate proposal', async () => {
+test('18. Create offchain undelegate proposal', async () => {
   const page = sharedPage;
-  log('=== Step 19: Create offchain undelegate proposal ===');
+  log('=== Step 18: Create offchain undelegate proposal ===');
   await gotoWithWallet('/', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -844,12 +805,12 @@ test('19. Create offchain undelegate proposal', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 20. Execute batch undelegate
+// 19. Execute batch undelegate
 // ---------------------------------------------------------------------------
 
-test('20. Execute batch undelegate', async () => {
+test('19. Execute batch undelegate', async () => {
   const page = sharedPage;
-  log('=== Step 20: Execute batch undelegate ===');
+  log('=== Step 19: Execute batch undelegate ===');
   await gotoWithWallet(`/transactions/${proposalHashes[5]}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -876,12 +837,12 @@ test('20. Execute batch undelegate', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 21. Propose transfer with near-future expiry
+// 20. Propose transfer with near-future expiry
 // ---------------------------------------------------------------------------
 
-test('21. Propose transfer with near-future expiry', async () => {
+test('20. Propose transfer with near-future expiry', async () => {
   const page = sharedPage;
-  log('=== Step 21: Propose transfer with expiry ===');
+  log('=== Step 20: Propose transfer with expiry ===');
 
   const status = await getIndexerStatus();
   const currentHeight = status?.latestChainHeight ?? status?.indexedHeight ?? 0;
@@ -936,12 +897,12 @@ test('21. Propose transfer with near-future expiry', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 22. Verify proposal expires and execute button is hidden
+// 21. Verify proposal expires and execute button is hidden
 // ---------------------------------------------------------------------------
 
-test('22. Verify proposal expires and execute button is hidden', async () => {
+test('21. Verify proposal expires and execute button is hidden', async () => {
   const page = sharedPage;
-  log('=== Step 22: Verify proposal expiry ===');
+  log('=== Step 21: Verify proposal expiry ===');
 
   log('Waiting for proposal to expire...');
   await waitForIndexer(
@@ -975,12 +936,12 @@ test('22. Verify proposal expires and execute button is hidden', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 23. Verify Transactions page filtering
+// 22. Verify Transactions page filtering
 // ---------------------------------------------------------------------------
 
-test('23. Verify Transactions page filtering', async () => {
+test('22. Verify Transactions page filtering', async () => {
   const page = sharedPage;
-  log('=== Step 23: Verify Transactions page filtering ===');
+  log('=== Step 22: Verify Transactions page filtering ===');
   await gotoWithWallet('/transactions', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -1013,12 +974,12 @@ test('23. Verify Transactions page filtering', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 24. Verify final state
+// 23. Verify final state
 // ---------------------------------------------------------------------------
 
-test('24. Verify final state', async () => {
+test('23. Verify final state', async () => {
   const page = sharedPage;
-  log('=== Step 24: Verify final state ===');
+  log('=== Step 23: Verify final state ===');
 
   // Dashboard — delegate card should show contract self (undelegated)
   await gotoWithWallet('/', accounts[0]);
@@ -1039,5 +1000,5 @@ test('24. Verify final state', async () => {
 
   log('\n=== Final State ===');
   await dumpState(contractAddress);
-  log('\n=== All 24 steps completed successfully! ===');
+  log('\n=== All 23 steps completed successfully! ===');
 });

--- a/ui/app/deploy/page.tsx
+++ b/ui/app/deploy/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Header from '@/components/Header';
 import { useAppContext } from '@/lib/app-context';
-import { deployContract, generateKeypair } from '@/lib/multisigClient';
+import { deployAndSetupContract, generateKeypair } from '@/lib/multisigClient';
 
 /** Deploy page for initializing new MinaGuard contracts from browser wallet session. */
 export default function DeployPage() {
@@ -25,6 +25,12 @@ export default function DeployPage() {
   const [keypair, setKeypair] = useState<{ privateKey: string; publicKey: string } | null>(null);
   const [generating, setGenerating] = useState(false);
 
+  // Setup fields
+  const [ownerFields, setOwnerFields] = useState<string[]>(() => [wallet.address ?? '']);
+  const [threshold, setThreshold] = useState('1');
+  const [networkId, setNetworkId] = useState('1');
+  const [formError, setFormError] = useState<string | null>(null);
+
   const generate = useCallback(async () => {
     setGenerating(true);
     try {
@@ -41,16 +47,41 @@ export default function DeployPage() {
     }
   }, [wallet.connected, keypair, generating, generate]);
 
+  const parsedOwners = useMemo(
+    () => ownerFields.map((s) => s.trim()).filter(Boolean),
+    [ownerFields]
+  );
+
+  const validate = (): string | null => {
+    if (parsedOwners.length === 0) return 'Add at least one owner address.';
+    const invalid = parsedOwners.find((addr) => !addr.startsWith('B62') || addr.length < 50);
+    if (invalid) return `Invalid address: ${invalid.slice(0, 20)}...`;
+    const unique = new Set(parsedOwners);
+    if (unique.size !== parsedOwners.length) return 'Duplicate owner addresses.';
+    if (parsedOwners.length > 20) return 'Maximum 20 owners allowed.';
+    const t = Number(threshold);
+    if (!t || t < 1) return 'Threshold must be at least 1.';
+    if (t > parsedOwners.length) return `Threshold (${t}) cannot exceed number of owners (${parsedOwners.length}).`;
+    if (!networkId.trim()) return 'Network ID is required.';
+    return null;
+  };
+
   const handleDeploy = () => {
+    const error = validate();
+    if (error) { setFormError(error); return; }
     if (!wallet.address || !keypair) return;
 
-    const captured = { feePayerAddress: wallet.address, zkAppPrivateKeyBase58: keypair.privateKey };
+    setFormError(null);
+    const captured = {
+      feePayerAddress: wallet.address,
+      zkAppPrivateKeyBase58: keypair.privateKey,
+      owners: parsedOwners,
+      threshold: Number(threshold),
+      networkId,
+    };
     const signer = wallet.type ? { type: wallet.type, ledgerAccountIndex: wallet.ledgerAccountIndex } : undefined;
     startOperation('Building deploy transaction...', (onProgress) =>
-      deployContract({
-        feePayerAddress: captured.feePayerAddress,
-        zkAppPrivateKeyBase58: captured.zkAppPrivateKeyBase58,
-      }, onProgress, signer)
+      deployAndSetupContract(captured, onProgress, signer)
     );
     router.push('/');
   };
@@ -78,33 +109,96 @@ export default function DeployPage() {
             <p className="text-safe-text">Connect wallet to deploy MinaGuard.</p>
           </div>
         ) : (
-          <section className="bg-safe-gray border border-safe-border rounded-xl p-6 space-y-4">
+          <section className="bg-safe-gray border border-safe-border rounded-xl p-6 space-y-5">
             <h3 className="text-sm font-semibold uppercase tracking-wider text-safe-text">Deploy Contract</h3>
             <p className="text-xs text-safe-text">
               A random keypair will be generated for the contract address. Your connected wallet pays the deployment fee.
+              The contract will be deployed and initialized in a single transaction.
             </p>
 
+            {/* Contract address */}
             {generating ? (
               <div className="flex items-center gap-2 py-3">
                 <span className="animate-spin w-4 h-4 border-2 border-safe-green border-t-transparent rounded-full" />
                 <span className="text-sm text-safe-text">Generating keypair...</span>
               </div>
             ) : keypair ? (
-              <div className="space-y-2">
-                <div>
-                  <p className="text-xs text-safe-text mb-1">Contract Address</p>
-                  <p className="text-sm font-mono break-all bg-safe-dark border border-safe-border rounded-lg px-3 py-2">
-                    {keypair.publicKey}
-                  </p>
-                </div>
-                <button
-                  onClick={generate}
-                  className="text-xs text-safe-green hover:underline"
-                >
+              <div className="space-y-1">
+                <p className="text-xs text-safe-text">Contract Address</p>
+                <p className="text-sm font-mono break-all bg-safe-dark border border-safe-border rounded-lg px-3 py-2">
+                  {keypair.publicKey}
+                </p>
+                <button onClick={generate} className="text-xs text-safe-green hover:underline">
                   Regenerate
                 </button>
               </div>
             ) : null}
+
+            {/* Owners */}
+            <div className="space-y-2">
+              <span className="text-xs text-safe-text">Owners</span>
+              {ownerFields.map((value, i) => (
+                <div key={i} className="flex gap-2">
+                  <input
+                    type="text"
+                    value={value}
+                    onChange={(e) => {
+                      const next = [...ownerFields];
+                      next[i] = e.target.value;
+                      setOwnerFields(next);
+                      setFormError(null);
+                    }}
+                    placeholder={`Owner ${i + 1} address (B62...)`}
+                    className="flex-1 bg-safe-dark border border-safe-border rounded-lg px-4 py-3 text-sm font-mono"
+                  />
+                  {ownerFields.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setOwnerFields(ownerFields.filter((_, j) => j !== i))}
+                      className="text-safe-text hover:text-red-400 px-2 text-lg leading-none"
+                    >
+                      &times;
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => setOwnerFields([...ownerFields, ''])}
+                className="text-xs text-safe-green hover:underline"
+              >
+                + Add owner
+              </button>
+            </div>
+
+            {/* Threshold + Network ID */}
+            <div className="grid grid-cols-2 gap-3">
+              <label className="space-y-1">
+                <span className="text-xs text-safe-text">Threshold</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={threshold}
+                  onChange={(e) => { setThreshold(e.target.value); setFormError(null); }}
+                  className="w-full bg-safe-dark border border-safe-border rounded-lg px-4 py-3 text-sm"
+                />
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs text-safe-text">Network ID</span>
+                <input
+                  type="text"
+                  value={networkId}
+                  onChange={(e) => { setNetworkId(e.target.value.trim()); setFormError(null); }}
+                  className="w-full bg-safe-dark border border-safe-border rounded-lg px-4 py-3 text-sm"
+                />
+                <p className="text-xs text-safe-text">
+                  Mainnet: <code className="font-mono">1</code> · Devnet: <code className="font-mono">0</code> · Localnet: <code className="font-mono">0</code>
+                </p>
+              </label>
+            </div>
+
+            {formError && <p className="text-sm text-red-400">{formError}</p>}
 
             <button
               disabled={!keypair || isOperating}

--- a/ui/app/deploy/page.tsx
+++ b/ui/app/deploy/page.tsx
@@ -26,7 +26,7 @@ export default function DeployPage() {
   const [generating, setGenerating] = useState(false);
 
   // Setup fields
-  const [ownerFields, setOwnerFields] = useState<string[]>(() => [wallet.address ?? '']);
+  const [ownerFields, setOwnerFields] = useState<string[]>(['']);
   const [threshold, setThreshold] = useState('1');
   const [networkId, setNetworkId] = useState('1');
   const [formError, setFormError] = useState<string | null>(null);
@@ -46,6 +46,12 @@ export default function DeployPage() {
       generate();
     }
   }, [wallet.connected, keypair, generating, generate]);
+
+  useEffect(() => {
+    if (wallet.address) {
+      setOwnerFields([wallet.address]);
+    }
+  }, [wallet.address]);
 
   const parsedOwners = useMemo(
     () => ownerFields.map((s) => s.trim()).filter(Boolean),

--- a/ui/lib/multisigClient.ts
+++ b/ui/lib/multisigClient.ts
@@ -144,6 +144,17 @@ export async function setupContract(params: {
   return getWorkerApi().setupContract(params, proxiedSendTx(signer), proxiedProgress(onProgress), proxiedSignFeePayer(signer));
 }
 
+/** Deploys and initializes the contract in a single transaction. */
+export async function deployAndSetupContract(params: {
+  feePayerAddress: string;
+  zkAppPrivateKeyBase58: string;
+  owners: string[];
+  threshold: number;
+  networkId: string;
+}, onProgress?: OnProgress, signer?: SignerConfig): Promise<string | null> {
+  return getWorkerApi().deployAndSetupContract(params, proxiedSendTx(signer), proxiedProgress(onProgress), proxiedSignFeePayer(signer));
+}
+
 /** Creates an offchain proposal in the backend and submits the proposer's first signature. */
 export async function createOffchainProposal(params: {
   contractAddress: string;

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -464,6 +464,57 @@ const workerApi = {
     return `Transaction submitted: ${deployHash}`;
   },
 
+  async deployAndSetupContract(
+    params: {
+      feePayerAddress: string;
+      zkAppPrivateKeyBase58: string;
+      owners: string[];
+      threshold: number;
+      networkId: string;
+    },
+    sendFn: SendTxFn | null,
+    progressFn: ProgressFn,
+    signFeePayerFn?: SignFeePayerFn
+  ): Promise<string | null> {
+    progressFn('Compiling contract...');
+    const ok = await compileContract();
+    if (!ok) return null;
+
+    progressFn('Building transaction...');
+    const feePayer = PublicKey.fromBase58(params.feePayerAddress);
+    const zkAppKey = PrivateKey.fromBase58(params.zkAppPrivateKeyBase58);
+    const zkAppAddress = zkAppKey.toPublicKey();
+    const zkApp = new MinaGuard(zkAppAddress);
+
+    const ownerStore = new OwnerStore();
+    const ownerKeys = params.owners.map((address) => PublicKey.fromBase58(address));
+    for (const owner of ownerKeys) ownerStore.add(owner);
+
+    const paddedOwners = [...ownerKeys];
+    while (paddedOwners.length < MAX_OWNERS) {
+      paddedOwners.push(PublicKey.empty());
+    }
+
+    const tx = await Mina.transaction(txSender(feePayer), async () => {
+      AccountUpdate.fundNewAccount(feePayer);
+      await zkApp.deploy();
+      await zkApp.setup(
+        ownerStore.getCommitment(),
+        Field(params.threshold),
+        Field(ownerKeys.length),
+        Field(params.networkId),
+        new SetupOwnersInput({ owners: paddedOwners.slice(0, MAX_OWNERS) })
+      );
+    });
+
+    progressFn('Generating proof...');
+    await tx.prove();
+
+    progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
+    const txHash = await submitTx(tx, sendFn, signFeePayerFn, [zkAppKey]);
+    return `Transaction submitted: ${txHash}`;
+  },
+
   async setupContract(
     params: {
       zkAppAddress: string;

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -488,9 +488,9 @@ const workerApi = {
 
     const ownerStore = new OwnerStore();
     const ownerKeys = params.owners.map((address) => PublicKey.fromBase58(address));
-    for (const owner of ownerKeys) ownerStore.add(owner);
+    for (const owner of ownerKeys) ownerStore.addSorted(owner);
 
-    const paddedOwners = [...ownerKeys];
+    const paddedOwners = [...ownerStore.owners];
     while (paddedOwners.length < MAX_OWNERS) {
       paddedOwners.push(PublicKey.empty());
     }


### PR DESCRIPTION
- Contract: replace getAndRequireEquals with requireEquals in setup() (get() is just a convenience method but it fails since `this.ownersCommitment` doesn't exist yet)
- UI: move setup form (owners, threshold, networkId) to the deploy page
- E2E: merge deploy+setup test steps, fix waitForBanner race condition where fast operations had their success banner dismissed as stale
