### PR TITLE
Fix preview teardown to remove built images

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -54,11 +54,13 @@ jobs:
           for i in $(seq 1 36); do
             if curl -sf "http://localhost:${PREVIEW_PORT}/preview/${PR_NUMBER}/health" > /dev/null 2>&1; then
               echo "Backend is ready!"
-              break
+              exit 0
             fi
             echo "Attempt $i/36: not ready yet..."
             sleep 5
           done
+          echo "Backend failed to become ready within timeout"
+          exit 1
 
       - name: Comment PR with preview URL
         uses: actions/github-script@v7

--- a/preview-env/preview.sh
+++ b/preview-env/preview.sh
@@ -174,7 +174,7 @@ case "$COMMAND" in
         fi
 
         echo "Tearing down PR #${PR_NUMBER} preview..."
-        docker compose -p "pr-${PR_NUMBER}" down -v --remove-orphans
+        docker compose -p "pr-${PR_NUMBER}" down -v --remove-orphans --rmi local
 
         # Remove route from main Caddy
         remove_caddy_route "$PR_NUMBER"


### PR DESCRIPTION
Add --rmi local to docker compose down so locally built PR images (frontend, backend, explorer) are cleaned up on teardown. Pulled base images (postgres, caddy, mina-local-network) are kept since they're shared across PRs.

Removing these images will remove the tag on the images and make them available for cleanup in the future.