### PR TITLE
Deploy main with `down && up` to avoid indexer/chain drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,13 @@ jobs:
           submodules: recursive
 
       - name: Deploy
+        # `down` wipes volumes before `up` rebuilds the stack. Without the
+        # `down`, `up --force-recreate` spins up a fresh lightnet (no volume
+        # → genesis chain) while the app DB keeps its old IndexerCursor and
+        # EventRaw rows — the indexer ends up pointing at a dead chain.
         run: |
           chmod +x deploy/deploy.sh
+          ./deploy/deploy.sh down
           ./deploy/deploy.sh up
 
       - name: Wait for services

--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -18,9 +18,13 @@ jobs:
           submodules: recursive
 
       - name: Reset
+        # Safety net for quiet periods on main: same `down && up` sequence
+        # as deploy.yml, so the stack self-heals from bloat/drift every 3
+        # days even if nothing has been pushed.
         run: |
           chmod +x deploy/deploy.sh
-          ./deploy/deploy.sh reset
+          ./deploy/deploy.sh down
+          ./deploy/deploy.sh up
 
       - name: Wait for services
         run: |

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -3,8 +3,9 @@
 #
 # Usage:
 #   ./deploy.sh up      — deploy main branch (force-recreates containers for fresh lightnet chain)
-#   ./deploy.sh reset   — wipe volumes and redeploy (used by the 3-day bloat-cleanup cron)
-#   ./deploy.sh down    — teardown deployment
+#   ./deploy.sh down    — teardown deployment (wipes volumes)
+#
+# To reset the stack fully, run `down` followed by `up`.
 #
 # Expects to be run from the repo root directory.
 
@@ -80,11 +81,6 @@ remove_caddy_route() {
 }
 
 case "$COMMAND" in
-    reset)
-        echo "Wiping volumes for bloat cleanup..."
-        docker compose -f deploy/docker-compose.yml -p minaguard down -v --remove-orphans 2>/dev/null || true
-        remove_caddy_route 2>/dev/null || true
-        ;&
     up)
         echo "Deploying main branch on port ${PORT}..."
         # TODO(devnet): replace force-recreate with zero-downtime strategy (e.g., blue/green via caddy route swap) — current approach briefly drops requests during container swap.
@@ -109,7 +105,7 @@ case "$COMMAND" in
         ;;
 
     *)
-        echo "Usage: $0 {up|reset|down}"
+        echo "Usage: $0 {up|down}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
`up --force-recreate` replaces the lightnet container (no volume → fresh genesis) but keeps the app DB volume. The preserved IndexerCursor then points past the new chain's tip. Running `down` first wipes volumes so the DB is reset in sync.

removed `reset` since it's functionally the same as down + up