### PR TITLE
Add auto-deploy workflow for main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,13 @@ jobs:
   deploy:
     runs-on: self-hosted
     steps:
+      - name: Verify branch is main
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error::Refusing to deploy from ${{ github.ref }}. This workflow only runs on main."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,10 @@ jobs:
           for i in $(seq 1 36); do
             if curl -sf "http://localhost:10000/app/health" > /dev/null 2>&1; then
               echo "Backend is ready!"
-              break
+              exit 0
             fi
             echo "Attempt $i/36: not ready yet..."
             sleep 5
           done
+          echo "Backend failed to become ready within timeout"
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Deploy
+        run: |
+          chmod +x deploy/deploy.sh
+          ./deploy/deploy.sh up
+
+      - name: Wait for services
+        run: |
+          echo "Waiting for backend..."
+          for i in $(seq 1 36); do
+            if curl -sf "http://localhost:10000/app/health" > /dev/null 2>&1; then
+              echo "Backend is ready!"
+              break
+            fi
+            echo "Attempt $i/36: not ready yet..."
+            sleep 5
+          done

--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -1,0 +1,37 @@
+name: Reset main deployment
+
+on:
+  schedule:
+    - cron: '0 4 */3 * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  reset:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Reset
+        run: |
+          chmod +x deploy/deploy.sh
+          ./deploy/deploy.sh reset
+
+      - name: Wait for services
+        run: |
+          echo "Waiting for backend..."
+          for i in $(seq 1 36); do
+            if curl -sf "http://localhost:10000/app/health" > /dev/null 2>&1; then
+              echo "Backend is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/36: not ready yet..."
+            sleep 5
+          done
+          echo "Backend failed to become ready within timeout"
+          exit 1

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,76 @@
+:80 {
+    # Backend health
+    handle /app/health {
+        uri strip_prefix /app
+        reverse_proxy backend:4000
+    }
+
+    # Backend API
+    handle /app/api/* {
+        uri strip_prefix /app
+        reverse_proxy backend:4000
+    }
+
+    # Lightnet GraphQL
+    handle /app/graphql {
+        uri strip_prefix /app
+        header Access-Control-Allow-Origin "*"
+        header Access-Control-Allow-Methods "GET, POST, OPTIONS"
+        header Access-Control-Allow-Headers "Content-Type"
+        @options method OPTIONS
+        respond @options 204
+        reverse_proxy lightnet:8080 {
+            header_down -Access-Control-Allow-Origin
+            header_down -Access-Control-Allow-Methods
+            header_down -Access-Control-Allow-Headers
+        }
+    }
+
+    # Lightnet accounts manager
+    handle /app/accounts/* {
+        uri strip_prefix /app/accounts
+        reverse_proxy lightnet:8181
+    }
+
+    # Lightnet archive node
+    handle /app/archive {
+        uri strip_prefix /app
+        header Access-Control-Allow-Origin "*"
+        header Access-Control-Allow-Methods "GET, POST, OPTIONS"
+        header Access-Control-Allow-Headers "Content-Type"
+        @options method OPTIONS
+        respond @options 204
+        reverse_proxy lightnet:8282 {
+            header_down -Access-Control-Allow-Origin
+            header_down -Access-Control-Allow-Methods
+            header_down -Access-Control-Allow-Headers
+        }
+    }
+
+    # Block explorer
+    handle /app/explorer/* {
+        reverse_proxy explorer:3000
+    }
+    handle /app/explorer {
+        reverse_proxy explorer:3000
+    }
+
+    # Static assets (content-hashed filenames, safe to cache long-term)
+    handle /app/_next/static/* {
+        reverse_proxy frontend:3000
+    }
+
+    # Frontend (catch-all)
+    handle /app/* {
+        reverse_proxy frontend:3000 {
+            header_down -Cache-Control
+        }
+        header Cache-Control "no-cache"
+    }
+    handle /app {
+        reverse_proxy frontend:3000 {
+            header_down -Cache-Control
+        }
+        header Cache-Control "no-cache"
+    }
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -2,8 +2,9 @@
 # MinaGuard Main Branch Deployment
 #
 # Usage:
-#   ./deploy.sh up     — deploy main branch
-#   ./deploy.sh down   — teardown deployment
+#   ./deploy.sh up      — deploy main branch (force-recreates containers for fresh lightnet chain)
+#   ./deploy.sh reset   — wipe volumes and redeploy (used by the 3-day bloat-cleanup cron)
+#   ./deploy.sh down    — teardown deployment
 #
 # Expects to be run from the repo root directory.
 
@@ -79,9 +80,14 @@ remove_caddy_route() {
 }
 
 case "$COMMAND" in
+    reset)
+        echo "Wiping volumes for bloat cleanup..."
+        docker compose -f deploy/docker-compose.yml -p minaguard down -v --remove-orphans 2>/dev/null || true
+        remove_caddy_route 2>/dev/null || true
+        ;&
     up)
         echo "Deploying main branch on port ${PORT}..."
-        docker compose -f deploy/docker-compose.yml -p minaguard up -d --build --remove-orphans
+        docker compose -f deploy/docker-compose.yml -p minaguard up -d --build --force-recreate --remove-orphans
         add_caddy_route
 
         echo ""
@@ -102,7 +108,7 @@ case "$COMMAND" in
         ;;
 
     *)
-        echo "Usage: $0 {up|down}"
+        echo "Usage: $0 {up|reset|down}"
         exit 1
         ;;
 esac

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -87,6 +87,7 @@ case "$COMMAND" in
         ;&
     up)
         echo "Deploying main branch on port ${PORT}..."
+        # TODO(devnet): replace force-recreate with zero-downtime strategy (e.g., blue/green via caddy route swap) — current approach briefly drops requests during container swap.
         docker compose -f deploy/docker-compose.yml -p minaguard up -d --build --force-recreate --remove-orphans
         add_caddy_route
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# MinaGuard Main Branch Deployment
+#
+# Usage:
+#   ./deploy.sh up     — deploy main branch
+#   ./deploy.sh down   — teardown deployment
+#
+# Expects to be run from the repo root directory.
+
+set -euo pipefail
+
+COMMAND="${1:-}"
+PORT=10000
+CADDY_API="http://localhost:2019"
+ROUTES_PATH="apps/http/servers/srv0/routes/0/handle/0/routes"
+
+add_caddy_route() {
+    remove_caddy_route 2>/dev/null || true
+
+    local group
+    group=$(curl -s "${CADDY_API}/config/${ROUTES_PATH}/0" | python3 -c "import sys,json; print(json.load(sys.stdin).get('group','group0'))" 2>/dev/null || echo "group0")
+
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"@id\": \"app-main\",
+          \"group\": \"${group}\",
+          \"match\": [{\"path\": [\"/app\", \"/app/*\"]}],
+          \"handle\": [{
+            \"handler\": \"subroute\",
+            \"routes\": [{
+              \"handle\": [
+                {
+                  \"handler\": \"headers\",
+                  \"response\": {
+                    \"set\": {
+                      \"Cross-Origin-Opener-Policy\": [\"same-origin\"],
+                      \"Cross-Origin-Embedder-Policy\": [\"credentialless\"]
+                    }
+                  }
+                },
+                {
+                  \"handler\": \"reverse_proxy\",
+                  \"headers\": {
+                    \"response\": {
+                      \"delete\": [\"Cross-Origin-Opener-Policy\", \"Cross-Origin-Embedder-Policy\"]
+                    }
+                  },
+                  \"upstreams\": [{\"dial\": \"localhost:${PORT}\"}]
+                }
+              ]
+            }]
+          }]
+        }" \
+        "${CADDY_API}/config/${ROUTES_PATH}")
+
+    if [ "$status" = "200" ]; then
+        echo "Caddy route added: /app/ → localhost:${PORT}"
+    else
+        echo "ERROR: Failed to add Caddy route (HTTP ${status})"
+        exit 1
+    fi
+}
+
+remove_caddy_route() {
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+        "${CADDY_API}/id/app-main")
+
+    if [ "$status" = "200" ]; then
+        echo "Caddy route removed for /app"
+    elif [ "$status" = "404" ]; then
+        echo "No Caddy route found for /app"
+    else
+        echo "ERROR: Failed to remove Caddy route (HTTP ${status})"
+        exit 1
+    fi
+}
+
+case "$COMMAND" in
+    up)
+        echo "Deploying main branch on port ${PORT}..."
+        docker compose -f deploy/docker-compose.yml -p minaguard up -d --build --remove-orphans
+        add_caddy_route
+
+        echo ""
+        echo "Waiting for lightnet to sync (this takes ~90s)..."
+        echo ""
+        echo "  App:       https://mina-nodes.duckdns.org/app/"
+        echo "  API:       https://mina-nodes.duckdns.org/app/health"
+        echo "  GraphQL:   https://mina-nodes.duckdns.org/app/graphql"
+        echo "  Accounts:  https://mina-nodes.duckdns.org/app/accounts/acquire-account"
+        echo "  Explorer:  https://mina-nodes.duckdns.org/app/explorer"
+        ;;
+
+    down)
+        echo "Tearing down main deployment..."
+        docker compose -p minaguard down -v --remove-orphans --rmi local
+        remove_caddy_route
+        echo "Done."
+        ;;
+
+    *)
+        echo "Usage: $0 {up|down}"
+        exit 1
+        ;;
+esac

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -96,4 +96,5 @@ services:
       - lightnet
 
 volumes:
+  # TODO(devnet): mark `external: true` when migrating off lightnet — db is wiped on every deploy because its state mirrors the lightnet chain.
   minaguard-db-data:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - POSTGRES_USER=minaguard
       - POSTGRES_PASSWORD=minaguard
       - POSTGRES_DB=minaguard
+    volumes:
+      - minaguard-db-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U minaguard"]
       interval: 5s
@@ -92,3 +94,6 @@ services:
       - backend
       - explorer
       - lightnet
+
+volumes:
+  minaguard-db-data:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,94 @@
+# Main branch deployment
+#
+# Usage (run from repo root):
+#   docker compose -f deploy/docker-compose.yml -p minaguard up -d --build
+#   docker compose -p minaguard down -v
+#
+# Access: https://mina-nodes.duckdns.org/app/
+
+services:
+  lightnet:
+    image: o1labs/mina-local-network:compatible-latest-lightnet
+    restart: unless-stopped
+    environment:
+      - SLOT_TIME=10000
+      - PROOF_LEVEL=none
+      - RUN_ARCHIVE_NODE=true
+      - NETWORK_TYPE=single-node
+      - LOG_LEVEL=Info
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ syncStatus }\"}' http://localhost:8080/graphql && curl -sf -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ networkState { maxBlockHeight { pendingMaxBlockHeight } } }\"}' http://localhost:8282"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 120s
+
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=minaguard
+      - POSTGRES_PASSWORD=minaguard
+      - POSTGRES_DB=minaguard
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U minaguard"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  backend:
+    build:
+      context: ..
+      dockerfile: preview-env/Dockerfile.backend
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgresql://minaguard:minaguard@db:5432/minaguard
+      - MINA_ENDPOINT=http://lightnet:8080/graphql
+      - ARCHIVE_ENDPOINT=http://lightnet:8282
+      - LIGHTNET_ACCOUNT_MANAGER=http://lightnet:8181
+      - PORT=4000
+    depends_on:
+      lightnet:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: preview-env/Dockerfile.frontend
+      args:
+        - NEXT_PUBLIC_BASE_PATH=/app
+        - NEXT_PUBLIC_API_BASE_URL=https://mina-nodes.duckdns.org/app
+        - NEXT_PUBLIC_MINA_ENDPOINT=https://mina-nodes.duckdns.org/app/graphql
+        - NEXT_PUBLIC_ARCHIVE_ENDPOINT=https://mina-nodes.duckdns.org/app/archive
+        - NEXT_PUBLIC_MINA_NETWORK=testnet
+        - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mina-nodes.duckdns.org/app/explorer
+    restart: unless-stopped
+    depends_on:
+      - backend
+
+  explorer:
+    build:
+      context: ../preview-env
+      dockerfile: Dockerfile.explorer
+      args:
+        - NEXT_PUBLIC_BASE_PATH=/app/explorer
+        - TESTNET_GRAPHQL_URL=http://lightnet:8080/graphql
+    restart: unless-stopped
+    depends_on:
+      lightnet:
+        condition: service_healthy
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports:
+      - "10000:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - frontend
+      - backend
+      - explorer
+      - lightnet


### PR DESCRIPTION
- Adds a GitHub Actions workflow that deploys the full stack (lightnet, postgres, backend, frontend, explorer) on push to main
- Uses `deploy/deploy.sh` for compose + Caddy route management, matching the preview system pattern
- Includes `deploy/docker-compose.yml` and `deploy/Caddyfile` for the `/app` path