### PR TITLE
Reduce lightnet slot time from 20s to 1s

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -156,7 +156,7 @@ export default async function globalSetup() {
 
       log('Starting lightnet (this may take 1-2 minutes)...');
       try {
-        execSync('zk lightnet start', {
+        execSync('zk lightnet start -o 1000', {
           cwd: ROOT,
           stdio: 'inherit',
           timeout: 300_000,


### PR DESCRIPTION
reduces e2e test CI by half (~20min -> ~10min)