### PR TITLE
Fix Invalid_signature and browser compat in production

### DIFF
--- a/ui/hooks/useWallet.ts
+++ b/ui/hooks/useWallet.ts
@@ -34,10 +34,32 @@ export function useWallet() {
     typeof window !== 'undefined' && localStorage.getItem('wallet-disconnected') === 'true'
   );
 
-  // Check capabilities on mount
+  // Check capabilities on mount, retrying briefly for Auro since the
+  // extension injects window.mina asynchronously after page load.
   useEffect(() => {
-    setAuroInstalled(isAuroInstalled());
     setLedgerSupported(isLedgerSupported());
+
+    if (isAuroInstalled()) {
+      setAuroInstalled(true);
+      return;
+    }
+
+    // Listen for the provider injection event fired by Auro
+    const onInit = () => setAuroInstalled(true);
+    window.addEventListener('mina#initialized', onInit);
+
+    // Fallback poll in case the event was missed or isn't dispatched
+    const id = setInterval(() => {
+      if (isAuroInstalled()) {
+        setAuroInstalled(true);
+        clearInterval(id);
+      }
+    }, 200);
+
+    return () => {
+      window.removeEventListener('mina#initialized', onInit);
+      clearInterval(id);
+    };
   }, []);
 
   // Listen for Auro account/network changes only when connected via Auro

--- a/ui/lib/auroWallet.ts
+++ b/ui/lib/auroWallet.ts
@@ -72,12 +72,10 @@ export async function sendTransaction(
 ): Promise<string | null> {
   if (!isAuroInstalled()) return null;
   try {
-    console.log('In sendtransaction, before sending');
     const result = await window.mina!.sendTransaction({
       transaction,
       feePayer: { fee, memo },
     });
-    console.log('In sendtransaction, after sending');
     return result.hash;
   } catch {
     return null;

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -82,6 +82,25 @@ function txSender(pub: InstanceType<typeof PublicKey>) {
   return { sender: pub, fee: ZKAPP_TX_FEE };
 }
 
+/**
+ * Force-clear any stale o1js transaction context left by a previous failed
+ * Mina.transaction() call.  o1js's createTransaction has code paths where a
+ * thrown error skips currentTransaction.leave(), leaving the global context
+ * dirty so that every subsequent Mina.transaction() call throws
+ * "Cannot start new transaction within another transaction".
+ *
+ * Safe to call unconditionally: this worker is single-threaded, so if
+ * currentTransaction.has() is true right before we start a new transaction,
+ * it is always stale.
+ */
+function clearStaleTransaction() {
+  const ctx = Mina.currentTransaction;
+  while (ctx.has()) {
+    console.warn('[MultisigWorker] Clearing stale o1js transaction context');
+    ctx.leave(ctx.id());
+  }
+}
+
 /** Contract state snapshot read directly from chain. */
 interface ContractState {
   ownersCommitment: string;
@@ -444,8 +463,8 @@ const workerApi = {
     const zkAppAddress = zkAppKey.toPublicKey();
     const zkApp = new MinaGuard(zkAppAddress);
 
-    console.log('built');
-
+    await fetchAccount({ publicKey: feePayer });
+    clearStaleTransaction();
     const tx = await Mina.transaction(txSender(feePayer), async () => {
       AccountUpdate.fundNewAccount(feePayer);
       await zkApp.deploy();
@@ -495,6 +514,8 @@ const workerApi = {
       paddedOwners.push(PublicKey.empty());
     }
 
+    await fetchAccount({ publicKey: feePayer });
+    clearStaleTransaction();
     const tx = await Mina.transaction(txSender(feePayer), async () => {
       AccountUpdate.fundNewAccount(feePayer);
       await zkApp.deploy();
@@ -545,6 +566,8 @@ const workerApi = {
     const feePayer = PublicKey.fromBase58(params.feePayerAddress);
     const zkApp = new MinaGuard(zkAppAddress);
 
+    await fetchAccount({ publicKey: feePayer });
+    clearStaleTransaction();
     const tx = await Mina.transaction(txSender(feePayer), async () => {
       await zkApp.setup(
         ownerStore.getCommitment(),
@@ -797,6 +820,8 @@ const workerApi = {
     const contract = new MinaGuard(PublicKey.fromBase58(params.contractAddress));
     const executor = PublicKey.fromBase58(params.executorAddress);
 
+    await fetchAccount({ publicKey: executor });
+    clearStaleTransaction();
     const tx = await Mina.transaction(txSender(executor), async () => {
       if (txType === 'transfer') {
         await contract.executeTransferBatchSig(proposalStruct, approvalWitness, sigInputs);

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -40,7 +40,7 @@ const nextConfig = {
         source: '/(.*)',
         headers: [
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
-          { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
         ],
       },
     ];

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -7,6 +7,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   reactStrictMode: true,
   webpack(config, { isServer }) {
+    // Disable minification: SWC/terser minifiers are known to mangle BigInt
+    // operations (see terser/terser#546, terser/terser#525). o1js relies on
+    // BigInt for field arithmetic and Poseidon hashing; minified builds
+    // silently produce wrong transaction commitments, causing the Mina node
+    // to reject signatures with Invalid_signature.
+    config.optimization = {
+      ...config.optimization,
+      minimize: false,
+    };
     // o1js uses top-level await and WASM
     config.experiments = {
       ...config.experiments,


### PR DESCRIPTION
Disables webpack minification which was mangling o1js BigInt operations and causing Invalid_signature errors on deployed builds. Also fixes stale transaction contexts, switches to credentialless COEP so browser extensions aren't blocked, and waits for Auro's async provider injection.