### PR TITLE
Migrate backend to PostgreSQL and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,21 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
-    # Enable the following block if you also want to use the Lightnet in your tests.
-    #
-    # services:
-    #   mina-local-network:
-    #     image: o1labs/mina-local-network:compatible-latest-lightnet
-    #     env:
-    #       NETWORK_TYPE: 'single-node'
-    #       PROOF_LEVEL: 'none'
-    #       LOG_LEVEL: 'Info'
-    #     ports:
-    #       - 3085:3085
-    #       - 5432:5432
-    #       - 8080:8080
-    #       - 8181:8181
-    #       - 8282:8282
-    #     volumes:
-    #       - /tmp:/root/logs
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: minaguard
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       #
       # Enable the following block if you also want to use the Lightnet in your tests.
@@ -50,6 +48,7 @@ jobs:
           bun run test
         env:
           CI: true
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
 
       # Enable the following block if you also want to use the Lightnet in your tests.
       #

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,20 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: minaguard
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
       mina-local-network:
         image: o1labs/mina-local-network:compatible-latest-lightnet
         env:
@@ -19,7 +33,6 @@ jobs:
           LOG_LEVEL: 'Info'
         ports:
           - 3085:3085
-          - 5432:5432
           - 8080:8080
           - 8181:8181
           - 8282:8282
@@ -69,13 +82,13 @@ jobs:
         run: bunx prisma db push
         working-directory: backend
         env:
-          DATABASE_URL: file:./dev.db
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
 
       - name: Start backend
         run: bun run --filter backend dev &
         env:
           PORT: '4000'
-          DATABASE_URL: file:./dev.db
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
           MINA_ENDPOINT: http://localhost:8080/graphql
           ARCHIVE_ENDPOINT: http://localhost:8282
           LIGHTNET_ACCOUNT_MANAGER: http://localhost:8181

--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,5 @@ e2e/playwright-report/
 # o1js compilation cache
 cache/
 
-# sqlite
-backend/prisma/dev.db
-backend/prisma/dev.db-shm
-backend/prisma/dev.db-wal
-
 # misc
 *.log

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MinaGuard is a multisig wallet zkApp for Mina built with o1js, plus a Next.js UI
 ## Packages
 
 - `contracts/` - MinaGuard smart contract, stores, and tests.
-- `backend/` - Express + Prisma + SQLite read API and chain indexer.
+- `backend/` - Express + Prisma + PostgreSQL read API and chain indexer.
 - `ui/` - Next.js app with Auro wallet integration and on-chain actions.
 
 ## Key Features

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,8 @@
 # Backend server config
 PORT=3001
-DATABASE_URL=file:./dev.db
+# On macOS (Homebrew): postgresql://<your-username>@localhost:5432/minaguard
+# On Docker/CI:        postgresql://postgres:postgres@localhost:5432/minaguard
+DATABASE_URL=postgresql://localhost:5432/minaguard
 MINA_ENDPOINT=http://127.0.0.1:8080/graphql
 ARCHIVE_ENDPOINT=http://127.0.0.1:8282
 LIGHTNET_ACCOUNT_MANAGER=http://127.0.0.1:8181

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,1 @@
 dist/
-prisma/dev.db

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,13 +4,13 @@ Read-only Express API + polling indexer for MinaGuard contracts.
 
 This package does two things:
 
-1. Indexes MinaGuard on-chain events into a local SQLite database.
+1. Indexes MinaGuard on-chain events into a PostgreSQL database.
 2. Exposes read APIs for contracts, owners, proposals, approvals, and raw events.
 
 ## What Is Included
 
 - `Express` server (`src/server.ts`)
-- `Prisma + SQLite` storage (`prisma/schema.prisma`)
+- `Prisma + PostgreSQL` storage (`prisma/schema.prisma`)
 - Polling indexer (`src/indexer.ts`)
 - Mina/Archive GraphQL client + event decoding (`src/mina-client.ts`)
 - Read-only API routes (`src/routes.ts`)
@@ -20,7 +20,7 @@ This package does two things:
 At startup:
 
 1. Environment is loaded from `.env`.
-2. Prisma connects to SQLite.
+2. Prisma connects to PostgreSQL.
 3. Indexer starts and runs one immediate sync tick.
 4. Express starts and serves API routes.
 
@@ -78,7 +78,7 @@ From `backend/`:
 | Variable | Default | Description |
 |---|---|---|
 | `PORT` | `4000` | Express server port |
-| `DATABASE_URL` | `file:./dev.db` | Prisma SQLite URL (resolves to `backend/prisma/dev.db`) |
+| `DATABASE_URL` | *(required)* | PostgreSQL connection URL (see `.env.example`) |
 | `MINA_ENDPOINT` | `https://api.minascan.io/node/devnet/v1/graphql` | Primary Mina GraphQL endpoint |
 | `ARCHIVE_ENDPOINT` | `https://api.minascan.io/archive/devnet/v1/graphql` | Primary archive GraphQL endpoint |
 | `MINA_FALLBACK_ENDPOINT` | empty | Optional Mina fallback endpoint |

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "db:push": "prisma db push --skip-generate",
-    "dev": "bun run db:push && tsx watch --env-file=.env src/server.ts",
+    "dev": "bun run db:push && bun --env-file=.env --watch src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "bun run db:push && bun dist/server.js",
     "prisma:generate": "prisma generate",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "db:push": "prisma db push --skip-generate",
-    "dev": "bun run db:push && tsx watch src/server.ts",
+    "dev": "bun run db:push && tsx watch --env-file=.env src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "bun run db:push && bun dist/server.js",
     "prisma:generate": "prisma generate",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -22,7 +22,7 @@ function requireEnv(name: string): string {
 /** Reads and validates environment variables. Requires MINA_ENDPOINT and ARCHIVE_ENDPOINT. */
 export function loadConfig(): BackendConfig {
   const port = Number(process.env.PORT ?? '4000');
-  const databaseUrl = process.env.DATABASE_URL ?? 'file:./dev.db';
+  const databaseUrl = requireEnv('DATABASE_URL');
   const minaEndpoint = requireEnv('MINA_ENDPOINT');
   const archiveEndpoint = requireEnv('ARCHIVE_ENDPOINT');
   const lightnetAccountManager = process.env.LIGHTNET_ACCOUNT_MANAGER;

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -2,11 +2,3 @@ import { PrismaClient } from '@prisma/client';
 
 /** Singleton Prisma client used across routes and indexer workers. */
 export const prisma = new PrismaClient();
-
-/**
- * Enable WAL journal mode and set a busy timeout for SQLite so that
- * concurrent writes from the indexer and API routes don't collide with
- * "Cannot start new transaction within another transaction".
- */
-await prisma.$queryRawUnsafe('PRAGMA journal_mode = WAL');
-await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 5000');

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -16,7 +16,9 @@ export function configureNetwork(config: BackendConfig): void {
     Mina.Network({
       mina: config.minaEndpoint,
       archive: config.archiveEndpoint,
-      lightnetAccountManager: config.lightnetAccountManager,
+      ...(config.lightnetAccountManager
+        ? { lightnetAccountManager: config.lightnetAccountManager }
+        : {}),
     })
   );
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,7 +13,6 @@ async function main(): Promise<void> {
 
   await prisma.$connect();
   const indexer = new MinaGuardIndexer(config);
-  await indexer.start();
 
   const app = express();
   app.use(cors());
@@ -25,6 +24,10 @@ async function main(): Promise<void> {
     console.log(`[backend] listening on http://localhost:${config.port}`);
   });
   const shutdown = createGracefulShutdown(server, indexer);
+
+  // Start the indexer after the HTTP server is listening so the /health
+  // endpoint is reachable while the first (potentially slow) tick runs.
+  await indexer.start();
 
   process.once('SIGINT', () => {
     void shutdown('SIGINT');

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -14,9 +14,16 @@ interface E2eState {
   accounts: TestAccount[];
   backendPid: number;
   frontendPid: number;
+  /** Whether we stopped a local PostgreSQL and need to restart it in teardown. */
+  restoreLocalPg: boolean;
 }
 
-function requireDatabaseUrl(): string {
+// When using lightnet locally, lightnet's bundled PostgreSQL takes over port 5432.
+// We create a `minaguard` database inside it and return that URL.
+const LIGHTNET_DB_URL = 'postgresql://postgres:postgres@localhost:5432/minaguard';
+
+function requireDatabaseUrl(useLightnetPg: boolean): string {
+  if (useLightnetPg) return LIGHTNET_DB_URL;
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL is not set. Check your backend/.env file.');
   return url;
@@ -110,6 +117,11 @@ export default async function globalSetup() {
   // Lightnet — only managed locally; in CI it's a Docker service
   // Skipped entirely when running against devnet.
   // -----------------------------------------------------------------------
+  // Track whether we're using lightnet's PostgreSQL (so we can pass it to the backend)
+  let useLightnetPg = false;
+  // Track whether we stopped a running local PostgreSQL (so teardown can restart it)
+  let stoppedLocalPg = false;
+
   if (config.mode === 'lightnet') {
     if (!IS_CI) {
       log('Stopping any existing lightnet...');
@@ -120,6 +132,28 @@ export default async function globalSetup() {
         log('No existing lightnet to stop');
       }
 
+      // Stop local PostgreSQL so lightnet can bind to port 5432 — but only if it's running
+      const localPgRunning = (() => {
+        try {
+          const out = execSync('lsof -ti:5432 2>/dev/null || true', { stdio: 'pipe' }).toString().trim();
+          return out.length > 0;
+        } catch { return false; }
+      })();
+
+      if (localPgRunning) {
+        log('Stopping local PostgreSQL to free port 5432 for lightnet...');
+        try {
+          execSync('brew services stop postgresql@17', { stdio: 'pipe', timeout: 15_000 });
+          stoppedLocalPg = true;
+          log('Local PostgreSQL stopped');
+        } catch {
+          log('No local PostgreSQL to stop (or not managed by brew)');
+        }
+      } else {
+        log('Port 5432 is free — no need to stop local PostgreSQL');
+      }
+      await waitForPortFree(5432, 15_000);
+
       log('Starting lightnet (this may take 1-2 minutes)...');
       try {
         execSync('zk lightnet start', {
@@ -128,8 +162,26 @@ export default async function globalSetup() {
           timeout: 300_000,
         });
       } catch (err) {
+        // Restart local PostgreSQL before throwing (only if we stopped it)
+        if (stoppedLocalPg) {
+          try { execSync('brew services start postgresql@17', { stdio: 'pipe' }); } catch {}
+        }
         throw new Error(`Failed to start lightnet: ${err}`);
       }
+
+      // Create the minaguard database in lightnet's PostgreSQL
+      log('Creating minaguard database in lightnet PostgreSQL...');
+      try {
+        execSync(
+          'docker exec $(docker ps -q --filter ancestor=o1labs/mina-local-network) ' +
+            'psql -U postgres -c "CREATE DATABASE minaguard;" 2>/dev/null || true',
+          { stdio: 'pipe', timeout: 15_000 },
+        );
+        log('minaguard database ready');
+      } catch {
+        log('Warning: could not create minaguard database (may already exist)');
+      }
+      useLightnetPg = true;
     }
 
     // Wait for lightnet services (both CI and local)
@@ -183,11 +235,13 @@ export default async function globalSetup() {
 
     // Reset database
     log('Resetting backend database...');
+    const dbUrl = requireDatabaseUrl(useLightnetPg);
     execSync('bunx prisma db push --force-reset', {
       cwd: resolve(ROOT, 'backend'),
       stdio: 'pipe',
+      env: { ...process.env, DATABASE_URL: dbUrl },
     });
-    log('Database schema pushed');
+    log(`Database schema pushed (${useLightnetPg ? 'lightnet PG' : 'local PG'})`);
 
     // -----------------------------------------------------------------------
     // Verification key hash — compile the contract to get the vk hash so
@@ -221,7 +275,7 @@ export default async function globalSetup() {
       INDEX_POLL_INTERVAL_MS: String(config.indexerPollIntervalMs),
       MINA_ENDPOINT: config.minaEndpoint,
       ARCHIVE_ENDPOINT: config.archiveEndpoint,
-      DATABASE_URL: requireDatabaseUrl(),
+      DATABASE_URL: requireDatabaseUrl(useLightnetPg),
       PORT: '4000',
     };
     if (config.accountManagerUrl) {
@@ -266,6 +320,7 @@ export default async function globalSetup() {
     accounts,
     backendPid,
     frontendPid,
+    restoreLocalPg: stoppedLocalPg,
   };
   writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
   log('State written to .e2e-state.json');

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
-import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getNetworkConfig, getDevnetAccounts, type TestAccount } from './network-config';
 
@@ -14,6 +14,12 @@ interface E2eState {
   accounts: TestAccount[];
   backendPid: number;
   frontendPid: number;
+}
+
+function requireDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error('DATABASE_URL is not set. Check your backend/.env file.');
+  return url;
 }
 
 function log(msg: string) {
@@ -177,15 +183,9 @@ export default async function globalSetup() {
 
     // Reset database
     log('Resetting backend database...');
-    const dbPath = resolve(ROOT, 'backend/prisma/dev.db');
-    if (existsSync(dbPath)) {
-      unlinkSync(dbPath);
-      log('Deleted existing dev.db');
-    }
-    execSync('bunx prisma db push', {
+    execSync('bunx prisma db push --force-reset', {
       cwd: resolve(ROOT, 'backend'),
       stdio: 'pipe',
-      env: { ...process.env, DATABASE_URL: 'file:./dev.db' },
     });
     log('Database schema pushed');
 
@@ -221,7 +221,7 @@ export default async function globalSetup() {
       INDEX_POLL_INTERVAL_MS: String(config.indexerPollIntervalMs),
       MINA_ENDPOINT: config.minaEndpoint,
       ARCHIVE_ENDPOINT: config.archiveEndpoint,
-      DATABASE_URL: 'file:./dev.db',
+      DATABASE_URL: requireDatabaseUrl(),
       PORT: '4000',
     };
     if (config.accountManagerUrl) {

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -29,15 +29,18 @@ function killProcess(pid: number, label: string) {
 export default async function globalTeardown() {
   log(`=== E2E Global Teardown (${IS_CI ? 'CI' : 'local'}) ===`);
 
-  // Kill backend and frontend (only locally — in CI they die with the job)
+  // Read state file once (before deleting it)
+  let state: Record<string, unknown> | null = null;
   if (existsSync(STATE_FILE)) {
-    const state = JSON.parse(readFileSync(STATE_FILE, 'utf-8'));
-    if (!IS_CI) {
-      if (state.backendPid) killProcess(state.backendPid, 'backend');
-      if (state.frontendPid) killProcess(state.frontendPid, 'frontend');
-    }
+    state = JSON.parse(readFileSync(STATE_FILE, 'utf-8'));
     unlinkSync(STATE_FILE);
     log('State file cleaned up');
+  }
+
+  // Kill backend and frontend (only locally — in CI they die with the job)
+  if (state && !IS_CI) {
+    if (state.backendPid) killProcess(state.backendPid as number, 'backend');
+    if (state.frontendPid) killProcess(state.frontendPid as number, 'frontend');
   }
 
   // Stop lightnet (only locally and only when using lightnet mode)
@@ -48,6 +51,17 @@ export default async function globalTeardown() {
       log('Lightnet stopped');
     } catch {
       log('Lightnet stop failed or was not running');
+    }
+
+    // Restart local PostgreSQL only if we stopped it during setup
+    if (state?.restoreLocalPg) {
+      log('Restarting local PostgreSQL...');
+      try {
+        execSync('brew services start postgresql@17', { stdio: 'pipe', timeout: 15_000 });
+        log('Local PostgreSQL restarted');
+      } catch {
+        log('Warning: could not restart local PostgreSQL — run "brew services start postgresql@17" manually');
+      }
     }
   }
 


### PR DESCRIPTION
Switches the backend from SQLite to PostgreSQL and updates CI workflows + e2e setup accordingly. Also fixes the CI health check timeout by starting the HTTP server before the indexer, and handles local PostgreSQL port conflicts when running lightnet.