### PR TITLE
Added Memo field and matching indicator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ui/deps/o1js"]
 	path = ui/deps/o1js
 	url = https://github.com/graikos/o1js.git
-	branch = develop-3.0
+	# branch = develop-3.0

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -56,6 +56,7 @@ model Proposal {
   networkId       String?
   guardAddress    String?
   memo            String?
+  executionMemoHash String?
   origin          String    @default("onchain")
   status          String    @default("pending")
   approvalCount   Int       @default(0)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -55,6 +55,7 @@ model Proposal {
   expiryBlock     String?
   networkId       String?
   guardAddress    String?
+  memo            String?
   origin          String    @default("onchain")
   status          String    @default("pending")
   approvalCount   Int       @default(0)

--- a/backend/src/batch-routes.ts
+++ b/backend/src/batch-routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { PublicKey } from 'o1js';
 import { z } from 'zod';
-import { MAX_RECEIVERS, TxType } from 'contracts';
+import { MAX_RECEIVERS, TxType, memoToField } from 'contracts';
 import { prisma } from './db.js';
 import { computeProposalHash, verifySignature, buildBatchPayload } from './batch-sig-service.js';
 import { serializeProposalRecord } from './proposal-record.js';
@@ -12,6 +12,7 @@ import {
   proposalParamsSchema,
   addressParamsMiddleware,
   proposalParamsMiddleware,
+  memoSchema,
   type AddressParams,
   type ProposalParams,
 } from './request-validation.js';
@@ -37,6 +38,8 @@ const createProposalSchema = z.object({
   tokenId: fieldString,
   txType: fieldString,
   data: fieldString,
+  memo: memoSchema.optional(),
+  memoHash: fieldString,
   uid: fieldString,
   configNonce: fieldString,
   expiryBlock: fieldString,
@@ -92,9 +95,23 @@ export function createBatchRouter(): Router {
 
     const {
       toAddress, receivers, tokenId, txType, data,
+      memo, memoHash,
       uid, configNonce, expiryBlock, networkId, guardAddress,
       proposalHash, proposer,
     } = parsed.data;
+
+    // Verify the submitted memoHash was derived from the submitted plaintext
+    // memo. Prevents a spoof where the client POSTs plaintext "pay alice"
+    // while the on-chain commitment binds to a hash of "pay bob".
+    const expectedMemoHash = memoToField(memo ?? '').toString();
+    if (memoHash !== expectedMemoHash) {
+      res.status(400).json({
+        error: 'memoHash does not match provided memo',
+        expected: expectedMemoHash,
+        received: memoHash,
+      });
+      return;
+    }
 
     const normalizedReceivers = normalizeProposalReceivers({
       txType,
@@ -136,7 +153,7 @@ export function createBatchRouter(): Router {
     try {
       computedHash = computeProposalHash({
         receivers: normalizedReceivers.receivers,
-        tokenId, txType, data,
+        tokenId, txType, data, memoHash,
         uid, configNonce, expiryBlock, networkId, guardAddress,
       });
     } catch (err) {
@@ -177,6 +194,7 @@ export function createBatchRouter(): Router {
         tokenId,
         txType,
         data,
+        memo: memo ?? null,
         uid,
         configNonce,
         expiryBlock,

--- a/backend/src/batch-sig-service.ts
+++ b/backend/src/batch-sig-service.ts
@@ -32,6 +32,7 @@ export function computeProposalHash(params: {
   tokenId: string;
   txType: string;
   data: string;
+  memoHash: string;
   uid: string;
   configNonce: string;
   expiryBlock: string;
@@ -51,6 +52,7 @@ export function computeProposalHash(params: {
     tokenId: Field(params.tokenId),
     txType: Field(params.txType),
     data: Field(params.data),
+    memoHash: Field(params.memoHash),
     uid: Field(params.uid),
     configNonce: Field(params.configNonce),
     expiryBlock: Field(params.expiryBlock),

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -1,7 +1,7 @@
 import { prisma } from './db.js';
 import type { BackendConfig } from './config.js';
 import { PublicKey } from 'o1js';
-import { MAX_RECEIVERS } from 'contracts';
+import { MAX_RECEIVERS, memoToField, decodeTxMemo } from 'contracts';
 import {
   configureNetwork,
   discoverCandidateAddresses,
@@ -507,10 +507,37 @@ export class MinaGuardIndexer {
     });
   }
 
-  /** Marks proposals executed when execution events are observed. */
+  /** Marks proposals executed when execution events are observed. Hashes the
+   *  outer Mina tx memo (from archive transactionInfo.memo) so the serializer
+   *  can cross-check it against the proposer's plaintext memo. The inner
+   *  struct memoHash emitted in the event is ignored here — it's always equal
+   *  to memoToField(proposer memo) for the normal execute path, so comparing
+   *  against it would be tautological. The outer tx memo is the meaningful
+   *  signal: a CLI executor or misbehaving wallet can set a different memo
+   *  on the envelope, and this catches it.
+   *
+   *  A missing tx memo from the archive is treated as the empty string (not
+   *  as unknown). Mina's envelope always carries a memo field, so "archive
+   *  reports none" really means "tx had an empty memo" — and if the proposer
+   *  memo was non-empty, that's a genuine mismatch to flag rather than a
+   *  don't-know state. */
   private async applyExecutionEvent(contractId: number, chainEvent: ChainEvent): Promise<void> {
     const proposalHash = asString(chainEvent.event.proposalHash);
     if (!proposalHash) return;
+
+    // Archive returns the outer tx memo base58check-encoded. Decode to
+    // plaintext so memoToField hashes the same string the proposer typed.
+    let observedMemo = '';
+    if (chainEvent.txMemo) {
+      try {
+        observedMemo = decodeTxMemo(chainEvent.txMemo);
+      } catch (err) {
+        // If decoding fails, fall back to the raw value — memoToField will
+        // hash it as-is, producing a mismatch (which is the safe default).
+        observedMemo = chainEvent.txMemo;
+      }
+    }
+    const executionMemoHash = memoToField(observedMemo).toString();
 
     await prisma.proposal.updateMany({
       where: {
@@ -520,6 +547,7 @@ export class MinaGuardIndexer {
       data: {
         status: 'executed',
         executedAtBlock: chainEvent.blockHeight,
+        executionMemoHash,
       },
     });
   }

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -8,6 +8,10 @@ export interface ChainEvent {
   event: Record<string, unknown>;
   blockHeight: number;
   txHash: string | null;
+  /** Outer Mina transaction memo from the archive's transactionInfo.memo
+   *  field. Used by the indexer to cross-check executor-committed memos
+   *  against proposer plaintext. Null when the archive doesn't surface it. */
+  txMemo: string | null;
 }
 
 /** Configures o1js network endpoints once at process start. */
@@ -149,12 +153,16 @@ export async function fetchDecodedContractEvents(
   // TODO: restore toHeight once archive node supports upper-bound filtering
   const rawEvents = await contract.fetchEvents(UInt32.from(fromHeight));
 
-  return rawEvents.map((entry) => ({
-    type: entry.type,
-    event: toSerializableObject((entry.event as any).data),
-    blockHeight: Number(entry.blockHeight.toString()),
-    txHash: ((entry.event as any).transactionInfo?.transactionHash as string | undefined) ?? null,
-  }));
+  return rawEvents.map((entry) => {
+    const txInfo = (entry.event as any).transactionInfo;
+    return {
+      type: entry.type,
+      event: toSerializableObject((entry.event as any).data),
+      blockHeight: Number(entry.blockHeight.toString()),
+      txHash: (txInfo?.transactionHash as string | undefined) ?? null,
+      txMemo: (txInfo?.transactionMemo as string | undefined) ?? null,
+    };
+  });
 }
 
 /** Runs a GraphQL request with optional endpoint fallback. */

--- a/backend/src/proposal-record.ts
+++ b/backend/src/proposal-record.ts
@@ -1,10 +1,20 @@
 import type { Proposal, ProposalReceiver } from '@prisma/client';
+import { memoToField } from 'contracts';
 
 export interface ProposalReceiverRecord {
   index: number;
   address: string;
   amount: string;
 }
+
+/** Verdict on whether the off-chain proposer memo matches the hash the
+ *  executor committed on-chain in the execution event.
+ *  - `null`  — not yet computable (pending, no proposer memo, or
+ *              executionMemoHash not yet observed).
+ *  - `true`  — proposer memo, when hashed, equals the executor's memoHash.
+ *  - `false` — proposer memo hashes to something different from what the
+ *              executor committed. */
+export type MemoExecutionMatch = boolean | null;
 
 export interface SerializedProposalRecord {
   proposalHash: string;
@@ -19,6 +29,7 @@ export interface SerializedProposalRecord {
   networkId: string | null;
   guardAddress: string | null;
   memo: string | null;
+  memoExecutionMatch: MemoExecutionMatch;
   status: string;
   origin: string;
   approvalCount: number;
@@ -34,6 +45,30 @@ export interface SerializedProposalRecord {
 type ProposalWithReceivers = Proposal & {
   receivers: ProposalReceiver[];
 };
+
+/** Derives the match verdict comparing the proposer's plaintext memo against
+ *  the hash of the executor's outer tx memo observed on-chain.
+ *
+ *  - `null` (indeterminate, UI shows yellow warning) iff we haven't yet seen
+ *    an execution event for this proposal — i.e. the row is still pending.
+ *    Once executed, the indexer always writes a non-null executionMemoHash
+ *    (at minimum '0' for an empty tx memo), so this branch maps 1:1 to
+ *    "not yet executed".
+ *  - Otherwise, a null proposer memo is treated as the empty string, matching
+ *    the indexer's null → '' normalization for the tx memo. This yields:
+ *      (null proposer, empty executor)    → match   → UI shows no icon
+ *      (null proposer, non-empty executor) → mismatch → red ✗
+ *      (memo proposer, empty executor)    → mismatch → red ✗
+ *      (memo proposer, matching executor) → match   → green ✓ */
+function computeMemoExecutionMatch(
+  memo: string | null,
+  executionMemoHash: string | null
+): MemoExecutionMatch {
+  if (executionMemoHash == null) return null;
+  const proposerHash = memoToField(memo ?? '').toString();
+  const match = proposerHash === executionMemoHash;
+  return match;
+}
 
 /** Converts Prisma proposal rows into the API shape expected by the UI. */
 export function serializeProposalRecord(
@@ -65,6 +100,7 @@ export function serializeProposalRecord(
     networkId: proposal.networkId,
     guardAddress: proposal.guardAddress,
     memo: proposal.memo,
+    memoExecutionMatch: computeMemoExecutionMatch(proposal.memo, proposal.executionMemoHash),
     status: proposal.status,
     origin: proposal.origin,
     approvalCount: proposal.approvalCount,

--- a/backend/src/proposal-record.ts
+++ b/backend/src/proposal-record.ts
@@ -18,6 +18,7 @@ export interface SerializedProposalRecord {
   expiryBlock: string | null;
   networkId: string | null;
   guardAddress: string | null;
+  memo: string | null;
   status: string;
   origin: string;
   approvalCount: number;
@@ -63,6 +64,7 @@ export function serializeProposalRecord(
     expiryBlock: proposal.expiryBlock,
     networkId: proposal.networkId,
     guardAddress: proposal.guardAddress,
+    memo: proposal.memo,
     status: proposal.status,
     origin: proposal.origin,
     approvalCount: proposal.approvalCount,

--- a/backend/src/request-validation.ts
+++ b/backend/src/request-validation.ts
@@ -23,6 +23,15 @@ export const proposalHashParamSchema = z.string().regex(
   'Must be a numeric string'
 );
 
+/** Mina transaction memo — max 32 UTF-8 bytes.
+ *  Byte-length semantics are shared with ui/lib/memo.ts; the constant is
+ *  intentionally duplicated to avoid cross-workspace imports. */
+export const MEMO_MAX_BYTES = 32;
+export const memoSchema = z.string().refine(
+  (value) => new TextEncoder().encode(value).length <= MEMO_MAX_BYTES,
+  { message: `Memo exceeds ${MEMO_MAX_BYTES} UTF-8 bytes` },
+);
+
 /** Zod query schema that preserves existing bounded integer parsing semantics. */
 export function clampedIntQuerySchema(
   fallback: number,

--- a/backend/src/tests/batch-sig-api.test.ts
+++ b/backend/src/tests/batch-sig-api.test.ts
@@ -6,6 +6,7 @@ import { prisma } from '../db.js';
 import { createBatchRouter } from '../batch-routes.js';
 import { MinaGuardIndexer } from '../indexer.js';
 import type { BackendConfig } from '../config.js';
+import { serializeProposalRecord } from '../proposal-record.js';
 import {
   Receiver, TransactionProposal, TxType, MinaGuard, SetupOwnersInput, MAX_OWNERS, MAX_RECEIVERS,
   computeOwnerChain, ApprovalStore, SignatureInputs, SignatureInput, SignatureOption, memoToField,
@@ -1166,5 +1167,260 @@ describe('indexer transfer event batch dedup', () => {
     // Cleanup
     await prisma.proposalReceiver.deleteMany({ where: { proposalId: testProposal.id } });
     await prisma.proposal.delete({ where: { id: testProposal.id } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeProposalRecord — memoExecutionMatch verdict
+// ---------------------------------------------------------------------------
+
+describe('serializeProposalRecord memoExecutionMatch', () => {
+  async function seedProposal(row: {
+    proposalHash: string;
+    memo: string | null;
+    executionMemoHash: string | null;
+    status: string;
+  }) {
+    const contract = await prisma.contract.findUnique({
+      where: { address: guardAddress.toBase58() },
+    });
+    return prisma.proposal.create({
+      data: {
+        contractId: contract!.id,
+        proposalHash: row.proposalHash,
+        origin: 'offchain',
+        status: row.status,
+        memo: row.memo,
+        executionMemoHash: row.executionMemoHash,
+      },
+      include: { receivers: true },
+    });
+  }
+
+  test('returns null for a pending proposal with a memo', async () => {
+    const p = await seedProposal({
+      proposalHash: 'mem-verdict-pending',
+      memo: 'rent payment',
+      executionMemoHash: null,
+      status: 'pending',
+    });
+    try {
+      const body = serializeProposalRecord(p);
+      expect(body.memoExecutionMatch).toBeNull();
+    } finally {
+      await prisma.proposal.delete({ where: { id: p.id } });
+    }
+  });
+
+  test('returns true when neither proposer nor executor set a memo (empty-vs-empty match)', async () => {
+    // Both sides being empty is a valid "match" state — the serializer
+    // normalizes null proposer memo to '', same as the indexer normalizes
+    // null tx memo to ''. Under the UI state machine this renders as no
+    // icon at all (match + null proposer memo → undefined adornment).
+    const p = await seedProposal({
+      proposalHash: 'mem-verdict-empty-match',
+      memo: null,
+      executionMemoHash: memoToField('').toString(),
+      status: 'executed',
+    });
+    try {
+      const body = serializeProposalRecord(p);
+      expect(body.memoExecutionMatch).toBe(true);
+    } finally {
+      await prisma.proposal.delete({ where: { id: p.id } });
+    }
+  });
+
+  test('returns false when the executor set a memo but the proposer did not', async () => {
+    // Null proposer memo + non-empty executor memo = mismatch (red ✗).
+    // Catches the case where someone executes a proposal with an off-brand
+    // memo the proposer never agreed to.
+    const p = await seedProposal({
+      proposalHash: 'mem-verdict-null-proposer-memo-executor',
+      memo: null,
+      executionMemoHash: memoToField('surprise memo').toString(),
+      status: 'executed',
+    });
+    try {
+      const body = serializeProposalRecord(p);
+      expect(body.memoExecutionMatch).toBe(false);
+    } finally {
+      await prisma.proposal.delete({ where: { id: p.id } });
+    }
+  });
+
+  test('returns null for an executed memo-bearing proposal with no executionMemoHash (pre-feature)', async () => {
+    const p = await seedProposal({
+      proposalHash: 'mem-verdict-legacy',
+      memo: 'rent payment',
+      executionMemoHash: null,
+      status: 'executed',
+    });
+    try {
+      const body = serializeProposalRecord(p);
+      expect(body.memoExecutionMatch).toBeNull();
+    } finally {
+      await prisma.proposal.delete({ where: { id: p.id } });
+    }
+  });
+
+  test('returns "match" when the executor committed the same memoHash', async () => {
+    const memo = 'rent payment';
+    const p = await seedProposal({
+      proposalHash: 'mem-verdict-match',
+      memo,
+      executionMemoHash: memoToField(memo).toString(),
+      status: 'executed',
+    });
+    try {
+      const body = serializeProposalRecord(p);
+      expect(body.memoExecutionMatch).toBe(true);
+    } finally {
+      await prisma.proposal.delete({ where: { id: p.id } });
+    }
+  });
+
+  test('returns "mismatch" when the executor committed a different memoHash', async () => {
+    const p = await seedProposal({
+      proposalHash: 'mem-verdict-mismatch',
+      memo: 'alice',
+      executionMemoHash: memoToField('bob').toString(),
+      status: 'executed',
+    });
+    try {
+      const body = serializeProposalRecord(p);
+      expect(body.memoExecutionMatch).toBe(false);
+    } finally {
+      await prisma.proposal.delete({ where: { id: p.id } });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyExecutionEvent — executionMemoHash derived from outer tx memo
+// ---------------------------------------------------------------------------
+
+describe('applyExecutionEvent executionMemoHash sourcing', () => {
+  const dummyConfig: BackendConfig = {
+    port: 0,
+    databaseUrl: '',
+    minaEndpoint: 'http://localhost:1',
+    archiveEndpoint: 'http://localhost:1',
+    lightnetAccountManager: undefined,
+    minaFallbackEndpoint: null,
+    archiveFallbackEndpoint: null,
+    indexPollIntervalMs: 99999,
+    indexStartHeight: 0,
+    minaguardVkHash: null,
+  };
+
+  async function seedPendingProposal(proposalHash: string) {
+    const contract = await prisma.contract.findUnique({
+      where: { address: guardAddress.toBase58() },
+    });
+    return prisma.proposal.create({
+      data: {
+        contractId: contract!.id,
+        proposalHash,
+        origin: 'offchain',
+        status: 'pending',
+      },
+    });
+  }
+
+  function makeExecutionChainEvent(
+    proposalHash: string,
+    txMemo: string | null
+  ): {
+    type: string;
+    event: Record<string, unknown>;
+    blockHeight: number;
+    txHash: string | null;
+    txMemo: string | null;
+  } {
+    return {
+      type: 'execution',
+      event: { proposalHash, txType: '0' },
+      blockHeight: 123,
+      txHash: null,
+      txMemo,
+    };
+  }
+
+  test('stores memoToField(txMemo) when the outer tx memo is present', async () => {
+    const indexer = new MinaGuardIndexer(dummyConfig);
+    const apply = (indexer as any).applyExecutionEvent.bind(indexer);
+    const contract = await prisma.contract.findUnique({
+      where: { address: guardAddress.toBase58() },
+    });
+
+    const seeded = await seedPendingProposal('exec-memo-happy');
+    try {
+      await apply(contract!.id, makeExecutionChainEvent('exec-memo-happy', 'rent payment'));
+      const row = await prisma.proposal.findUnique({ where: { id: seeded.id } });
+      expect(row?.status).toBe('executed');
+      expect(row?.executionMemoHash).toBe(memoToField('rent payment').toString());
+    } finally {
+      await prisma.proposal.delete({ where: { id: seeded.id } });
+    }
+  });
+
+  test('normalizes an absent outer tx memo to the empty-string hash', async () => {
+    // Mina's envelope always has a memo field — if the archive reports null,
+    // it means the tx was sent with an empty memo, not "unknown". Treat it
+    // as empty so that a non-empty proposer memo is flagged as a mismatch
+    // downstream, rather than rendering as the indeterminate yellow warning.
+    const indexer = new MinaGuardIndexer(dummyConfig);
+    const apply = (indexer as any).applyExecutionEvent.bind(indexer);
+    const contract = await prisma.contract.findUnique({
+      where: { address: guardAddress.toBase58() },
+    });
+
+    const seeded = await seedPendingProposal('exec-memo-absent');
+    try {
+      await apply(contract!.id, makeExecutionChainEvent('exec-memo-absent', null));
+      const row = await prisma.proposal.findUnique({ where: { id: seeded.id } });
+      expect(row?.status).toBe('executed');
+      // memoToField('') === Field(0), whose decimal string form is '0'.
+      expect(row?.executionMemoHash).toBe(memoToField('').toString());
+    } finally {
+      await prisma.proposal.delete({ where: { id: seeded.id } });
+    }
+  });
+
+  test('drives the downstream verdict to mismatch when proposer had a memo and executor did not', async () => {
+    // End-to-end check of the null-normalization decision: a proposal with a
+    // non-empty memo, executed with a null outer tx memo, should serialize as
+    // memoExecutionMatch === false (the red ✗ tooltip state), not null.
+    const indexer = new MinaGuardIndexer(dummyConfig);
+    const apply = (indexer as any).applyExecutionEvent.bind(indexer);
+    const contract = await prisma.contract.findUnique({
+      where: { address: guardAddress.toBase58() },
+    });
+
+    const seeded = await prisma.proposal.create({
+      data: {
+        contractId: contract!.id,
+        proposalHash: 'exec-memo-absent-with-proposer-memo',
+        origin: 'offchain',
+        status: 'pending',
+        memo: 'rent payment',
+      },
+      include: { receivers: true },
+    });
+    try {
+      await apply(
+        contract!.id,
+        makeExecutionChainEvent('exec-memo-absent-with-proposer-memo', null)
+      );
+      const row = await prisma.proposal.findUnique({
+        where: { id: seeded.id },
+        include: { receivers: true },
+      });
+      const body = serializeProposalRecord(row!);
+      expect(body.memoExecutionMatch).toBe(false);
+    } finally {
+      await prisma.proposal.delete({ where: { id: seeded.id } });
+    }
   });
 });

--- a/backend/src/tests/batch-sig-api.test.ts
+++ b/backend/src/tests/batch-sig-api.test.ts
@@ -8,7 +8,7 @@ import { MinaGuardIndexer } from '../indexer.js';
 import type { BackendConfig } from '../config.js';
 import {
   Receiver, TransactionProposal, TxType, MinaGuard, SetupOwnersInput, MAX_OWNERS, MAX_RECEIVERS,
-  computeOwnerChain, ApprovalStore, SignatureInputs, SignatureInput, SignatureOption,
+  computeOwnerChain, ApprovalStore, SignatureInputs, SignatureInput, SignatureOption, memoToField,
 } from 'contracts';
 
 let PORT: number;
@@ -36,6 +36,7 @@ const proposal = new TransactionProposal({
   tokenId: Field(0),
   txType: TxType.TRANSFER,
   data: Field(0),
+  memoHash: Field(0),
   uid: Field(42),
   configNonce: Field(0),
   expiryBlock: Field(0),
@@ -124,6 +125,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: '0',
       txType: '0',
       data: '0',
+      memoHash: '0',
       uid: '42',
       configNonce: '0',
       expiryBlock: '0',
@@ -145,6 +147,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: '0',
       txType: '0',
       data: '0',
+      memoHash: '0',
       uid: '42',
       configNonce: '0',
       expiryBlock: '0',
@@ -162,6 +165,7 @@ describe('POST /api/contracts/:address/proposals', () => {
     expect(body.receivers).toEqual([{ index: 0, address: owners[0].pub.toBase58(), amount: '1000000000' }]);
     expect(body.recipientCount).toBe(1);
     expect(body.totalAmount).toBe('1000000000');
+    expect(body.memo).toBeNull();
   });
 
   test('rejects duplicate proposal', async () => {
@@ -171,6 +175,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: '0',
       txType: '0',
       data: '0',
+      memoHash: '0',
       uid: '42',
       configNonce: '0',
       expiryBlock: '0',
@@ -190,6 +195,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: '0',
       txType: '0',
       data: '0',
+      memoHash: '0',
       uid: '42',
       configNonce: '0',
       expiryBlock: '0',
@@ -211,6 +217,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: Field(0),
       txType: TxType.ADD_OWNER,
       data: Field(123),
+      memoHash: Field(0),
       uid: Field(88),
       configNonce: Field(0),
       expiryBlock: Field(0),
@@ -222,6 +229,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: '0',
       txType: TxType.ADD_OWNER.toString(),
       data: addOwnerProposal.data.toString(),
+      memoHash: '0',
       uid: '88',
       configNonce: '0',
       expiryBlock: '0',
@@ -243,6 +251,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: Field(0),
       txType: TxType.SET_DELEGATE,
       data: Field(1),
+      memoHash: Field(0),
       uid: Field(89),
       configNonce: Field(0),
       expiryBlock: Field(0),
@@ -254,6 +263,7 @@ describe('POST /api/contracts/:address/proposals', () => {
       tokenId: '0',
       txType: TxType.SET_DELEGATE.toString(),
       data: '1',
+      memoHash: '0',
       uid: '89',
       configNonce: '0',
       expiryBlock: '0',
@@ -266,6 +276,188 @@ describe('POST /api/contracts/:address/proposals', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBe('Proposal toAddress is required for this transaction type');
+  });
+
+  // --- memo field ---------------------------------------------------------
+
+  /** Builds a fresh transfer proposal bound to a given memoHash for memo tests. */
+  function buildMemoProposal(uid: number, memoHashField: ReturnType<typeof Field>) {
+    return new TransactionProposal({
+      receivers: [
+        new Receiver({ address: owners[0].pub, amount: UInt64.from(1_000_000_000) }),
+        ...Array.from({ length: MAX_RECEIVERS - 1 }, () => Receiver.empty()),
+      ],
+      tokenId: Field(0),
+      txType: TxType.TRANSFER,
+      data: Field(0),
+      memoHash: memoHashField,
+      uid: Field(uid),
+      configNonce: Field(0),
+      expiryBlock: Field(0),
+      networkId: Field(1),
+      guardAddress,
+    });
+  }
+
+  test('accepts a proposal with a valid plaintext memo', async () => {
+    const addr = guardAddress.toBase58();
+    const memo = 'rent payment';
+    const memoHash = memoToField(memo);
+    const p = buildMemoProposal(201, memoHash);
+
+    const res = await post(`/api/contracts/${addr}/proposals`, {
+      receivers: [{ address: owners[0].pub.toBase58(), amount: '1000000000' }],
+      tokenId: '0',
+      txType: '0',
+      data: '0',
+      memo,
+      memoHash: memoHash.toString(),
+      uid: '201',
+      configNonce: '0',
+      expiryBlock: '0',
+      networkId: '1',
+      guardAddress: addr,
+      proposalHash: p.hash().toString(),
+      proposer: defaultProposer,
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.memo).toBe('rent payment');
+  });
+
+  test('accepts an omitted memo and defaults memoHash to Field(0)', async () => {
+    const addr = guardAddress.toBase58();
+    const p = buildMemoProposal(202, Field(0));
+
+    const res = await post(`/api/contracts/${addr}/proposals`, {
+      receivers: [{ address: owners[0].pub.toBase58(), amount: '1000000000' }],
+      tokenId: '0',
+      txType: '0',
+      data: '0',
+      memoHash: '0',
+      uid: '202',
+      configNonce: '0',
+      expiryBlock: '0',
+      networkId: '1',
+      guardAddress: addr,
+      proposalHash: p.hash().toString(),
+      proposer: defaultProposer,
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.memo).toBeNull();
+  });
+
+  test('rejects a memo exceeding 32 ASCII bytes', async () => {
+    const addr = guardAddress.toBase58();
+    const longMemo = 'a'.repeat(33);
+    const memoHash = memoToField(longMemo);
+    const p = buildMemoProposal(203, memoHash);
+
+    const res = await post(`/api/contracts/${addr}/proposals`, {
+      receivers: [{ address: owners[0].pub.toBase58(), amount: '1000000000' }],
+      tokenId: '0',
+      txType: '0',
+      data: '0',
+      memo: longMemo,
+      memoHash: memoHash.toString(),
+      uid: '203',
+      configNonce: '0',
+      expiryBlock: '0',
+      networkId: '1',
+      guardAddress: addr,
+      proposalHash: p.hash().toString(),
+      proposer: defaultProposer,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid request body');
+    expect(body.details.memo).toBeDefined();
+  });
+
+  test('rejects a memo exceeding 32 bytes via multi-byte characters', async () => {
+    const addr = guardAddress.toBase58();
+    // 11 rocket emojis = 44 UTF-8 bytes but only 11 code points.
+    const emojiMemo = '🚀'.repeat(11);
+    const memoHash = memoToField(emojiMemo);
+    const p = buildMemoProposal(204, memoHash);
+
+    const res = await post(`/api/contracts/${addr}/proposals`, {
+      receivers: [{ address: owners[0].pub.toBase58(), amount: '1000000000' }],
+      tokenId: '0',
+      txType: '0',
+      data: '0',
+      memo: emojiMemo,
+      memoHash: memoHash.toString(),
+      uid: '204',
+      configNonce: '0',
+      expiryBlock: '0',
+      networkId: '1',
+      guardAddress: addr,
+      proposalHash: p.hash().toString(),
+      proposer: defaultProposer,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid request body');
+    expect(body.details.memo).toBeDefined();
+  });
+
+  test('rejects memoHash that does not match the plaintext memo', async () => {
+    const addr = guardAddress.toBase58();
+    // Client posts plaintext 'alice' but a memoHash computed from 'bob'.
+    const spoofedMemoHash = memoToField('bob');
+    const p = buildMemoProposal(205, spoofedMemoHash);
+
+    const res = await post(`/api/contracts/${addr}/proposals`, {
+      receivers: [{ address: owners[0].pub.toBase58(), amount: '1000000000' }],
+      tokenId: '0',
+      txType: '0',
+      data: '0',
+      memo: 'alice',
+      memoHash: spoofedMemoHash.toString(),
+      uid: '205',
+      configNonce: '0',
+      expiryBlock: '0',
+      networkId: '1',
+      guardAddress: addr,
+      proposalHash: p.hash().toString(),
+      proposer: defaultProposer,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('memoHash does not match provided memo');
+  });
+
+  test('still catches a tampered proposal hash even when memo is valid', async () => {
+    const addr = guardAddress.toBase58();
+    const memo = 'valid memo';
+    const memoHash = memoToField(memo);
+
+    const res = await post(`/api/contracts/${addr}/proposals`, {
+      receivers: [{ address: owners[0].pub.toBase58(), amount: '1000000000' }],
+      tokenId: '0',
+      txType: '0',
+      data: '0',
+      memo,
+      memoHash: memoHash.toString(),
+      uid: '206',
+      configNonce: '0',
+      expiryBlock: '0',
+      networkId: '1',
+      guardAddress: addr,
+      proposalHash: '12345', // tampered
+      proposer: defaultProposer,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Proposal hash mismatch');
   });
 });
 
@@ -477,7 +669,9 @@ describe('GET /api/contracts/:address/proposals/:proposalHash/batch-payload', ()
 
   test('returns 404 for unknown proposal', async () => {
     const addr = guardAddress.toBase58();
-    const res = await get(`/api/contracts/${addr}/proposals/nonexistent/batch-payload`);
+    // The URL param middleware requires a numeric Field string; use a
+    // valid-shaped hash that does not exist in the DB.
+    const res = await get(`/api/contracts/${addr}/proposals/999999999999/batch-payload`);
 
     expect(res.status).toBe(404);
   });
@@ -556,6 +750,7 @@ describe('cross-flow edge cases', () => {
       tokenId: Field(0),
       txType: TxType.TRANSFER,
       data: Field(0),
+      memoHash: Field(0),
       uid: Field(77),
       configNonce: Field(0),
       expiryBlock: Field(0),
@@ -581,6 +776,7 @@ describe('cross-flow edge cases', () => {
       tokenId: '0',
       txType: '0',
       data: '0',
+      memoHash: '0',
       uid: '77',
       configNonce: '0',
       expiryBlock: '0',
@@ -696,6 +892,7 @@ describe('executeTransferBatchSig with API payload', () => {
       tokenId: Field(0),
       txType: TxType.TRANSFER,
       data: Field(0),
+      memoHash: Field(0),
       uid: Field(100),
       configNonce: Field(0),
       expiryBlock: Field(0),
@@ -735,6 +932,7 @@ describe('executeTransferBatchSig with API payload', () => {
       tokenId: '0',
       txType: '0',
       data: '0',
+      memoHash: '0',
       uid: '100',
       configNonce: '0',
       expiryBlock: '0',
@@ -779,6 +977,12 @@ describe('executeTransferBatchSig with API payload', () => {
 
     const balanceAfter = Mina.getBalance(recipient);
     expect(balanceAfter.sub(balanceBefore)).toEqual(UInt64.from(500_000_000));
+
+    // Restore the shared seed for later describe blocks that still expect
+    // the original guardAddress contract + owners (this test cleared the DB
+    // at step 2 to seed a fresh zkApp-specific contract).
+    await clearDatabase();
+    await seedDatabase();
   });
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -1652,7 +1652,7 @@
 
     "ui/@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
-    "ui/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "blakejs": "^1.2.1", "js-sha256": "^0.9.0" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
+    "ui/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "^1.2.1" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
 
     "@babel/core/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/contracts/src/MinaGuard.ts
+++ b/contracts/src/MinaGuard.ts
@@ -50,6 +50,7 @@ export class TransactionProposal extends Struct({
   tokenId: Field,
   txType: Field,
   data: Field,
+  memoHash: Field,
   uid: Field,
   configNonce: Field,
   expiryBlock: Field,
@@ -67,6 +68,7 @@ export class TransactionProposal extends Struct({
       this.tokenId,
       this.txType,
       this.data,
+      this.memoHash,
       this.uid,
       this.configNonce,
       this.expiryBlock,
@@ -113,6 +115,7 @@ export class ProposalEvent extends Struct({
   tokenId: Field,
   txType: Field,
   data: Field,
+  memoHash: Field,
   uid: Field,
   configNonce: Field,
   expiryBlock: Field,
@@ -138,11 +141,13 @@ export class ApprovalEvent extends Struct({
 export class ExecutionEvent extends Struct({
   proposalHash: Field,
   txType: Field,
+  memoHash: Field,
 }) { }
 
 export class ExecutionBatchEvent extends Struct({
   proposalHash: Field,
   txType: Field,
+  memoHash: Field,
   approverChain: Field,
 }) { }
 
@@ -437,6 +442,7 @@ export class MinaGuard extends SmartContract {
       tokenId: proposal.tokenId,
       txType: proposal.txType,
       data: proposal.data,
+      memoHash: proposal.memoHash,
       uid: proposal.uid,
       configNonce: proposal.configNonce,
       expiryBlock: proposal.expiryBlock,
@@ -540,6 +546,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('execution', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
     });
   }
 
@@ -581,7 +588,8 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('executionBatch', {
       proposalHash,
       txType: proposal.txType,
-      approverChain: verificationRes.signerChain
+      memoHash: proposal.memoHash,
+      approverChain: verificationRes.signerChain,
     });
 
   }
@@ -650,6 +658,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('executionBatch', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
       approverChain: verificationRes.signerChain,
     });
 
@@ -718,6 +727,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('executionBatch', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
       approverChain: verificationRes.signerChain,
     });
 
@@ -776,6 +786,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('executionBatch', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
       approverChain: verificationRes.signerChain,
     });
 
@@ -845,6 +856,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('execution', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
     });
 
     this.emitEvent('ownerChange', {
@@ -904,6 +916,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('execution', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
     });
 
     this.emitEvent('thresholdChange', {
@@ -954,6 +967,7 @@ export class MinaGuard extends SmartContract {
     this.emitEvent('execution', {
       proposalHash,
       txType: proposal.txType,
+      memoHash: proposal.memoHash,
     });
 
     this.emitEvent('delegate', {

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -28,3 +28,5 @@ export { batchVerify, SignatureInputs, SignatureInput, SignatureOption } from '.
 export { ownerKey } from './utils.js';
 
 export { OwnerStore, ApprovalStore, VoteNullifierStore } from './storage.js';
+
+export { memoToField } from './memo.js';

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -29,4 +29,4 @@ export { ownerKey } from './utils.js';
 
 export { OwnerStore, ApprovalStore, VoteNullifierStore } from './storage.js';
 
-export { memoToField } from './memo.js';
+export { memoToField, decodeTxMemo } from './memo.js';

--- a/contracts/src/memo.ts
+++ b/contracts/src/memo.ts
@@ -15,3 +15,67 @@ export function memoToField(memo: string): Field {
   const bytes = new TextEncoder().encode(memo);
   return Poseidon.hash(Array.from(bytes, (b) => Field(b)));
 }
+
+// ---------------------------------------------------------------------------
+// Base58check → plaintext memo decoder
+//
+// Mina archive nodes return the outer transaction memo as a base58check-
+// encoded string. The wire format is:
+//   base58check( versionByte=0x14 | 34-byte-payload )
+// where the 34-byte payload is:
+//   [ 0x01, length, ...utf8Content, ...zeroPadding ]
+//
+// This decoder is self-contained (no o1js deep imports, no external deps)
+// because the o1js package doesn't re-export its internal Memo module.
+// ---------------------------------------------------------------------------
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+/** Decodes a base58-encoded string into raw bytes. */
+function base58Decode(input: string): Uint8Array {
+  const base = BASE58_ALPHABET.length;
+  const bytes: number[] = [0];
+  for (const char of input) {
+    const idx = BASE58_ALPHABET.indexOf(char);
+    if (idx < 0) throw new Error(`Invalid base58 character: ${char}`);
+    let carry = idx;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * base;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  // Preserve leading zeros (base58 '1' characters)
+  for (const char of input) {
+    if (char !== '1') break;
+    bytes.push(0);
+  }
+  return new Uint8Array(bytes.reverse());
+}
+
+/**
+ * Decodes a Mina base58check-encoded transaction memo to plaintext.
+ *
+ * Wire format: `base58check(0x14 | 34-byte-payload)`.
+ * Payload:     `[0x01, length, ...utf8Content, ...zeroPadding]`.
+ *
+ * Returns the UTF-8 plaintext. Throws on malformed input.
+ */
+export function decodeTxMemo(base58Memo: string): string {
+  const raw = base58Decode(base58Memo);
+  // Strip version byte (first byte = 0x14) and checksum (last 4 bytes).
+  const payload = raw.slice(1, raw.length - 4);
+  if (payload.length !== 34) {
+    throw new Error(`decodeTxMemo: expected 34-byte payload, got ${payload.length}`);
+  }
+  const contentLength = payload[1];
+  if (contentLength > 32) {
+    throw new Error(`decodeTxMemo: invalid content length ${contentLength}`);
+  }
+  const contentBytes = payload.slice(2, 2 + contentLength);
+  return new TextDecoder().decode(contentBytes);
+}

--- a/contracts/src/memo.ts
+++ b/contracts/src/memo.ts
@@ -1,0 +1,17 @@
+import { Field, Poseidon } from 'o1js';
+
+/**
+ * Encodes a memo string as the Field commitment stored in
+ * `TransactionProposal.memoHash`.
+ *
+ * Shared between the UI (when building a proposal to sign) and the backend
+ * (when verifying a submitted plaintext memo against its claimed memoHash),
+ * so both sides MUST derive the commitment the same way.
+ *
+ * Empty string → `Field(0)` (the "no memo" convention).
+ */
+export function memoToField(memo: string): Field {
+  if (memo.length === 0) return Field(0);
+  const bytes = new TextEncoder().encode(memo);
+  return Poseidon.hash(Array.from(bytes, (b) => Field(b)));
+}

--- a/contracts/src/tests/governance.test.ts
+++ b/contracts/src/tests/governance.test.ts
@@ -362,6 +362,7 @@ describe('MinaGuard - Governance', () => {
         tokenId: Field(0),
         txType: TxType.TRANSFER,
         data: Field(0),
+        memoHash: Field(0),
         uid: Field(1),
         configNonce: Field(0), // old configNonce
         expiryBlock: Field(0),
@@ -623,6 +624,7 @@ describe('MinaGuard - Owner Change BatchSig', () => {
         tokenId: Field(0),
         txType: TxType.ADD_OWNER,
         data: ownerKey(newOwner),
+        memoHash: Field(0),
         uid: Field(0),
         configNonce: Field(0),
         expiryBlock: Field(0),

--- a/contracts/src/tests/memo.test.ts
+++ b/contracts/src/tests/memo.test.ts
@@ -1,5 +1,5 @@
 import { Field } from 'o1js';
-import { memoToField } from '../memo.js';
+import { memoToField, decodeTxMemo } from '../memo.js';
 import { describe, expect, it } from 'bun:test';
 
 describe('memoToField', () => {
@@ -16,6 +16,25 @@ describe('memoToField', () => {
   it('is deterministic', () => {
     expect(memoToField('rent payment').toString()).toEqual(
       memoToField('rent payment').toString()
+    );
+  });
+});
+
+describe('decodeTxMemo', () => {
+  // Test vectors generated via o1js Memo.toBase58(Memo.fromString(...))
+  it('decodes a base58check-encoded memo to plaintext', () => {
+    expect(decodeTxMemo('E4YmEEfk9NFJZBjzsNatCdzLGVbYK6xWZa9oBgLkwNoLqQh34cjPv')).toBe('rent payment');
+  });
+
+  it('decodes the empty memo to an empty string', () => {
+    expect(decodeTxMemo('E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH')).toBe('');
+  });
+
+  it('round-trips: memoToField(decodeTxMemo(encoded)) equals memoToField(plaintext)', () => {
+    const plaintext = 'rent payment';
+    const encoded = 'E4YmEEfk9NFJZBjzsNatCdzLGVbYK6xWZa9oBgLkwNoLqQh34cjPv';
+    expect(memoToField(decodeTxMemo(encoded)).toString()).toEqual(
+      memoToField(plaintext).toString()
     );
   });
 });

--- a/contracts/src/tests/memo.test.ts
+++ b/contracts/src/tests/memo.test.ts
@@ -1,0 +1,21 @@
+import { Field } from 'o1js';
+import { memoToField } from '../memo.js';
+import { describe, expect, it } from 'bun:test';
+
+describe('memoToField', () => {
+  it('returns Field(0) for the empty string', () => {
+    expect(memoToField('').toString()).toEqual(Field(0).toString());
+  });
+
+  it('produces distinct commitments for distinct memos', () => {
+    expect(memoToField('hello').toString()).not.toEqual(
+      memoToField('world').toString()
+    );
+  });
+
+  it('is deterministic', () => {
+    expect(memoToField('rent payment').toString()).toEqual(
+      memoToField('rent payment').toString()
+    );
+  });
+});

--- a/contracts/src/tests/propose.test.ts
+++ b/contracts/src/tests/propose.test.ts
@@ -1,4 +1,4 @@
-import { Field, Mina, PrivateKey, Signature, UInt64 } from 'o1js';
+import { Field, Mina, Poseidon, PrivateKey, Signature, UInt64 } from 'o1js';
 import { Receiver, TransactionProposal } from '../MinaGuard.js';
 import { TxType } from '../constants.js';
 import {
@@ -166,6 +166,62 @@ describe('MinaGuard - Propose', () => {
       await txn.prove();
       await txn.sign([ctx.owners[0].key]).send();
     }).toThrow('Field.assertEquals()');
+  });
+
+  it('binds memoHash into the proposal hash', async () => {
+    const recipient = PrivateKey.random().toPublicKey();
+    const receivers = [
+      new Receiver({ address: recipient, amount: UInt64.from(1_000_000_000) }),
+    ];
+
+    // Two proposals identical in every field except memoHash.
+    const baseProposal = createTransferProposal(
+      receivers,
+      Field(0),
+      Field(0),
+      ctx.zkAppAddress
+    );
+    const memoHash = Poseidon.hash([Field(42)]);
+    const withMemo = createTransferProposal(
+      receivers,
+      Field(0),
+      Field(0),
+      ctx.zkAppAddress,
+      Field(0),
+      Field(1),
+      memoHash
+    );
+
+    // memoHash must participate in the proposal hash.
+    expect(baseProposal.hash().toString()).not.toEqual(
+      withMemo.hash().toString()
+    );
+
+    // A signature over the base hash must not authorize the memo'd proposal:
+    // the contract re-derives the hash from the struct (which now includes
+    // memoHash), so the signature check fails.
+    const ownerWitness = makeOwnerWitness(ctx.owners.map((o) => o.pub));
+    const staleSig = Signature.create(ctx.owners[0].key, [baseProposal.hash()]);
+    const nullifierWitness = ctx.nullifierStore.getWitness(
+      withMemo.hash(),
+      ctx.owners[0].pub
+    );
+    const approvalWitness = ctx.approvalStore.getWitness(withMemo.hash());
+
+    await expect(async () => {
+      const txn = await Mina.transaction(ctx.owners[0].pub, async () => {
+        await ctx.zkApp.propose(
+          withMemo,
+          ownerWitness,
+          ctx.owners[0].pub,
+          staleSig,
+          nullifierWitness,
+          approvalWitness
+        );
+      });
+      await txn.prove();
+      await txn.sign([ctx.owners[0].key]).send();
+    }).toThrow('Invalid signature');
   });
 
   it('should increment counter across multiple proposals', async () => {

--- a/contracts/src/tests/test-helpers.ts
+++ b/contracts/src/tests/test-helpers.ts
@@ -209,7 +209,8 @@ export function createTransferProposal(
   configNonce: Field,
   guardAddress: PublicKey,
   expiryBlock = Field(0),
-  networkId = Field(1)
+  networkId = Field(1),
+  memoHash = Field(0),
 ): TransactionProposal {
   const padded = [...receivers];
   while (padded.length < MAX_RECEIVERS) {
@@ -220,6 +221,7 @@ export function createTransferProposal(
     tokenId: Field(0),
     txType: TxType.TRANSFER,
     data: Field(0),
+    memoHash,
     uid,
     configNonce,
     expiryBlock,
@@ -239,13 +241,15 @@ export function createAddOwnerProposal(
   configNonce: Field,
   guardAddress: PublicKey,
   expiryBlock = Field(0),
-  networkId = Field(1)
+  networkId = Field(1),
+  memoHash = Field(0),
 ): TransactionProposal {
   return new TransactionProposal({
     receivers: emptyReceivers(),
     tokenId: Field(0),
     txType: TxType.ADD_OWNER,
     data: ownerKey(newOwner),
+    memoHash,
     uid,
     configNonce,
     expiryBlock,
@@ -261,13 +265,15 @@ export function createRemoveOwnerProposal(
   configNonce: Field,
   guardAddress: PublicKey,
   expiryBlock = Field(0),
-  networkId = Field(1)
+  networkId = Field(1),
+  memoHash = Field(0),
 ): TransactionProposal {
   return new TransactionProposal({
     receivers: emptyReceivers(),
     tokenId: Field(0),
     txType: TxType.REMOVE_OWNER,
     data: ownerKey(ownerToRemove),
+    memoHash,
     uid,
     configNonce,
     expiryBlock,
@@ -283,13 +289,15 @@ export function createThresholdProposal(
   configNonce: Field,
   guardAddress: PublicKey,
   expiryBlock = Field(0),
-  networkId = Field(1)
+  networkId = Field(1),
+  memoHash = Field(0),
 ): TransactionProposal {
   return new TransactionProposal({
     receivers: emptyReceivers(),
     tokenId: Field(0),
     txType: TxType.CHANGE_THRESHOLD,
     data: newThreshold,
+    memoHash,
     uid,
     configNonce,
     expiryBlock,
@@ -305,13 +313,15 @@ export function createDelegateProposal(
   configNonce: Field,
   guardAddress: PublicKey,
   expiryBlock = Field(0),
-  networkId = Field(1)
+  networkId = Field(1),
+  memoHash = Field(0),
 ): TransactionProposal {
   return new TransactionProposal({
     receivers: emptyReceivers(),
     tokenId: Field(0),
     txType: TxType.SET_DELEGATE,
     data: ownerKey(delegate),
+    memoHash,
     uid,
     configNonce,
     expiryBlock,
@@ -326,13 +336,15 @@ export function createUndelegateProposal(
   configNonce: Field,
   guardAddress: PublicKey,
   expiryBlock = Field(0),
-  networkId = Field(1)
+  networkId = Field(1),
+  memoHash = Field(0),
 ): TransactionProposal {
   return new TransactionProposal({
     receivers: emptyReceivers(),
     tokenId: Field(0),
     txType: TxType.SET_DELEGATE,
     data: Field(0),
+    memoHash,
     uid,
     configNonce,
     expiryBlock,

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useAppContext } from '@/lib/app-context';
 import Header from '@/components/Header';
 import ApprovalProgress from '@/components/ApprovalProgress';
+import MemoWarningTooltip from '@/components/MemoWarningTooltip';
 import {
   TX_TYPE_LABELS,
   truncateAddress,
@@ -230,7 +231,7 @@ export default function TransactionDetailPage() {
             )}
             <DetailRow label="Config Nonce" value={proposal.configNonce ?? '-'} mono />
             <DetailRow label="Expiry Block" value={proposal.expiryBlock ?? '0'} mono />
-            <DetailRow label="Memo" value={proposal.memo ?? '—'} />
+            <DetailRow label="Memo" value={proposal.memo ?? '—'} labelAdornment={<MemoWarningTooltip />} />
             <DetailRow label="Created" value={new Date(proposal.createdAt).toLocaleString()} />
           </div>
         </div>
@@ -307,11 +308,13 @@ function DetailRow({
   value,
   mono = false,
   copyable = false,
+  labelAdornment,
 }: {
   label: string;
   value: string;
   mono?: boolean;
   copyable?: boolean;
+  labelAdornment?: ReactNode;
 }) {
   const [showTooltip, setShowTooltip] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -327,7 +330,10 @@ function DetailRow({
 
   return (
     <div className="flex justify-between items-center py-2 border-b border-safe-border/50 last:border-0">
-      <span className="text-sm text-safe-text shrink-0">{label}</span>
+      <span className="flex items-center gap-1 text-sm text-safe-text shrink-0">
+        {label}
+        {labelAdornment}
+      </span>
       {copyable ? (
         <div className="relative ml-12 min-w-0">
           <button

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -230,6 +230,7 @@ export default function TransactionDetailPage() {
             )}
             <DetailRow label="Config Nonce" value={proposal.configNonce ?? '-'} mono />
             <DetailRow label="Expiry Block" value={proposal.expiryBlock ?? '0'} mono />
+            <DetailRow label="Memo" value={proposal.memo ?? '—'} />
             <DetailRow label="Created" value={new Date(proposal.createdAt).toLocaleString()} />
           </div>
         </div>

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -182,6 +182,25 @@ export default function TransactionDetailPage() {
 
   const txLabel = proposal.txType ? TX_TYPE_LABELS[proposal.txType] : 'Unknown';
 
+  // Memo tooltip state machine, driven entirely by memoExecutionMatch:
+  //  - match   + no proposer memo → no icon (empty-vs-empty, nothing to say)
+  //  - match   + proposer memo    → green ✓
+  //  - mismatch                   → red ✗ (covers proposer-memo/no-exec-memo,
+  //                                 no-proposer-memo/exec-memo, and any
+  //                                 genuine divergence)
+  //  - null (indeterminate)       → yellow ⚠ (pending, or pre-feature row
+  //                                 whose execution wasn't observed with the
+  //                                 new txMemo plumbing)
+  const memoAdornment: ReactNode | undefined = (() => {
+    if (proposal.memoExecutionMatch === true) {
+      return proposal.memo ? <MemoWarningTooltip variant="match" /> : undefined;
+    }
+    if (proposal.memoExecutionMatch === false) {
+      return <MemoWarningTooltip variant="mismatch" />;
+    }
+    return <MemoWarningTooltip />;
+  })();
+
   return (
     <div>
       <Header
@@ -231,7 +250,7 @@ export default function TransactionDetailPage() {
             )}
             <DetailRow label="Config Nonce" value={proposal.configNonce ?? '-'} mono />
             <DetailRow label="Expiry Block" value={proposal.expiryBlock ?? '0'} mono />
-            <DetailRow label="Memo" value={proposal.memo ?? '—'} labelAdornment={<MemoWarningTooltip />} />
+            <DetailRow label="Memo" value={proposal.memo ?? '—'} labelAdornment={memoAdornment} />
             <DetailRow label="Created" value={new Date(proposal.createdAt).toLocaleString()} />
           </div>
         </div>

--- a/ui/components/MemoWarningTooltip.tsx
+++ b/ui/components/MemoWarningTooltip.tsx
@@ -1,13 +1,46 @@
-/** Hover tooltip warning that the on-chain transaction memo is set by whoever
- *  executes the proposal — it may differ from the memo entered here, which is
- *  only committed to the proposal hash (off-chain plaintext, on-chain hash). */
-export default function MemoWarningTooltip() {
+/** Hover tooltip shown next to user-visible memo labels.
+ *
+ *  Variants:
+ *  - `warning`  — default. Yellow ⚠. Warns that the on-chain tx memo is set
+ *                 by whoever executes the proposal and may differ.
+ *  - `match`    — green ✓. Shown on executed proposals whose executor committed
+ *                 the same memoHash as the proposer's plaintext.
+ *  - `mismatch` — red ✗. Shown on executed proposals whose executor committed
+ *                 a different memoHash. */
+type Variant = 'warning' | 'match' | 'mismatch';
+
+const VARIANTS: Record<
+  Variant,
+  { glyph: string; color: string; border: string; text: string }
+> = {
+  warning: {
+    glyph: '⚠',
+    color: 'text-yellow-400',
+    border: 'border-yellow-400/40',
+    text: 'The final transaction memo on-chain is set by whoever executes the proposal and may differ.',
+  },
+  match: {
+    glyph: '✓',
+    color: 'text-safe-green',
+    border: 'border-safe-green/40',
+    text: 'Proposal memo matches on-chain execution memo.',
+  },
+  mismatch: {
+    glyph: '✗',
+    color: 'text-red-400',
+    border: 'border-red-400/40',
+    text: 'Memo mismatch: the executor committed a different memo on-chain.',
+  },
+};
+
+export default function MemoWarningTooltip({ variant = 'warning' }: { variant?: Variant }) {
+  const v = VARIANTS[variant];
   return (
     <span className="relative group">
-      <span className="inline-flex items-center justify-center w-4 h-4 rounded-full border border-yellow-400/40 text-[10px] leading-none text-yellow-400 cursor-help">⚠</span>
+      <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full border ${v.border} text-[10px] leading-none ${v.color} cursor-help`}>{v.glyph}</span>
       <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 z-50 transition-all duration-200 pointer-events-none opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0">
         <div className="bg-safe-green/70 backdrop-blur-md text-white text-xs font-semibold rounded-lg px-3 py-2 shadow-lg w-80">
-          The final transaction memo on-chain is set by whoever executes the proposal and may differ.
+          {v.text}
         </div>
         <svg className="mx-auto -mt-px" width="10" height="6" viewBox="0 0 10 6">
           <path d="M0 0L5 6L10 0Z" className="fill-safe-green/70" />

--- a/ui/components/MemoWarningTooltip.tsx
+++ b/ui/components/MemoWarningTooltip.tsx
@@ -1,0 +1,18 @@
+/** Hover tooltip warning that the on-chain transaction memo is set by whoever
+ *  executes the proposal — it may differ from the memo entered here, which is
+ *  only committed to the proposal hash (off-chain plaintext, on-chain hash). */
+export default function MemoWarningTooltip() {
+  return (
+    <span className="relative group">
+      <span className="inline-flex items-center justify-center w-4 h-4 rounded-full border border-yellow-400/40 text-[10px] leading-none text-yellow-400 cursor-help">⚠</span>
+      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 z-50 transition-all duration-200 pointer-events-none opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0">
+        <div className="bg-safe-green/70 backdrop-blur-md text-white text-xs font-semibold rounded-lg px-3 py-2 shadow-lg w-80">
+          The final transaction memo on-chain is set by whoever executes the proposal and may differ.
+        </div>
+        <svg className="mx-auto -mt-px" width="10" height="6" viewBox="0 0 10 6">
+          <path d="M0 0L5 6L10 0Z" className="fill-safe-green/70" />
+        </svg>
+      </div>
+    </span>
+  );
+}

--- a/ui/components/ProposalForm.tsx
+++ b/ui/components/ProposalForm.tsx
@@ -3,6 +3,7 @@
 import { MAX_OWNERS, MAX_RECEIVERS } from '@/lib/constants';
 import { useEffect, useState } from 'react';
 import { NewProposalInput, TxType } from '@/lib/types';
+import { MEMO_MAX_BYTES, memoByteLength, isValidMemoLength } from '@/lib/memo';
 
 interface ProposalFormProps {
   owners: string[];
@@ -32,6 +33,9 @@ export default function ProposalForm({
   const [delegate, setDelegate] = useState('');
   const [undelegate, setUndelegate] = useState(false);
   const [expiryBlock, setExpiryBlock] = useState('0');
+  const [memo, setMemo] = useState('');
+  const memoBytes = memoByteLength(memo);
+  const memoOverLimit = !isValidMemoLength(memo);
 
   const [validationError, setValidationError] = useState<string | null>(null);
   const transferParse = parseTransferLines(transferLines);
@@ -76,6 +80,10 @@ export default function ProposalForm({
       setValidationError('The new threshold is the same as the current one.');
       return;
     }
+    if (memoOverLimit) {
+      setValidationError(`Memo exceeds ${MEMO_MAX_BYTES} UTF-8 bytes.`);
+      return;
+    }
 
     onSubmit({
       txType,
@@ -86,6 +94,7 @@ export default function ProposalForm({
       delegate: txType === 'setDelegate' && !undelegate ? delegate : undefined,
       undelegate: txType === 'setDelegate' ? undelegate : undefined,
       expiryBlock: Number(expiryBlock) > 0 ? Number(expiryBlock) : 0,
+      memo: memo.length > 0 ? memo : undefined,
     });
   };
 
@@ -236,6 +245,26 @@ export default function ProposalForm({
           )}
         </div>
       )}
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm text-safe-text">Memo (optional)</label>
+          <span className={`text-xs ${memoOverLimit ? 'text-red-400' : 'text-safe-text/60'}`}>
+            {memoBytes} / {MEMO_MAX_BYTES} bytes
+          </span>
+        </div>
+        <input
+          type="text"
+          value={memo}
+          onChange={(e) => setMemo(e.target.value)}
+          placeholder="Short note committed to the proposal hash"
+          className={`w-full bg-safe-gray border rounded-lg px-4 py-3 text-sm placeholder:text-safe-border focus:outline-none transition-colors ${
+            memoOverLimit
+              ? 'border-red-400 focus:border-red-400'
+              : 'border-safe-border focus:border-safe-green'
+          }`}
+        />
+      </div>
 
       <FormInput
         label="Expiry Block (0 = no expiry)"

--- a/ui/components/ProposalForm.tsx
+++ b/ui/components/ProposalForm.tsx
@@ -4,6 +4,7 @@ import { MAX_OWNERS, MAX_RECEIVERS } from '@/lib/constants';
 import { useEffect, useState } from 'react';
 import { NewProposalInput, TxType } from '@/lib/types';
 import { MEMO_MAX_BYTES, memoByteLength, isValidMemoLength } from '@/lib/memo';
+import MemoWarningTooltip from '@/components/MemoWarningTooltip';
 
 interface ProposalFormProps {
   owners: string[];
@@ -248,7 +249,10 @@ export default function ProposalForm({
 
       <div>
         <div className="flex items-center justify-between mb-2">
-          <label className="block text-sm text-safe-text">Memo (optional)</label>
+          <label className="flex items-center gap-1 text-sm text-safe-text">
+            Memo (optional)
+            <MemoWarningTooltip />
+          </label>
           <span className={`text-xs ${memoOverLimit ? 'text-red-400' : 'text-safe-text/60'}`}>
             {memoBytes} / {MEMO_MAX_BYTES} bytes
           </span>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -145,6 +145,7 @@ function toProposal(input: Record<string, unknown>): Proposal {
     expiryBlock: asNullableString(input.expiryBlock),
     networkId: asNullableString(input.networkId),
     guardAddress: asNullableString(input.guardAddress),
+    memo: asNullableString(input.memo),
     status: asProposalStatus(input.status),
     origin: asString(input.origin) === 'onchain' ? 'onchain' : 'offchain',
     approvalCount: asNumber(input.approvalCount),
@@ -217,6 +218,8 @@ export async function postOffchainProposal(
     tokenId: string;
     txType: string;
     data: string;
+    memo?: string;
+    memoHash: string;
     uid: string;
     configNonce: string;
     expiryBlock: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -146,6 +146,7 @@ function toProposal(input: Record<string, unknown>): Proposal {
     networkId: asNullableString(input.networkId),
     guardAddress: asNullableString(input.guardAddress),
     memo: asNullableString(input.memo),
+    memoExecutionMatch: asMemoExecutionMatch(input.memoExecutionMatch),
     status: asProposalStatus(input.status),
     origin: asString(input.origin) === 'onchain' ? 'onchain' : 'offchain',
     approvalCount: asNumber(input.approvalCount),
@@ -203,6 +204,12 @@ function asProposalStatus(value: unknown): Proposal['status'] {
   const text = asString(value);
   if (text === 'executed' || text === 'expired') return text;
   return 'pending';
+}
+
+/** Narrows a memo-execution match verdict from an unknown backend value. */
+function asMemoExecutionMatch(value: unknown): Proposal['memoExecutionMatch'] {
+  if (value === true || value === false) return value;
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/lib/memo.ts
+++ b/ui/lib/memo.ts
@@ -1,0 +1,25 @@
+/**
+ * Proposal memo helpers.
+ *
+ * Mina's native transaction memo caps at 32 UTF-8 bytes, and we mirror that
+ * limit for proposal memos so the plaintext can also ride on the outer tx
+ * memo without truncation. Note the limit is in *bytes*, not characters —
+ * multi-byte chars (emoji, CJK, accented letters) consume more than one byte.
+ *
+ * o1js exposes `Memo.toValidString` with the same check, but it lives in an
+ * internal `mina-signer` submodule that isn't part of the public package
+ * exports, so we reimplement the 3 lines here instead of reaching into deps.
+ */
+
+/** Mina transaction memo max length in UTF-8 bytes. */
+export const MEMO_MAX_BYTES = 32;
+
+/** Byte length of a string when UTF-8 encoded. */
+export function memoByteLength(memo: string): number {
+  return new TextEncoder().encode(memo).length;
+}
+
+/** True iff `memo` fits in a Mina transaction memo (<= MEMO_MAX_BYTES). */
+export function isValidMemoLength(memo: string): boolean {
+  return memoByteLength(memo) <= MEMO_MAX_BYTES;
+}

--- a/ui/lib/multisigClient.ts
+++ b/ui/lib/multisigClient.ts
@@ -60,7 +60,7 @@ export async function assertLedgerReady(signer?: SignerConfig): Promise<void> {
 /** Proxied Auro sendTransaction callback for use inside the worker. Returns null for Ledger. */
 function proxiedSendTx(signer?: SignerConfig) {
   if (signer?.type === 'ledger') return null;
-  return Comlink.proxy((txJson: string) => sendTransaction(txJson));
+  return Comlink.proxy((txJson: string, memo?: string) => sendTransaction(txJson, undefined, memo));
 }
 
 /** Proxied Ledger fee payer signing callback. Returns undefined for Auro. */

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -24,6 +24,7 @@ import {
   Receiver,
   TransactionProposal,
   ownerKey,
+  memoToField,
   EXECUTED_MARKER,
   PROPOSED_MARKER,
   MAX_OWNERS,
@@ -373,7 +374,7 @@ function buildTransferReceivers(
 function buildProposalStruct(
   proposal: Pick<
     Proposal,
-    'receivers' | 'tokenId' | 'txType' | 'data' | 'uid' | 'configNonce' | 'expiryBlock' | 'networkId' | 'guardAddress'
+    'receivers' | 'tokenId' | 'txType' | 'data' | 'memo' | 'uid' | 'configNonce' | 'expiryBlock' | 'networkId' | 'guardAddress'
   >,
   fallbackGuardAddress: string
 ): InstanceType<typeof TransactionProposal> {
@@ -383,6 +384,7 @@ function buildProposalStruct(
     tokenId: Field(proposal.tokenId ?? '0'),
     txType: txType ? uiTxTypeToField(txType) : Field(0),
     data: Field(proposal.data ?? '0'),
+    memoHash: memoToField(proposal.memo ?? ''),
     uid: Field(proposal.uid ?? '0'),
     configNonce: Field(proposal.configNonce ?? '0'),
     expiryBlock: Field(proposal.expiryBlock ?? '0'),
@@ -665,12 +667,14 @@ const workerApi = {
     const txType = uiTxTypeToField(params.input.txType);
     const data = buildProposalDataField(params.input);
     const uid = Field.random();
+    const memoHash = memoToField(params.input.memo ?? '');
 
     const proposal = new TransactionProposal({
       receivers: transferReceivers,
       tokenId: Field(0),
       txType,
       data,
+      memoHash,
       uid,
       configNonce: Field(params.configNonce),
       expiryBlock: Field(params.input.expiryBlock ?? 0),
@@ -700,6 +704,8 @@ const workerApi = {
       tokenId: '0',
       txType: txType.toString(),
       data: data.toString(),
+      memo: params.input.memo,
+      memoHash: memoHash.toString(),
       uid: uid.toString(),
       configNonce: params.configNonce.toString(),
       expiryBlock: (params.input.expiryBlock ?? 0).toString(),

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -53,7 +53,7 @@ import {
 } from './api';
 
 /** Callback type for sending a signed transaction via Auro wallet on the main thread. */
-type SendTxFn = (txJson: string) => Promise<string | null>;
+type SendTxFn = (txJson: string, memo?: string) => Promise<string | null>;
 
 /** Callback type for requesting a field signature from Auro or Ledger on the main thread.
  *  Auro returns a base58 signature string; Ledger returns {field, scalar} decimal strings. */
@@ -81,9 +81,16 @@ let compilePromise: Promise<void> | null = null;
 let testPrivateKey: InstanceType<typeof PrivateKey> | null = null;
 let skipProofs = false;
 
-/** Returns Mina.transaction sender arg — includes fee since we always set it explicitly. */
-function txSender(pub: InstanceType<typeof PublicKey>) {
-  return { sender: pub, fee: ZKAPP_TX_FEE };
+/** Returns Mina.transaction sender arg — includes fee since we always set it
+ *  explicitly. When a memo is supplied, it rides via FeePayerSpec.memo so that
+ *  o1js bakes it into zkappCommand.memo during tx.toJSON(). This propagates to
+ *  both Auro and Ledger paths without any wallet-specific code, because both
+ *  just forward the serialized txJson. Branches on undefined so we omit the
+ *  key entirely rather than passing memo: undefined. */
+function txSender(pub: InstanceType<typeof PublicKey>, memo?: string) {
+  return memo !== undefined
+    ? { sender: pub, fee: ZKAPP_TX_FEE, memo }
+    : { sender: pub, fee: ZKAPP_TX_FEE };
 }
 
 /**
@@ -449,7 +456,8 @@ async function submitTx(
   tx: Awaited<ReturnType<typeof Mina.transaction>>,
   sendFn: SendTxFn | null,
   signFeePayerFn?: SignFeePayerFn,
-  extraKeys: InstanceType<typeof PrivateKey>[] = []
+  extraKeys: InstanceType<typeof PrivateKey>[] = [],
+  memo?: string
 ): Promise<string | null> {
   // E2E test mode: sign and send directly
   if (testPrivateKey) {
@@ -464,9 +472,9 @@ async function submitTx(
   if (signFeePayerFn) {
     return broadcastWithLedgerSig(txJson, signFeePayerFn);
   }
-  // Auro path: send via Auro wallet
+  // Auro path: send via Auro wallet — pass memo so Auro sets feePayer.memo
   if (sendFn) {
-    return sendFn(txJson);
+    return sendFn(txJson, memo);
   }
   return null;
 }
@@ -867,7 +875,10 @@ const workerApi = {
 
     await fetchAccount({ publicKey: executor });
     clearStaleTransaction();
-    const tx = await Mina.transaction(txSender(executor), async () => {
+    // Propagate the proposer memo to the outer Mina tx memo so block explorers
+    // and the backend indexer can cross-check it against the proposer's
+    // committed plaintext (see backend applyExecutionEvent).
+    const tx = await Mina.transaction(txSender(executor, params.proposal.memo ?? undefined), async () => {
       if (txType === 'transfer') {
         await contract.executeTransferBatchSig(proposalStruct, approvalWitness, sigInputs);
         return;
@@ -913,8 +924,12 @@ const workerApi = {
     progressFn('Generating proof...');
     await tx.prove();
 
+    const txJson = serializeTx(tx);
+    const parsedTx = JSON.parse(txJson);
+
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
-    const executeHash = await submitTx(tx, sendFn, signFeePayerFn);
+    const proposalMemo = params.proposal.memo ?? undefined;
+    const executeHash = await submitTx(tx, sendFn, signFeePayerFn, [], proposalMemo);
     return `Transaction submitted: ${executeHash}`;
   },
 };

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -72,6 +72,7 @@ export interface Proposal {
   expiryBlock: string | null;
   networkId: string | null;
   guardAddress: string | null;
+  memo: string | null;
   status: ProposalStatus;
   origin: 'onchain' | 'offchain';
   approvalCount: number;
@@ -147,6 +148,7 @@ export interface NewProposalInput {
   delegate?: string;
   undelegate?: boolean;
   expiryBlock?: number;
+  memo?: string;
 }
 
 export const TX_TYPE_LABELS: Record<TxType, string> = {

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -73,6 +73,7 @@ export interface Proposal {
   networkId: string | null;
   guardAddress: string | null;
   memo: string | null;
+  memoExecutionMatch: boolean | null;
   status: ProposalStatus;
   origin: 'onchain' | 'offchain';
   approvalCount: number;


### PR DESCRIPTION
- Proposal creation allows user to input "Memo" (max 32 utf-8 bytes)
- When confirmed executed, memo field shows tick or [x] to indicate that the tx memo matched the proposal memo
- Switched back to main branch of mina-signer, since mesa branch is not backwards compatible and Ledger signatures failed