### PR TITLE
Indexer handles re-org

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 dist/
 prisma/*.db
 prisma/*.db-journal
+src/generated/

--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -1,0 +1,122 @@
+# Indexer Architecture
+
+Deep-dive on how `backend/src/indexer.ts` turns a stream of Mina archive events into the normalized tables in `prisma/schema.prisma`. For operator concerns (env vars, scripts, API shape), see `backend/README.md`.
+
+## 1. Modes
+
+The indexer runs in one of two modes, set by config at startup.
+
+| Mode | Discovery | Backfill lower bound | Subscribe API |
+|---|---|---|---|
+| `full` | Scans every bestChain block for MinaGuard deployments | `indexedHeight - 300` (bestChain window) | disabled |
+| `lite` | No scan; only tracks contracts added via `POST /api/subscribe` | `config.indexStartHeight` (default `0`) | enabled |
+
+`full` is the batch indexer posture: look at the whole chain and keep everything. `lite` is the user-facing posture: only track what a user asked for, but pull full history for it.
+
+## 2. Tick loop
+
+`MinaGuardIndexer.tick()` runs every `INDEX_POLL_INTERVAL_MS`. One pass:
+
+1. **Fetch latest height** — `fetchLatestBlockHeight`.
+2. **Reorg check** — `detectAndRollbackReorg`. If a fork is detected, rewind cursor + delete all rows above fork height, then bail out of the tick. Next tick resumes from the rewound cursor.
+3. **Read cursor** — `IndexerCursor.indexed_height` (default `indexStartHeight` if absent).
+4. **Discover (full mode only)** — scan a `[latestHeight - window, latestHeight]` bestChain slice for new zkApp deployments. Window = `min(290, delta + margin)`.
+5. **Rescan unready contracts** — any `Contract` with `ready = false` is re-synced from its `discoveredAtBlock` up to `latestHeight`. This is what makes subscribe-before-deploy self-healing.
+6. **Forward sweep** — `syncKnownContracts(indexedHeight + 1, latestHeight)` across every tracked contract.
+7. **Advance cursor** — persist `indexed_height = latestHeight`.
+
+If any step throws, the cursor is **not** advanced, so the next tick retries the same window. Per-contract sync errors re-throw for the same reason.
+
+## 3. Reorg handling
+
+Mina has probabilistic finality (~290 blocks). The indexer treats anything within that window as potentially reorg-able.
+
+**Detection** (`detectAndRollbackReorg`):
+- Fetch the last `REORG_DETECTION_WINDOW` (290) bestChain headers.
+- Compare against stored `BlockHeader` rows over the same height range.
+- Walk descending: the fork point is the highest stored height whose hash still matches the chain. Everything above it is non-canonical.
+- If every overlapping header mismatches, the reorg is deeper than visibility — log and skip (operator intervention).
+
+**Rollback** (`rollbackAboveFork`) is one atomic transaction deleting all `> forkHeight` rows across `BlockHeader`, `EventRaw`, `ContractConfig`, `OwnerMembership`, `ProposalExecution`, `Approval`, `Proposal`, `Contract` (by `discoveredAtBlock`), and rewinding the cursor to `forkHeight`.
+
+This is safe because every mutable table stores the block at which its row became valid (`validFromBlock`, `createdAtBlock`, `blockHeight`, `discoveredAtBlock`). No "current state" row needs patching — deleting the post-fork history is enough, and the forward sweep re-derives state from re-fetched events.
+
+`BlockHeader` is upserted at event ingestion time. A height with no events gets no header, so reorg detection only has teeth on heights where MinaGuard activity landed — which is exactly where we need it.
+
+## 4. Contract discovery and readiness
+
+A `Contract` row exists in one of two states:
+
+- **`ready = false`** — address is known (discovered or subscribed) but no MinaGuard event has been ingested yet. Hidden from most read routes.
+- **`ready = true`** — flipped on first event ingestion in `syncSingleContract`. Any event other than `setup`/`setupOwner` proves the contract actually initialized on-chain.
+
+`ready` exists because a `Contract` row can be inserted speculatively — a user subscribing before the deploy tx lands, or `applyProposalEvent` eagerly inserting a child on a CREATE_CHILD proposal before `executeSetupChild` actually runs. Read routes filter on `ready = true` so these speculative rows don't surface as ghost UI entries, while the unready-rescan loop keeps polling their address range until real events land and promote them.
+
+Two ways to become tracked:
+
+- **Full mode discovery**: `discoverCandidateAddresses` scans recent blocks, `fetchVerificationKeyHash` confirms it's a zkApp, and the hash is optionally matched against `MINAGUARD_VK_HASH`. Backfill window is `max(0, indexedHeight - 300)`.
+- **Lite mode subscribe**: user calls `POST /api/subscribe { address, fromBlock? }`. `fromBlock` omitted = `latestHeight - 5` (margin to cover a block landing mid-request). `fromBlock` supplied = trusted explicit lower bound, but the address must already resolve to a deployed zkApp (guards against typos backfilling forever). VK hash is **not** checked on subscribe — the user may subscribe before the deploy tx lands.
+
+The `rescanUnreadyContracts` loop re-scans `[discoveredAtBlock, latestHeight]` every tick until events land. First event flips `ready = true` and the contract joins the forward sweep.
+
+## 5. Event pipeline
+
+`syncSingleContract(contractId, address, from, to)`:
+
+1. **Fetch** decoded events via `fetchDecodedContractEvents` (archive GraphQL).
+2. **Reverse per-tx groups** (`reverseEventsWithinEachTx`). o1js returns events within a single tx in newest-first order; the contract emits them oldest-first. Cross-tx ordering is preserved. This matters for multi-receiver proposals — reversed `receiver` indices break the off-chain proposal-hash recomputation on approve.
+3. **Stable sort by type** (`setup`/`setupOwner`/`proposal`/`approval`/`receiver`/`execution`/...). Ensures a `proposal` row exists before its `approval`/`receiver`/`execution` children are processed within the same batch.
+4. **Dedupe by fingerprint** (`address::type::blockHeight::txHash::payload`). `EventRaw.fingerprint` is unique; second writer is a no-op.
+5. **Upsert BlockHeader** for the event's `(height, blockHash, parentHash)`. First writer wins; mismatches across events at the same height get caught by the next tick's reorg detector.
+6. **Insert EventRaw** and dispatch to the appropriate `apply*` handler.
+7. **Flip `ready`** if any event was ingested.
+
+## 6. Data model
+
+Two kinds of tables:
+
+### Append-only history
+
+Every mutation gets a new row stamped with `validFromBlock` + `eventOrder`. Current state = latest row by `(validFromBlock DESC, eventOrder DESC)`. Rollback on reorg is a single `DELETE WHERE > forkHeight`.
+
+- **`BlockHeader`** — `(height, blockHash, parentHash)`. Only populated at heights with MinaGuard activity.
+- **`ContractConfig`** — full snapshot of `threshold`, `numOwners`, `configNonce`, `delegate`, `childMultiSigEnabled`, `ownersCommitment`, `networkId`. `appendContractConfigSnapshot` copies the latest row forward and overlays changes, so every row is a complete point-in-time view.
+- **`OwnerMembership`** — `{address, action: 'added'|'removed', index?}`. Active owners = reduce memberships per address, keep addresses whose latest action is `added`.
+- **`ProposalExecution`** — unique per proposal; upserted when an `execution` event is ingested.
+- **`Approval`** — unique per `(proposalId, approver)`; upserted so duplicate approval events from reorgs/retries don't inflate counts.
+- **`EventRaw`** — raw per-event record, unique by `fingerprint`. Source of truth for replay/debug.
+
+### Identity / pointer
+
+- **`Contract`** — `(address, parent?, ready, discoveredAtBlock, ...)`. Identity + latest-synced metadata. `parent` set from `setup.parent` (null/EMPTY for root guards).
+- **`Proposal`** — `(contractId, proposalHash, ...)`. Identity + propose-time fields. `ProposalReceiver` child rows carry per-slot receivers from `receiver` events (padded empties skipped). For governance proposals (addOwner/removeOwner/setDelegate), slot 0 is mirrored onto `Proposal.toAddress`.
+- **`IndexerCursor`** — single row `key = 'indexed_height'`.
+
+### Cross-contract execution (REMOTE path)
+
+Child-lifecycle methods (`executeSetupChild`, `executeReclaim`, `executeDestroy`, `executeEnableChildMultiSig`) emit `ExecutionEvent` on the **child** guard, but the `Proposal` row lives under the **parent**. `applyExecutionEvent`:
+
+1. Try `(contractId, proposalHash)` local lookup.
+2. On miss, walk `child.parent` → parent contract → retry `(parent.id, proposalHash)`.
+3. Upsert `ProposalExecution` against whichever matched.
+
+In lite mode, a `proposal` event for `txType = 5` (CREATE_CHILD) eagerly inserts the child's `Contract` row so the parent's execution event can be matched later. Without this, the child address would never be tracked and the parent proposal would stay pending forever.
+
+## 7. Failure semantics
+
+- **GraphQL fetch failure during reorg check** → log, skip rollback, continue tick (the stored state may still be valid).
+- **GraphQL fetch failure mid-tick** → caught at `tick()` boundary, `lastError` set, cursor not advanced. Next tick retries.
+- **Per-contract sync failure** → re-thrown from `syncKnownContracts` so the cursor stays put. Every tracked contract must sync cleanly before the cursor moves.
+- **Duplicate events** → idempotent via `EventRaw.fingerprint` unique constraint.
+- **Reorg deeper than 290** → not auto-handled. Logged as `reorg deeper than detection window`.
+
+## 8. Surfaces for tests
+
+Exported beyond the class so tests can drive pipeline stages directly:
+
+- `detectAndRollbackReorg(config)` — drive reorg detection with fixture `BlockHeader` rows.
+- `rollbackAboveFork(forkHeight)` — verify cascade deletes.
+- `deleteContract(contractId)` — unsubscribe cascade (lite mode).
+- `MinaGuardIndexer#syncSingleContract` / `#backfillContract` — public for feeding mocked `ChainEvent[]` through the apply pipeline.
+
+See `backend/src/tests/indexer-reorg.test.ts` and `backend/src/tests/indexer-autosubscribe.test.ts` for usage.

--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -29,7 +29,7 @@ If any step throws, the cursor is **not** advanced, so the next tick retries the
 
 ## 3. Reorg handling
 
-Mina has probabilistic finality (~290 blocks). The indexer treats anything within that window as potentially reorg-able.
+Mina has probabilistic finality (~290 blocks). The indexer handles any reorg that forks at or above the last 290 bestChain headers; reorgs that fork deeper than the detection window are logged and left for operator intervention (see §7 Failure semantics).
 
 **Detection** (`detectAndRollbackReorg`):
 - Fetch the last `REORG_DETECTION_WINDOW` (290) bestChain headers.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,74 +12,106 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Contract {
-  id             Int       @id @default(autoincrement())
-  address        String    @unique
-  networkId      String?
-  ownersCommitment String?
-  threshold      Int?
-  numOwners      Int?
-  nonce          Int?
-  configNonce    Int?
-  parent         String?
-  parentNonce    Int?
-  childMultiSigEnabled Boolean?
-  delegate       String?
-  discoveredAt   DateTime  @default(now())
-  lastSyncedAt   DateTime?
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
-  owners         Owner[]
-  proposals      Proposal[]
-  events         EventRaw[]
+model BlockHeader {
+  height     Int      @id
+  blockHash  String
+  parentHash String
+  indexedAt  DateTime @default(now())
 
-  @@index([parent])
+  @@index([blockHash])
 }
 
-model Owner {
-  id         Int       @id @default(autoincrement())
-  contractId Int
-  address    String
-  ownerHash  String?
-  index      Int?
-  active     Boolean   @default(true)
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @updatedAt
-  contract   Contract  @relation(fields: [contractId], references: [id], onDelete: Cascade)
+model Contract {
+  id                Int       @id @default(autoincrement())
+  address           String    @unique
+  parent            String?
+  ready             Boolean   @default(false)
+  discoveredAt      DateTime  @default(now())
+  discoveredAtBlock Int?
+  lastSyncedAt      DateTime?
+  proposalCounter   Int?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
-  @@unique([contractId, address])
-  @@index([contractId, active])
+  configs     ContractConfig[]
+  memberships OwnerMembership[]
+  proposals   Proposal[]
+  events      EventRaw[]
+
+  @@index([parent])
+  @@index([discoveredAtBlock])
+}
+
+model ContractConfig {
+  id                   Int      @id @default(autoincrement())
+  contractId           Int
+  validFromBlock       Int
+  eventOrder           Int      @default(0)
+  threshold            Int?
+  numOwners            Int?
+  nonce                Int?
+  parentNonce          Int?
+  configNonce          Int?
+  delegate             String?
+  childMultiSigEnabled Boolean?
+  ownersCommitment     String?
+  networkId            String?
+  sourceEventId        Int?
+  createdAt            DateTime @default(now())
+
+  contract Contract @relation(fields: [contractId], references: [id], onDelete: Cascade)
+
+  @@index([contractId, validFromBlock(sort: Desc), eventOrder(sort: Desc)])
+  @@index([validFromBlock])
+}
+
+model OwnerMembership {
+  id             Int      @id @default(autoincrement())
+  contractId     Int
+  address        String
+  action         String
+  index          Int?
+  ownerHash      String?
+  validFromBlock Int
+  eventOrder     Int      @default(0)
+  sourceEventId  Int?
+  createdAt      DateTime @default(now())
+
+  contract Contract @relation(fields: [contractId], references: [id], onDelete: Cascade)
+
+  @@index([contractId, address, validFromBlock(sort: Desc), eventOrder(sort: Desc)])
+  @@index([contractId, validFromBlock(sort: Desc)])
+  @@index([validFromBlock])
 }
 
 model Proposal {
-  id              Int       @id @default(autoincrement())
-  contractId      Int
-  proposalHash    String
-  proposer        String?
-  toAddress       String?
-  tokenId         String?
-  txType          String?
-  data            String?
-  nonce           String?
-  configNonce     String?
-  expiryBlock     String?
-  networkId       String?
-  guardAddress    String?
-  destination     String?
-  childAccount    String?
-  status          String    @default("pending")
-  invalidReason   String?
-  approvalCount   Int       @default(0)
-  createdAtBlock  Int?
-  executedAtBlock Int?
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
-  contract        Contract  @relation(fields: [contractId], references: [id], onDelete: Cascade)
-  approvals       Approval[]
-  receivers       ProposalReceiver[]
+  id             Int      @id @default(autoincrement())
+  contractId     Int
+  proposalHash   String
+  proposer       String?
+  toAddress      String?
+  tokenId        String?
+  txType         String?
+  data           String?
+  nonce          String?
+  configNonce    String?
+  expiryBlock    String?
+  networkId      String?
+  guardAddress   String?
+  destination    String?
+  childAccount   String?
+  createdAtBlock Int
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  contract   Contract            @relation(fields: [contractId], references: [id], onDelete: Cascade)
+  approvals  Approval[]
+  receivers  ProposalReceiver[]
+  executions ProposalExecution[]
 
   @@unique([contractId, proposalHash])
-  @@index([contractId, status])
+  @@index([contractId, createdAtBlock])
+  @@index([createdAtBlock])
 }
 
 model ProposalReceiver {
@@ -89,8 +121,8 @@ model ProposalReceiver {
   address    String
   amount     String
   createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  proposal   Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  proposal Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
 
   @@unique([proposalId, idx])
   @@index([proposalId])
@@ -101,25 +133,46 @@ model Approval {
   proposalId  Int
   approver    String
   approvalRaw String?
-  blockHeight Int?
+  blockHeight Int
+  eventOrder  Int      @default(0)
   createdAt   DateTime @default(now())
-  proposal    Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  proposal Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
 
   @@unique([proposalId, approver])
+  @@index([proposalId, blockHeight])
+  @@index([blockHeight])
+}
+
+model ProposalExecution {
+  id          Int      @id @default(autoincrement())
+  proposalId  Int
+  blockHeight Int
+  txHash      String?
+  eventOrder  Int      @default(0)
+  createdAt   DateTime @default(now())
+
+  proposal Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  @@unique([proposalId])
+  @@index([proposalId, blockHeight])
+  @@index([blockHeight])
 }
 
 model EventRaw {
-  id          Int       @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   contractId  Int?
   blockHeight Int
   txHash      String?
   eventType   String
   payload     String
-  fingerprint String    @unique
-  createdAt   DateTime  @default(now())
-  contract    Contract? @relation(fields: [contractId], references: [id], onDelete: SetNull)
+  fingerprint String   @unique
+  createdAt   DateTime @default(now())
+
+  contract Contract? @relation(fields: [contractId], references: [id], onDelete: SetNull)
 
   @@index([contractId, blockHeight])
+  @@index([blockHeight])
 }
 
 model IndexerCursor {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -10,6 +10,7 @@ export interface BackendConfig {
   indexPollIntervalMs: number;
   indexStartHeight: number;
   minaguardVkHash: string | null;
+  indexerMode: 'full' | 'lite';
 }
 
 /** Throws if a required environment variable is missing or empty. */
@@ -38,6 +39,12 @@ export function loadConfig(): BackendConfig {
   const archiveEndpoint = requireEnv('ARCHIVE_ENDPOINT');
   const lightnetAccountManager = process.env.LIGHTNET_ACCOUNT_MANAGER;
 
+  const rawMode = process.env.INDEXER_MODE ?? 'full';
+  if (rawMode !== 'full' && rawMode !== 'lite') {
+    throw new Error(`Env var INDEXER_MODE must be 'full' or 'lite', got: "${rawMode}"`);
+  }
+  const indexerMode: 'full' | 'lite' = rawMode;
+
   return {
     port,
     databaseUrl,
@@ -49,5 +56,6 @@ export function loadConfig(): BackendConfig {
     indexPollIntervalMs: numericEnv('INDEX_POLL_INTERVAL_MS', 15000),
     indexStartHeight: numericEnv('INDEX_START_HEIGHT', 0),
     minaguardVkHash: process.env.MINAGUARD_VK_HASH ?? null,
+    indexerMode,
   };
 }

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -4,12 +4,15 @@ import { PublicKey } from 'o1js';
 import {
   configureNetwork,
   discoverCandidateAddresses,
+  fetchBestChainHeaders,
   fetchDecodedContractEvents,
   fetchLatestBlockHeight,
   fetchOnChainState,
   fetchVerificationKeyHash,
   type ChainEvent,
 } from './mina-client.js';
+
+const REORG_DETECTION_WINDOW = 290;
 
 const EMPTY_PUBLIC_KEY = PublicKey.empty().toBase58();
 
@@ -22,13 +25,30 @@ export interface IndexerStatus {
   indexedHeight: number;
   lastError: string | null;
   discoveredContracts: number;
+  indexerMode: 'full' | 'lite';
 }
+
+/** Fields describing a single ContractConfig row — subset used when merging deltas. */
+type ContractConfigFields = {
+  threshold: number | null;
+  numOwners: number | null;
+  nonce: number | null;
+  parentNonce: number | null;
+  configNonce: number | null;
+  delegate: string | null;
+  childMultiSigEnabled: boolean | null;
+  ownersCommitment: string | null;
+  networkId: string | null;
+};
+
+/** Partial change set for a config-mutating event. Fields left undefined are copied from the latest row. */
+type ContractConfigChanges = Partial<ContractConfigFields>;
 
 /** Polling indexer that discovers MinaGuard contracts and ingests lifecycle events. */
 export class MinaGuardIndexer {
   private readonly config: BackendConfig;
   private intervalHandle: NodeJS.Timeout | null = null;
-  private status: IndexerStatus = {
+  private status: Omit<IndexerStatus, 'indexerMode'> = {
     running: false,
     lastRunAt: null,
     lastSuccessfulRunAt: null,
@@ -63,8 +83,8 @@ export class MinaGuardIndexer {
     this.status.running = false;
   }
 
-  /** Returns the latest in-memory indexer status snapshot. */
-  getStatus(): IndexerStatus {
+  /** Returns the latest in-memory indexer status snapshot. Does not include `indexerMode` — the route layer adds it from config. */
+  getStatus(): Omit<IndexerStatus, 'indexerMode'> {
     return { ...this.status };
   }
 
@@ -76,25 +96,50 @@ export class MinaGuardIndexer {
       const latestHeight = await fetchLatestBlockHeight(this.config);
       this.status.latestChainHeight = latestHeight;
 
+      // Detect a chain reorg before doing any new work. If detected, rollback
+      // has rewound the cursor and deleted all rows above the fork; bail out
+      // of this tick and let the next one resume syncing from the new cursor.
+      const rolledBackTo = await this.detectAndRollbackReorg();
+      if (rolledBackTo !== null) {
+        this.status.indexedHeight = rolledBackTo;
+        this.status.lastSuccessfulRunAt = new Date().toISOString();
+        this.status.lastError = null;
+        return;
+      }
+
       const indexedHeight = await this.getIndexedHeight();
       this.status.indexedHeight = indexedHeight;
 
       const fromHeight = indexedHeight + 1;
       const toHeight = latestHeight;
 
-      // Scan bestChain for new contract deployments
-      await this.discoverContracts(Math.max(1, Math.min(290, latestHeight)));
+      // Scan bestChain for new contract deployments. Only look at the
+      // un-indexed delta plus a small margin for the race where a block lands
+      // between the latestHeight read and the bestChain call. Clamped to 290
+      // (Mina's bestChain cap); reorg safety is handled by detectAndRollbackReorg
+      // above, which rewinds IndexerCursor on fork — the next tick's window
+      // naturally re-covers the reorged range. Lite mode skips discovery
+      // entirely and tracks only contracts added via the /subscribe route.
+      if (this.config.indexerMode === 'full') {
+        const DISCOVERY_MARGIN = 5;
+        const discoveryWindow = Math.max(
+          1,
+          Math.min(290, latestHeight - indexedHeight + DISCOVERY_MARGIN),
+        );
+        await this.discoverContracts(discoveryWindow, latestHeight);
+      }
+
+      // Rescan contracts that haven't yet seen a MinaGuard event. Runs
+      // every tick until events land; syncSingleContract flips ready=true
+      // on first ingestion, after which the contract joins the forward
+      // sweep below.
+      await this.rescanUnreadyContracts(latestHeight);
 
       if (toHeight >= fromHeight) {
         await this.syncKnownContracts(fromHeight, toHeight);
         await this.setIndexedHeight(toHeight);
         this.status.indexedHeight = toHeight;
       }
-
-      // Re-derive proposal lifecycle state on every tick, even when no new
-      // blocks were ingested — expiry and nonce/config invalidation are all
-      // functions of current on-chain state.
-      await this.deriveProposalStatuses(latestHeight);
 
       this.status.lastSuccessfulRunAt = new Date().toISOString();
       this.status.lastError = null;
@@ -103,8 +148,13 @@ export class MinaGuardIndexer {
     }
   }
 
+  /** Instance wrapper around {@link detectAndRollbackReorg} for use inside tick(). */
+  private async detectAndRollbackReorg(): Promise<number | null> {
+    return detectAndRollbackReorg(this.config);
+  }
+
   /** Discovers candidate contracts and stores verified MinaGuard addresses. */
-  private async discoverContracts(blockWindow: number): Promise<void> {
+  private async discoverContracts(blockWindow: number, latestHeight: number): Promise<void> {
     const candidates = await discoverCandidateAddresses(this.config, blockWindow);
 
     for (const address of candidates) {
@@ -122,21 +172,60 @@ export class MinaGuardIndexer {
       }
 
       const created = await prisma.contract.create({
-        data: { address },
+        data: { address, discoveredAtBlock: latestHeight },
       });
 
-      // Backfill events for the newly discovered contract. The contract was
-      // deployed within the bestChain window (~290 blocks), so scanning from
-      // a small margin before discovery is sufficient and stays cheap on mainnet.
-      const indexedHeight = await this.getIndexedHeight();
-      const backfillFrom = Math.max(0, indexedHeight - 300);
-      if (indexedHeight > backfillFrom) {
-        console.log(`[indexer] backfilling events for ${address} from block ${backfillFrom} to ${indexedHeight}`);
-        await this.syncSingleContract(created.id, address, backfillFrom, indexedHeight);
-      }
+      await this.backfillContract(created.id, address);
     }
 
     this.status.discoveredContracts = await prisma.contract.count();
+  }
+
+  /**
+   * Backfills events for a newly tracked contract. In full mode the backfill
+   * spans 300 blocks (bestChain window — the contract was just discovered there,
+   * so any earlier events are out of reorg range anyway). In lite mode the
+   * backfill starts at config.indexStartHeight (default 0) so a cold-started
+   * indexer pulls full history for any user-subscribed contract.
+   *
+   * Readiness is flipped by syncSingleContract on first event ingestion —
+   * a subscribed-before-deploy contract returns from here with ready=false
+   * and becomes ready once its deploy tx lands and the next sync picks up
+   * events for it.
+   *
+   * Exposed for use by the subscribe API route and the auto-subscribe path.
+   */
+  async backfillContract(contractId: number, address: string): Promise<void> {
+    const indexedHeight = await this.getIndexedHeight();
+    const backfillFrom =
+      this.config.indexerMode === 'lite'
+        ? this.config.indexStartHeight
+        : Math.max(0, indexedHeight - 300);
+    if (indexedHeight > backfillFrom) {
+      console.log(`[indexer] backfilling events for ${address} from block ${backfillFrom} to ${indexedHeight}`);
+      await this.syncSingleContract(contractId, address, backfillFrom, indexedHeight);
+    }
+  }
+
+  /**
+   * Re-scans every unready contract over its persisted lower bound
+   * (`discoveredAtBlock`) up to the current chain tip. The subscribe
+   * route records `discoveredAtBlock` at insert time; the tick rescans
+   * that range each run until `syncSingleContract` ingests a first event
+   * and flips `ready=true`. This is what makes subscribe-before-deploy
+   * self-healing: the first tick after the deploy lands (and the archive
+   * indexes it) picks up the events.
+   */
+  private async rescanUnreadyContracts(latestHeight: number): Promise<void> {
+    const unready = await prisma.contract.findMany({
+      where: { ready: false },
+      select: { id: true, address: true, discoveredAtBlock: true },
+    });
+    for (const c of unready) {
+      const from = c.discoveredAtBlock ?? this.config.indexStartHeight;
+      if (from > latestHeight) continue;
+      await this.syncSingleContract(c.id, c.address, from, latestHeight);
+    }
   }
 
   /** Indexes events for all tracked contracts across the requested block range. */
@@ -158,8 +247,12 @@ export class MinaGuardIndexer {
     }
   }
 
-  /** Fetches, stores, and applies decoded events for a single contract address. */
-  private async syncSingleContract(
+  /**
+   * Fetches, stores, and applies decoded events for a single contract address.
+   * Public so tests can drive the event-apply pipeline with mocked chain data
+   * (used by the reorg-reconstruction test).
+   */
+  async syncSingleContract(
     contractId: number,
     address: string,
     fromHeight: number,
@@ -196,12 +289,30 @@ export class MinaGuardIndexer {
     };
     events.sort((a, b) => (eventOrder[a.type] ?? 99) - (eventOrder[b.type] ?? 99));
 
-    for (const chainEvent of events) {
+    let ingested = false;
+    for (let seq = 0; seq < events.length; seq++) {
+      const chainEvent = events[seq];
       const fingerprint = this.fingerprintEvent(address, chainEvent);
       const existingRaw = await prisma.eventRaw.findUnique({ where: { fingerprint } });
       if (existingRaw) continue;
 
-      await prisma.eventRaw.create({
+      // Record the block identity before applying the event. Many events may
+      // share a height — upsert so the first writer wins and subsequent ones
+      // are no-ops. If hashes disagree across events at the same height, the
+      // reorg detector will catch that on the next tick.
+      if (chainEvent.blockHash) {
+        await prisma.blockHeader.upsert({
+          where: { height: chainEvent.blockHeight },
+          create: {
+            height: chainEvent.blockHeight,
+            blockHash: chainEvent.blockHash,
+            parentHash: chainEvent.parentHash,
+          },
+          update: {},
+        });
+      }
+
+      const eventRaw = await prisma.eventRaw.create({
         data: {
           contractId,
           blockHeight: chainEvent.blockHeight,
@@ -211,15 +322,21 @@ export class MinaGuardIndexer {
           fingerprint,
         },
       });
+      ingested = true;
 
-      await this.applyEvent(contractId, chainEvent);
+      await this.applyEvent(contractId, chainEvent, seq, eventRaw.id);
     }
 
-    await this.refreshContractState(contractId, address);
-
+    // Any MinaGuard event other than setup/setupOwner can only fire after
+    // the contract was initialized on-chain, so event presence is proof of
+    // a real, set-up contract. Flipping ready here gates a subscribed-before-
+    // deploy contract from appearing in API read routes until its first
+    // event actually lands.
     await prisma.contract.update({
       where: { id: contractId },
-      data: { lastSyncedAt: new Date() },
+      data: ingested
+        ? { lastSyncedAt: new Date(), ready: true }
+        : { lastSyncedAt: new Date() },
     });
   }
 
@@ -227,14 +344,16 @@ export class MinaGuardIndexer {
   private async applyEvent(
     contractId: number,
     chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
     switch (chainEvent.type) {
       case 'setup': {
-        await this.applySetupEvent(contractId, chainEvent.event);
+        await this.applySetupEvent(contractId, chainEvent, eventOrder, sourceEventId);
         return;
       }
       case 'setupOwner': {
-        await this.applySetupOwnerEvent(contractId, chainEvent.event);
+        await this.applySetupOwnerEvent(contractId, chainEvent, eventOrder, sourceEventId);
         return;
       }
       case 'proposal': {
@@ -242,38 +361,11 @@ export class MinaGuardIndexer {
         return;
       }
       case 'approval': {
-        await this.applyApprovalEvent(contractId, chainEvent);
+        await this.applyApprovalEvent(contractId, chainEvent, eventOrder);
         return;
       }
       case 'execution': {
-        await this.applyExecutionEvent(contractId, chainEvent);
-        return;
-      }
-      case 'createChild': {
-        await this.applyCreateChildEvent(contractId, chainEvent.event);
-        return;
-      }
-      case 'reclaimChild': {
-        return;
-      }
-      case 'enableChildMultiSig': {
-        await this.applyEnableChildMultiSigEvent(contractId, chainEvent.event);
-        return;
-      }
-      case 'receiver': {
-        await this.applyReceiverEvent(contractId, chainEvent.event);
-        return;
-      }
-      case 'ownerChange': {
-        await this.applyOwnerChangeEvent(contractId, chainEvent.event);
-        return;
-      }
-      case 'thresholdChange': {
-        await this.applyThresholdChangeEvent(contractId, chainEvent.event);
-        return;
-      }
-      case 'delegate': {
-        await this.applyDelegateEvent(contractId, chainEvent.event);
+        await this.applyExecutionEvent(contractId, chainEvent, eventOrder);
         return;
       }
       case 'createChild': {
@@ -287,7 +379,23 @@ export class MinaGuardIndexer {
         return;
       }
       case 'enableChildMultiSig': {
-        await this.applyEnableChildMultiSigEvent(contractId, chainEvent.event);
+        await this.applyEnableChildMultiSigEvent(contractId, chainEvent, eventOrder, sourceEventId);
+        return;
+      }
+      case 'receiver': {
+        await this.applyReceiverEvent(contractId, chainEvent.event);
+        return;
+      }
+      case 'ownerChange': {
+        await this.applyOwnerChangeEvent(contractId, chainEvent, eventOrder, sourceEventId);
+        return;
+      }
+      case 'thresholdChange': {
+        await this.applyThresholdChangeEvent(contractId, chainEvent, eventOrder, sourceEventId);
+        return;
+      }
+      case 'delegate': {
+        await this.applyDelegateEvent(contractId, chainEvent, eventOrder, sourceEventId);
         return;
       }
       default:
@@ -295,62 +403,139 @@ export class MinaGuardIndexer {
     }
   }
 
-  /** Applies setup summary fields to contract metadata if the event is emitted. */
+  /** Reads the latest ContractConfig row for a contract, or null if none exists yet. */
+  private async getLatestConfig(contractId: number) {
+    return prisma.contractConfig.findFirst({
+      where: { contractId },
+      orderBy: [{ validFromBlock: 'desc' }, { eventOrder: 'desc' }],
+    });
+  }
+
+  /**
+   * Inserts a full-snapshot ContractConfig row by copying the latest row
+   * forward and overlaying the partial `changes`. Fields not present in
+   * `changes` are copied from the latest row (or null if no prior row exists).
+   */
+  private async appendContractConfigSnapshot(
+    contractId: number,
+    validFromBlock: number,
+    eventOrder: number,
+    sourceEventId: number | null,
+    changes: ContractConfigChanges,
+  ): Promise<void> {
+    const latest = await this.getLatestConfig(contractId);
+    await prisma.contractConfig.create({
+      data: {
+        contractId,
+        validFromBlock,
+        eventOrder,
+        sourceEventId,
+        threshold:            changes.threshold            ?? latest?.threshold            ?? null,
+        numOwners:            changes.numOwners            ?? latest?.numOwners            ?? null,
+        nonce:                changes.nonce                ?? latest?.nonce                ?? null,
+        parentNonce:          changes.parentNonce          ?? latest?.parentNonce          ?? null,
+        configNonce:          changes.configNonce          ?? latest?.configNonce          ?? null,
+        delegate:             changes.delegate             ?? latest?.delegate             ?? null,
+        childMultiSigEnabled: changes.childMultiSigEnabled ?? latest?.childMultiSigEnabled ?? null,
+        ownersCommitment:     changes.ownersCommitment     ?? latest?.ownersCommitment     ?? null,
+        networkId:            changes.networkId            ?? latest?.networkId            ?? null,
+      },
+    });
+  }
+
+  /** Applies setup summary fields: writes parent onto Contract, inserts ContractConfig snapshot. */
   private async applySetupEvent(
     contractId: number,
-    event: Record<string, unknown>
+    chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
+    const event = chainEvent.event;
     const parent = asString(event.parent);
     const isRoot = parent === null || parent === EMPTY_PUBLIC_KEY;
 
     await prisma.contract.update({
       where: { id: contractId },
-      data: {
-        ownersCommitment: asString(event.ownersCommitment),
+      data: { parent: isRoot ? null : parent },
+    });
+
+    await this.appendContractConfigSnapshot(
+      contractId,
+      chainEvent.blockHeight,
+      eventOrder,
+      sourceEventId,
+      {
         threshold: asNumber(event.threshold),
         numOwners: asNumber(event.numOwners),
-        networkId: asString(event.networkId),
-        parent: isRoot ? null : parent,
         nonce: 0,
-        configNonce: 0,
         parentNonce: 0,
+        configNonce: 0,
+        networkId: asString(event.networkId),
+        ownersCommitment: asString(event.ownersCommitment),
         childMultiSigEnabled: true,
       },
-    });
+    );
   }
 
-  /** Upserts one owner entry from setup bootstrap events. */
+  /** Inserts an OwnerMembership row for a setup owner and backfills config from on-chain if needed. */
   private async applySetupOwnerEvent(
     contractId: number,
-    event: Record<string, unknown>
+    chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
+    const event = chainEvent.event;
     const ownerAddress = asString(event.owner);
     if (!ownerAddress || ownerAddress.length < 10 || ownerAddress === EMPTY_PUBLIC_KEY) return;
 
-    await prisma.owner.upsert({
-      where: {
-        contractId_address: {
-          contractId,
-          address: ownerAddress,
-        },
-      },
-      create: {
+    await prisma.ownerMembership.create({
+      data: {
         contractId,
         address: ownerAddress,
+        action: 'added',
         index: asNumber(event.index),
-        active: true,
-      },
-      update: {
-        index: asNumber(event.index),
-        active: true,
+        ownerHash: null,
+        validFromBlock: chainEvent.blockHeight,
+        eventOrder,
+        sourceEventId,
       },
     });
+
+    // Derive threshold/numOwners from on-chain state when no setup event was emitted.
+    const latest = await this.getLatestConfig(contractId);
+    if (latest && latest.threshold != null) return;
+
+    const contract = await prisma.contract.findUnique({ where: { id: contractId } });
+    if (!contract) return;
+
+    const onChain = await fetchOnChainState(contract.address);
+    if (!onChain) return;
+
+    await this.appendContractConfigSnapshot(
+      contractId,
+      chainEvent.blockHeight,
+      eventOrder,
+      sourceEventId,
+      {
+        threshold: onChain.threshold,
+        numOwners: onChain.numOwners,
+        networkId: onChain.networkId,
+        ownersCommitment: onChain.ownersCommitment,
+      },
+    );
   }
 
   /**
    * Creates a proposal row from on-chain event data.
    * ProposalEvent includes all TransactionProposal fields so the indexer
    * can reconstruct full proposal details purely from on-chain events.
+   *
+   * For CREATE_CHILD proposals in lite mode, eagerly inserts the child's
+   * Contract row so the indexer starts tracking its address immediately.
+   * This is required because `executeSetupChild` emits its execution event
+   * on the child, not the parent — if the child weren't tracked, the
+   * REMOTE path in applyExecutionEvent could never walk back to upsert
+   * ProposalExecution, and the proposal would stay pending forever.
    */
   private async applyProposalEvent(contractId: number, chainEvent: ChainEvent): Promise<void> {
     const event = chainEvent.event;
@@ -379,8 +564,6 @@ export class MinaGuardIndexer {
         destination: normalizeDestination(asString(event.destination)),
         childAccount: asNullableAddress(asString(event.childAccount)),
         createdAtBlock: chainEvent.blockHeight,
-        status: 'pending',
-        invalidReason: null,
       },
       update: {
         tokenId: asString(event.tokenId),
@@ -395,6 +578,33 @@ export class MinaGuardIndexer {
         childAccount: asNullableAddress(asString(event.childAccount)),
       },
     });
+
+    if (this.config.indexerMode === 'lite' && asString(event.txType) === '5') {
+      const childAddress = asNullableAddress(asString(event.childAccount));
+      if (childAddress) {
+        const parent = await prisma.contract.findUnique({
+          where: { id: contractId },
+          select: { address: true },
+        });
+        if (parent) {
+          const existing = await prisma.contract.findUnique({
+            where: { address: childAddress },
+          });
+          if (!existing) {
+            await prisma.contract.create({
+              data: {
+                address: childAddress,
+                parent: parent.address,
+                discoveredAtBlock: chainEvent.blockHeight,
+              },
+            });
+            console.log(
+              `[indexer] eager-subscribing child ${childAddress} of parent ${parent.address} on CREATE_CHILD proposal`,
+            );
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -457,8 +667,12 @@ export class MinaGuardIndexer {
     }
   }
 
-  /** Stores per-approver records and updates aggregate approval count on proposal rows. */
-  private async applyApprovalEvent(contractId: number, chainEvent: ChainEvent): Promise<void> {
+  /** Upserts per-approver approval rows. Approval count is derived at read time. */
+  private async applyApprovalEvent(
+    contractId: number,
+    chainEvent: ChainEvent,
+    eventOrder: number,
+  ): Promise<void> {
     const event = chainEvent.event;
     const proposalHash = asString(event.proposalHash);
     const approver = asString(event.approver);
@@ -488,24 +702,18 @@ export class MinaGuardIndexer {
         approver,
         approvalRaw: asString(event.approvalCount),
         blockHeight: chainEvent.blockHeight,
+        eventOrder,
       },
       update: {
         approvalRaw: asString(event.approvalCount),
         blockHeight: chainEvent.blockHeight,
-      },
-    });
-
-    const approvals = await prisma.approval.count({ where: { proposalId: proposal.id } });
-    await prisma.proposal.update({
-      where: { id: proposal.id },
-      data: {
-        approvalCount: approvals,
+        eventOrder,
       },
     });
   }
 
   /**
-   * Marks proposals executed when execution events are observed.
+   * Records a proposal execution by upserting a ProposalExecution row.
    *
    * LOCAL path: the Proposal row lives under the emitting contract, so
    * (contractId, proposalHash) resolves it directly.
@@ -515,17 +723,35 @@ export class MinaGuardIndexer {
    * child guard, but the Proposal row lives under the parent's contractId.
    * On a local miss, walk to the child's `parent` and retry.
    */
-  private async applyExecutionEvent(contractId: number, chainEvent: ChainEvent): Promise<void> {
+  private async applyExecutionEvent(
+    contractId: number,
+    chainEvent: ChainEvent,
+    eventOrder: number,
+  ): Promise<void> {
     const proposalHash = asString(chainEvent.event.proposalHash);
     if (!proposalHash) return;
 
-    const executedAtBlock = chainEvent.blockHeight;
+    const blockHeight = chainEvent.blockHeight;
+    const txHash = chainEvent.txHash;
 
-    const local = await prisma.proposal.updateMany({
-      where: { contractId, proposalHash },
-      data: { status: 'executed', invalidReason: null, executedAtBlock },
+    const local = await prisma.proposal.findUnique({
+      where: { contractId_proposalHash: { contractId, proposalHash } },
+      select: { id: true, nonce: true },
     });
-    if (local.count > 0) return;
+    if (local) {
+      await this.upsertProposalExecution(local.id, blockHeight, txHash, eventOrder);
+      const localNonce = local.nonce === null ? null : Number(local.nonce);
+      if (localNonce !== null && Number.isFinite(localNonce)) {
+        await this.appendContractConfigSnapshot(
+          contractId,
+          blockHeight,
+          eventOrder,
+          null,
+          { nonce: localNonce },
+        );
+      }
+      return;
+    }
 
     const child = await prisma.contract.findUnique({
       where: { id: contractId },
@@ -539,245 +765,146 @@ export class MinaGuardIndexer {
     });
     if (!parent) return;
 
-    await prisma.proposal.updateMany({
-      where: { contractId: parent.id, proposalHash },
-      data: { status: 'executed', invalidReason: null, executedAtBlock },
+    const remote = await prisma.proposal.findUnique({
+      where: { contractId_proposalHash: { contractId: parent.id, proposalHash } },
+      select: { id: true, nonce: true },
     });
+    if (!remote) return;
+
+    await this.upsertProposalExecution(remote.id, blockHeight, txHash, eventOrder);
+    const remoteNonce = remote.nonce === null ? null : Number(remote.nonce);
+    if (remoteNonce !== null && Number.isFinite(remoteNonce)) {
+      await this.appendContractConfigSnapshot(
+        contractId,
+        blockHeight,
+        eventOrder,
+        null,
+        { parentNonce: remoteNonce },
+      );
+    }
   }
 
-  /** Persists child-parent linkage when a child finishes CREATE_CHILD setup. */
-  private async applyCreateChildEvent(
-    contractId: number,
-    event: Record<string, unknown>
+  private async upsertProposalExecution(
+    proposalId: number,
+    blockHeight: number,
+    txHash: string | null,
+    eventOrder: number,
   ): Promise<void> {
-    const parent = asString(event.parentAddress);
-    if (parent === null) return;
-
-    await prisma.contract.update({
-      where: { id: contractId },
-      data: {
-        parent,
-        childMultiSigEnabled: true,
-      },
+    await prisma.proposalExecution.upsert({
+      where: { proposalId },
+      create: { proposalId, blockHeight, txHash, eventOrder },
+      update: { blockHeight, txHash, eventOrder },
     });
   }
 
-  /** Applies owner add/remove governance results to owner table state. */
+  /** Records an owner add/remove governance result and appends a ContractConfig snapshot. */
   private async applyOwnerChangeEvent(
     contractId: number,
-    event: Record<string, unknown>
+    chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
+    const event = chainEvent.event;
     const owner = asString(event.owner);
     if (!owner) return;
 
     const added = asString(event.added) === '1';
 
-    await prisma.owner.upsert({
-      where: {
-        contractId_address: {
-          contractId,
-          address: owner,
-        },
-      },
-      create: {
+    await prisma.ownerMembership.create({
+      data: {
         contractId,
         address: owner,
-        active: added,
-      },
-      update: {
-        active: added,
+        action: added ? 'added' : 'removed',
+        index: null,
+        ownerHash: null,
+        validFromBlock: chainEvent.blockHeight,
+        eventOrder,
+        sourceEventId,
       },
     });
 
     const newNumOwners = asNumber(event.newNumOwners);
-    if (newNumOwners !== null) {
-      await prisma.contract.update({
-        where: { id: contractId },
-        data: { numOwners: newNumOwners },
-      });
-    }
-
     const configNonce = asNumber(event.configNonce);
-    if (configNonce !== null) {
-      await prisma.contract.update({
-        where: { id: contractId },
-        data: { configNonce },
-      });
+
+    const changes: ContractConfigChanges = {};
+    if (newNumOwners !== null) changes.numOwners = newNumOwners;
+    if (configNonce !== null) changes.configNonce = configNonce;
+
+    if (Object.keys(changes).length > 0) {
+      await this.appendContractConfigSnapshot(
+        contractId,
+        chainEvent.blockHeight,
+        eventOrder,
+        sourceEventId,
+        changes,
+      );
     }
   }
 
-  /** Applies threshold change governance results to contract metadata. */
+  /** Applies threshold change governance results to a ContractConfig snapshot. */
   private async applyThresholdChangeEvent(
     contractId: number,
-    event: Record<string, unknown>
+    chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
+    const event = chainEvent.event;
     const newThreshold = asNumber(event.newThreshold);
     if (newThreshold === null) return;
 
     const configNonce = asNumber(event.configNonce);
-    await prisma.contract.update({
-      where: { id: contractId },
-      data: {
-        threshold: newThreshold,
-        ...(configNonce !== null ? { configNonce } : {}),
-      },
-    });
+    const changes: ContractConfigChanges = { threshold: newThreshold };
+    if (configNonce !== null) changes.configNonce = configNonce;
+
+    await this.appendContractConfigSnapshot(
+      contractId,
+      chainEvent.blockHeight,
+      eventOrder,
+      sourceEventId,
+      changes,
+    );
   }
 
-  /** Updates the delegate address on a contract when a delegate event is processed. */
+  /** Appends a ContractConfig snapshot updating the delegate address. */
   private async applyDelegateEvent(
     contractId: number,
-    event: Record<string, unknown>
+    chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
-    const delegate = asString(event.delegate);
+    const delegate = asString(chainEvent.event.delegate);
     if (delegate === null) return;
 
-    await prisma.contract.update({
-      where: { id: contractId },
-      data: { delegate },
-    });
+    await this.appendContractConfigSnapshot(
+      contractId,
+      chainEvent.blockHeight,
+      eventOrder,
+      sourceEventId,
+      { delegate },
+    );
   }
 
   /**
-   * Flips child.childMultiSigEnabled from EnableChildMultiSigEvent on the child guard.
+   * Appends a ContractConfig snapshot flipping childMultiSigEnabled on the child guard.
    * Doubles as the destroy state-flip handler since executeDestroy emits the same
    * event with enabled=0.
    */
   private async applyEnableChildMultiSigEvent(
     contractId: number,
-    event: Record<string, unknown>
+    chainEvent: ChainEvent,
+    eventOrder: number,
+    sourceEventId: number,
   ): Promise<void> {
-    const enabled = asNumber(event.enabled);
+    const enabled = asNumber(chainEvent.event.enabled);
     if (enabled === null) return;
 
-    await prisma.contract.update({
-      where: { id: contractId },
-      data: { childMultiSigEnabled: enabled === 1 },
-    });
-  }
-
-  /** Refreshes one contract row from on-chain state when readable. */
-  private async refreshContractState(contractId: number, address: string): Promise<void> {
-    const onChain = await fetchOnChainState(address);
-    if (!onChain) return;
-
-    await prisma.contract.update({
-      where: { id: contractId },
-      data: {
-        threshold: onChain.threshold,
-        numOwners: onChain.numOwners,
-        networkId: onChain.networkId,
-        ownersCommitment: onChain.ownersCommitment,
-        nonce: onChain.nonce,
-        configNonce: onChain.configNonce,
-        parent: onChain.parent,
-        parentNonce: onChain.parentNonce,
-        childMultiSigEnabled: onChain.childMultiSigEnabled,
-      },
-    });
-  }
-
-  /** Recomputes non-executed proposal status from expiry plus current contract nonce/config state. */
-  private async deriveProposalStatuses(latestHeight: number): Promise<void> {
-    const proposals = await prisma.proposal.findMany({
-      where: {
-        status: { not: 'executed' },
-      },
-      include: {
-        contract: {
-          select: {
-            id: true,
-            address: true,
-            configNonce: true,
-            nonce: true,
-            parent: true,
-            parentNonce: true,
-          },
-        },
-      },
-    });
-
-    const contracts = await prisma.contract.findMany({
-      select: {
-        address: true,
-        parent: true,
-        nonce: true,
-        parentNonce: true,
-      },
-    });
-    const contractByAddress = new Map(contracts.map((contract) => [contract.address, contract]));
-
-    for (const proposal of proposals) {
-      let status = 'pending';
-      let invalidReason: string | null = null;
-
-      const expiry = Number(proposal.expiryBlock ?? '0');
-      if (Number.isFinite(expiry) && expiry > 0 && latestHeight > expiry) {
-        status = 'expired';
-      } else if (this.isConfigNonceStale(proposal.configNonce, proposal.contract.configNonce)) {
-        status = 'invalidated';
-        invalidReason = 'config_nonce_stale';
-      } else if (this.isProposalNonceStale(proposal, contractByAddress)) {
-        status = 'invalidated';
-        invalidReason = 'proposal_nonce_stale';
-      }
-
-      if (proposal.status !== status || proposal.invalidReason !== invalidReason) {
-        await prisma.proposal.update({
-          where: { id: proposal.id },
-          data: { status, invalidReason },
-        });
-      }
-    }
-  }
-
-  private isConfigNonceStale(
-    proposalConfigNonce: string | null,
-    currentConfigNonce: number | null,
-  ): boolean {
-    if (proposalConfigNonce === null || currentConfigNonce === null) return false;
-    const parsed = Number(proposalConfigNonce);
-    if (!Number.isFinite(parsed)) return false;
-    // Strict-less-than: only invalidate when the proposal is behind the contract.
-    // A proposal with a future configNonce (shouldn't happen) is left alone so
-    // the on-chain configNonce check can surface the mismatch at execute time.
-    return parsed < currentConfigNonce;
-  }
-
-  private isProposalNonceStale(
-    proposal: {
-      nonce: string | null;
-      destination: string | null;
-      txType: string | null;
-      childAccount: string | null;
-      contract: {
-        nonce: number | null;
-      };
-    },
-    contractByAddress: Map<string, { address: string; parent: string | null; nonce: number | null; parentNonce: number | null }>
-  ): boolean {
-    if (proposal.nonce === null) return false;
-    const parsedNonce = Number(proposal.nonce);
-    if (!Number.isFinite(parsedNonce)) return false;
-
-    // `destination` is persisted already normalized by normalizeDestination()
-    // to 'local' / 'remote' strings. Comparing to the raw field value '1'
-    // here silently misrouted REMOTE proposals (including CREATE_CHILD) into
-    // the LOCAL-nonce branch.
-    const isRemote = proposal.destination === 'remote';
-    const isCreateChild = proposal.txType === '5';
-
-    if (!isRemote) {
-      return proposal.contract.nonce !== null && parsedNonce <= proposal.contract.nonce;
-    }
-
-    if (isCreateChild) return false;
-
-    if (!proposal.childAccount) return false;
-    const child = contractByAddress.get(proposal.childAccount);
-    return child?.parentNonce !== null && child?.parentNonce !== undefined
-      ? parsedNonce <= child.parentNonce
-      : false;
+    await this.appendContractConfigSnapshot(
+      contractId,
+      chainEvent.blockHeight,
+      eventOrder,
+      sourceEventId,
+      { childMultiSigEnabled: enabled === 1 },
+    );
   }
 
   /** Returns current indexed block height cursor from DB or configured default start. */
@@ -860,4 +987,120 @@ function normalizeDestination(value: string | null): string | null {
 function asNullableAddress(value: string | null): string | null {
   if (!value || value === EMPTY_PUBLIC_KEY) return null;
   return value;
+}
+
+/**
+ * Compares stored BlockHeader hashes against the daemon's current bestChain.
+ * On mismatch, rolls back all history above the fork point and returns the
+ * fork height. Returns null when stored state agrees with the chain, no
+ * stored headers overlap the detection window, or the daemon is unreachable.
+ *
+ * Exported so tests can drive reorg handling directly without the rest of tick().
+ */
+export async function detectAndRollbackReorg(config: BackendConfig): Promise<number | null> {
+  let headers: Awaited<ReturnType<typeof fetchBestChainHeaders>>;
+  try {
+    headers = await fetchBestChainHeaders(config, REORG_DETECTION_WINDOW);
+  } catch (error) {
+    console.warn(
+      '[indexer] reorg detection skipped: bestChain fetch failed:',
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+  if (headers.length === 0) return null;
+
+  const minHeight = headers[0].height;
+  const maxHeight = headers[headers.length - 1].height;
+
+  const stored = await prisma.blockHeader.findMany({
+    where: { height: { gte: minHeight, lte: maxHeight } },
+    orderBy: { height: 'asc' },
+  });
+  if (stored.length === 0) return null;
+
+  const chainByHeight = new Map(headers.map((h) => [h.height, h]));
+
+  // Walk descending. The fork point is the highest stored height whose hash
+  // matches the chain — every stored row above it is non-canonical and must
+  // be rolled back. We can't stop at the first mismatch: a multi-block reorg
+  // may have a run of mismatches before hitting the last agreed height below.
+  let forkHeight: number | null = null;
+  let highestMismatch: { height: number; stored: string; chain: string } | null = null;
+  for (let i = stored.length - 1; i >= 0; i--) {
+    const s = stored[i];
+    const c = chainByHeight.get(s.height);
+    if (!c) continue;
+    if (c.blockHash === s.blockHash) {
+      forkHeight = s.height;
+      break;
+    }
+    if (highestMismatch === null) {
+      highestMismatch = { height: s.height, stored: s.blockHash, chain: c.blockHash };
+    }
+  }
+
+  if (highestMismatch === null) {
+    // No mismatches anywhere in the overlap — stored state is a prefix of the
+    // chain, nothing to do.
+    return null;
+  }
+
+  if (forkHeight === null) {
+    // Every stored row in the detection window disagrees with the chain. The
+    // reorg is deeper than our visibility; we can't pinpoint the fork safely.
+    // Log loudly and bail — operator intervention needed (Mina finality is
+    // ~290 blocks, so this effectively shouldn't happen in practice).
+    console.error(
+      `[indexer] reorg deeper than detection window (${REORG_DETECTION_WINDOW} blocks); ` +
+      `all overlapping stored headers disagree with chain. Skipping rollback.`,
+    );
+    return null;
+  }
+
+  console.warn(
+    `[indexer] reorg detected: highest mismatch at ${highestMismatch.height} ` +
+    `(stored=${highestMismatch.stored} chain=${highestMismatch.chain}); ` +
+    `rolling back to last agreed height ${forkHeight}`,
+  );
+  await rollbackAboveFork(forkHeight);
+  return forkHeight;
+}
+
+/**
+ * Atomically deletes a single contract and all of its tracked history
+ * (events, configs, memberships, proposals and their executions/approvals).
+ * Used by the unsubscribe API route in lite mode.
+ *
+ * Relation cascades cover everything except EventRaw (SetNull), so we delete
+ * events explicitly up front.
+ */
+export async function deleteContract(contractId: number): Promise<void> {
+  await prisma.$transaction([
+    prisma.eventRaw.deleteMany({ where: { contractId } }),
+    prisma.contract.delete({ where: { id: contractId } }),
+  ]);
+}
+
+/**
+ * Atomically deletes all append-only history rows above `forkHeight` and
+ * rewinds the indexer cursor. The next tick resumes syncing from fork + 1.
+ * Exported for testing.
+ */
+export async function rollbackAboveFork(forkHeight: number): Promise<void> {
+  await prisma.$transaction([
+    prisma.blockHeader.deleteMany({ where: { height: { gt: forkHeight } } }),
+    prisma.eventRaw.deleteMany({ where: { blockHeight: { gt: forkHeight } } }),
+    prisma.contractConfig.deleteMany({ where: { validFromBlock: { gt: forkHeight } } }),
+    prisma.ownerMembership.deleteMany({ where: { validFromBlock: { gt: forkHeight } } }),
+    prisma.proposalExecution.deleteMany({ where: { blockHeight: { gt: forkHeight } } }),
+    prisma.approval.deleteMany({ where: { blockHeight: { gt: forkHeight } } }),
+    prisma.proposal.deleteMany({ where: { createdAtBlock: { gt: forkHeight } } }),
+    prisma.contract.deleteMany({ where: { discoveredAtBlock: { gt: forkHeight } } }),
+    prisma.indexerCursor.upsert({
+      where: { key: 'indexed_height' },
+      create: { key: 'indexed_height', value: String(forkHeight) },
+      update: { value: String(forkHeight) },
+    }),
+  ]);
 }

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -9,7 +9,16 @@ export interface ChainEvent {
   type: string;
   event: Record<string, unknown>;
   blockHeight: number;
+  blockHash: string;
+  parentHash: string;
   txHash: string | null;
+}
+
+/** Block identity row returned by the daemon's bestChain query. */
+export interface BestChainHeader {
+  height: number;
+  blockHash: string;
+  parentHash: string;
 }
 
 /** Configures o1js network endpoints once at process start. */
@@ -23,6 +32,55 @@ export function configureNetwork(config: BackendConfig): void {
         : {}),
     })
   );
+}
+
+/**
+ * Fetches block identities for the daemon's current bestChain, ordered ascending by height.
+ * Used by the reorg-detection path to compare stored BlockHeader hashes against the
+ * node's authoritative canonical view.
+ */
+export async function fetchBestChainHeaders(
+  config: BackendConfig,
+  maxLength: number,
+): Promise<BestChainHeader[]> {
+  const query = `{
+    bestChain(maxLength: ${maxLength}) {
+      stateHash
+      protocolState {
+        previousStateHash
+        consensusState { blockHeight }
+      }
+    }
+  }`;
+
+  type Response = {
+    bestChain?: Array<{
+      stateHash?: string;
+      protocolState?: {
+        previousStateHash?: string;
+        consensusState?: { blockHeight?: string | number };
+      };
+    }>;
+  };
+
+  const data = await graphqlRequest<Response>(
+    query,
+    config.minaEndpoint,
+    config.minaFallbackEndpoint,
+  );
+
+  const headers: BestChainHeader[] = [];
+  for (const block of data.bestChain ?? []) {
+    const stateHash = block.stateHash;
+    const parentHash = block.protocolState?.previousStateHash;
+    const heightRaw = block.protocolState?.consensusState?.blockHeight;
+    if (!stateHash || !parentHash || heightRaw === undefined) continue;
+    const height = Number(heightRaw);
+    if (!Number.isFinite(height)) continue;
+    headers.push({ height, blockHash: stateHash, parentHash });
+  }
+  headers.sort((a, b) => a.height - b.height);
+  return headers;
 }
 
 /** Fetches latest block height from archive node to stay aligned with event availability. */
@@ -178,6 +236,8 @@ export async function fetchDecodedContractEvents(
     type: entry.type,
     event: toSerializableObject((entry.event as any).data),
     blockHeight: Number(entry.blockHeight.toString()),
+    blockHash: (entry as any).blockHash as string,
+    parentHash: (entry as any).parentBlockHash as string,
     txHash: ((entry.event as any).transactionInfo?.transactionHash as string | undefined) ?? null,
   }));
 }

--- a/backend/src/proposal-record.ts
+++ b/backend/src/proposal-record.ts
@@ -32,13 +32,30 @@ export interface SerializedProposalRecord {
   totalAmount: string | null;
 }
 
-type ProposalWithReceivers = Proposal & {
+export type ProposalWithDerived = Proposal & {
   receivers: ProposalReceiver[];
+  executions: { blockHeight: number; txHash: string | null }[];
+  _count: { approvals: number };
 };
+
+/**
+ * Derives proposal status from the append-only schema.
+ *
+ * `executed` iff a ProposalExecution row exists. Else `expired` iff the chain
+ * has moved past `expiryBlock`. Else `pending`. `latestHeight` is the current
+ * chain tip reported by the indexer.
+ */
+function deriveStatus(proposal: Proposal, executed: boolean, latestHeight: number): string {
+  if (executed) return 'executed';
+  const expiry = Number(proposal.expiryBlock ?? '0');
+  if (Number.isFinite(expiry) && expiry > 0 && latestHeight > expiry) return 'expired';
+  return 'pending';
+}
 
 /** Converts Prisma proposal rows into the API shape expected by the UI. */
 export function serializeProposalRecord(
-  proposal: ProposalWithReceivers
+  proposal: ProposalWithDerived,
+  latestHeight: number,
 ): SerializedProposalRecord {
   const receivers = proposal.receivers
     .slice()
@@ -52,6 +69,9 @@ export function serializeProposalRecord(
   const totalAmount = receivers.length > 0
     ? receivers.reduce((sum: bigint, receiver: ProposalReceiverRecord) => sum + BigInt(receiver.amount), 0n).toString()
     : null;
+
+  const execution = proposal.executions[0] ?? null;
+  const status = deriveStatus(proposal, execution !== null, latestHeight);
 
   return {
     proposalHash: proposal.proposalHash,
@@ -67,11 +87,11 @@ export function serializeProposalRecord(
     guardAddress: proposal.guardAddress,
     destination: proposal.destination,
     childAccount: proposal.childAccount,
-    status: proposal.status,
-    invalidReason: proposal.invalidReason,
-    approvalCount: proposal.approvalCount,
+    status,
+    invalidReason: null, // TODO: add it back to schema?
+    approvalCount: proposal._count.approvals,
     createdAtBlock: proposal.createdAtBlock,
-    executedAtBlock: proposal.executedAtBlock,
+    executedAtBlock: execution?.blockHeight ?? null,
     createdAt: proposal.createdAt,
     updatedAt: proposal.updatedAt,
     receivers,

--- a/backend/src/proposal-record.ts
+++ b/backend/src/proposal-record.ts
@@ -6,6 +6,17 @@ export interface ProposalReceiverRecord {
   amount: string;
 }
 
+export type InvalidReason = 'config_nonce_stale' | 'proposal_nonce_stale';
+
+/** Snapshot of a contract's current on-chain counters, derived from the latest
+ *  ContractConfig row. Used to compute per-proposal `invalidReason` at read
+ *  time — no persistence, no rollback bookkeeping. */
+export type ContractState = {
+  nonce: number | null;
+  parentNonce: number | null;
+  configNonce: number | null;
+};
+
 export interface SerializedProposalRecord {
   proposalHash: string;
   proposer: string | null;
@@ -21,7 +32,7 @@ export interface SerializedProposalRecord {
   destination: string | null;
   childAccount: string | null;
   status: string;
-  invalidReason: string | null;
+  invalidReason: InvalidReason | null;
   approvalCount: number;
   createdAtBlock: number | null;
   executedAtBlock: number | null;
@@ -38,15 +49,62 @@ export type ProposalWithDerived = Proposal & {
   _count: { approvals: number };
 };
 
+type ProposalInvalidInput = Pick<Proposal, 'nonce' | 'configNonce' | 'destination' | 'txType'>;
+
 /**
- * Derives proposal status from the append-only schema.
+ * Pure check: is this proposal invalidated by the current contract state?
  *
- * `executed` iff a ProposalExecution row exists. Else `expired` iff the chain
- * has moved past `expiryBlock`. Else `pending`. `latestHeight` is the current
- * chain tip reported by the indexer.
+ * Config-stale takes precedence over nonce-stale (matches on-chain assert
+ * ordering and prior indexer logic). CREATE_CHILD (txType='5') bypasses
+ * nonce-stale entirely — its nonce is structural (always 0), not sequential.
  */
-function deriveStatus(proposal: Proposal, executed: boolean, latestHeight: number): string {
+export function deriveInvalidReason(
+  proposal: ProposalInvalidInput,
+  parent: ContractState | null,
+  child: ContractState | null,
+): InvalidReason | null {
+  if (parent?.configNonce != null && proposal.configNonce != null) {
+    const parsedConfig = Number(proposal.configNonce);
+    if (Number.isFinite(parsedConfig) && parsedConfig < parent.configNonce) {
+      return 'config_nonce_stale';
+    }
+  }
+
+  if (proposal.txType === '5') return null;
+
+  if (proposal.nonce == null) return null;
+  const parsedNonce = Number(proposal.nonce);
+  if (!Number.isFinite(parsedNonce)) return null;
+
+  const isRemote = proposal.destination === 'remote';
+  if (!isRemote) {
+    if (parent?.nonce != null && parsedNonce <= parent.nonce) {
+      return 'proposal_nonce_stale';
+    }
+    return null;
+  }
+
+  if (child?.parentNonce != null && parsedNonce <= child.parentNonce) {
+    return 'proposal_nonce_stale';
+  }
+  return null;
+}
+
+/**
+ * Derives proposal status from the append-only schema plus read-time checks.
+ *
+ * Precedence: `executed` (ProposalExecution row) > `invalidated`
+ * (deriveInvalidReason returned non-null) > `expired` (latestHeight past
+ * expiryBlock) > `pending`.
+ */
+function deriveStatus(
+  proposal: Proposal,
+  executed: boolean,
+  latestHeight: number,
+  invalidReason: InvalidReason | null,
+): string {
   if (executed) return 'executed';
+  if (invalidReason !== null) return 'invalidated';
   const expiry = Number(proposal.expiryBlock ?? '0');
   if (Number.isFinite(expiry) && expiry > 0 && latestHeight > expiry) return 'expired';
   return 'pending';
@@ -56,6 +114,8 @@ function deriveStatus(proposal: Proposal, executed: boolean, latestHeight: numbe
 export function serializeProposalRecord(
   proposal: ProposalWithDerived,
   latestHeight: number,
+  parentState: ContractState | null = null,
+  childState: ContractState | null = null,
 ): SerializedProposalRecord {
   const receivers = proposal.receivers
     .slice()
@@ -71,7 +131,8 @@ export function serializeProposalRecord(
     : null;
 
   const execution = proposal.executions[0] ?? null;
-  const status = deriveStatus(proposal, execution !== null, latestHeight);
+  const invalidReason = deriveInvalidReason(proposal, parentState, childState);
+  const status = deriveStatus(proposal, execution !== null, latestHeight, invalidReason);
 
   return {
     proposalHash: proposal.proposalHash,
@@ -88,7 +149,7 @@ export function serializeProposalRecord(
     destination: proposal.destination,
     childAccount: proposal.childAccount,
     status,
-    invalidReason: null, // TODO: add it back to schema?
+    invalidReason,
     approvalCount: proposal._count.approvals,
     createdAtBlock: proposal.createdAtBlock,
     executedAtBlock: execution?.blockHeight ?? null,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -3,8 +3,9 @@ import { z } from 'zod';
 import { PublicKey, fetchAccount } from 'o1js';
 
 import { prisma } from './db.js';
-import type { MinaGuardIndexer } from './indexer.js';
+import { deleteContract, type MinaGuardIndexer } from './indexer.js';
 import type { BackendConfig } from './config.js';
+import { fetchLatestBlockHeight, fetchVerificationKeyHash } from './mina-client.js';
 import { serializeProposalRecord } from './proposal-record.js';
 import {
   acquireLightnetAccount,
@@ -63,17 +64,17 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
   /** Returns current polling indexer status and latest sync metadata. */
   router.get('/api/indexer/status', safe(async (_req, res) => {
-    res.json(indexer.getStatus());
+    res.json({ ...indexer.getStatus(), indexerMode: config?.indexerMode ?? 'full' });
   }));
 
-  /** Lists tracked contracts with owner/proposal aggregate counts. */
+  /** Lists tracked contracts with derived config + aggregate counts. */
   router.get('/api/contracts', safe(async (_req, res) => {
     const contracts = await prisma.contract.findMany({
+      where: { ready: true },
       orderBy: { discoveredAt: 'desc' },
       include: {
         _count: {
           select: {
-            owners: true,
             proposals: true,
             events: true,
           },
@@ -81,7 +82,17 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
       },
     });
 
-    res.json(contracts);
+    const enriched = await Promise.all(
+      contracts.map(async (contract) => {
+        const [config, ownerCount] = await Promise.all([
+          latestContractConfig(contract.id),
+          currentOwnerCount(contract.id),
+        ]);
+        return decorateContract(contract, config, ownerCount);
+      })
+    );
+
+    res.json(enriched);
   }));
 
   /** Returns one tracked contract by base58 address. */
@@ -93,7 +104,6 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
       include: {
         _count: {
           select: {
-            owners: true,
             proposals: true,
             events: true,
           },
@@ -101,12 +111,16 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
       },
     });
 
-    if (!contract) {
+    if (!contract || !contract.ready) {
       res.status(404).json({ error: 'Contract not found' });
       return;
     }
 
-    res.json(contract);
+    const [config, ownerCount] = await Promise.all([
+      latestContractConfig(contract.id),
+      currentOwnerCount(contract.id),
+    ]);
+    res.json(decorateContract(contract, config, ownerCount));
   }));
 
   /** Lists child contracts (subaccounts) whose `parent` points at the given address. */
@@ -114,11 +128,18 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
     const { address } = addressParamsSchema.parse(req.params) as AddressParams;
 
     const children = await prisma.contract.findMany({
-      where: { parent: address },
+      where: { parent: address, ready: true },
       orderBy: { discoveredAt: 'asc' },
     });
 
-    res.json(children);
+    const enriched = await Promise.all(
+      children.map(async (child) => {
+        const config = await latestContractConfig(child.id);
+        return decorateContract(child, config, null);
+      })
+    );
+
+    res.json(enriched);
   }));
 
   /** Lists owner records for a contract with optional active-state filter. */
@@ -132,22 +153,15 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
       const contract = await prisma.contract.findUnique({
         where: { address },
-        select: { id: true },
+        select: { id: true, ready: true },
       });
 
-      if (!contract) {
+      if (!contract || !contract.ready) {
         res.status(404).json({ error: 'Contract not found' });
         return;
       }
 
-      const owners = await prisma.owner.findMany({
-        where: {
-          contractId: contract.id,
-          ...(active === undefined ? {} : { active }),
-        },
-        orderBy: [{ index: 'asc' }, { createdAt: 'asc' }],
-      });
-
+      const owners = await listOwners(contract.id, active);
       res.json(owners);
     })
   );
@@ -163,30 +177,46 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
       const contract = await prisma.contract.findUnique({
         where: { address },
-        select: { id: true },
+        select: { id: true, ready: true },
       });
 
-      if (!contract) {
+      if (!contract || !contract.ready) {
         res.status(404).json({ error: 'Contract not found' });
         return;
       }
 
+      const latestHeight = indexer.getStatus().latestChainHeight;
+
+      // Status is derived from ProposalExecution existence + expiry vs
+      // latestHeight, so filtering happens in Prisma via relation filters
+      // where possible, and in memory for the expiry-based cases.
+      const dbFilter = buildProposalStatusWhere(status);
+
       const proposals = await prisma.proposal.findMany({
         where: {
           contractId: contract.id,
-          ...(status ? { status } : {}),
+          ...dbFilter,
         },
         include: {
-          receivers: {
-            orderBy: { idx: 'asc' },
-          },
+          receivers: { orderBy: { idx: 'asc' } },
+          executions: { select: { blockHeight: true, txHash: true } },
+          _count: { select: { approvals: true } },
         },
         orderBy: [{ createdAtBlock: 'desc' }, { createdAt: 'desc' }],
-        take: limit,
-        skip: offset,
+        // Over-fetch when status requires in-memory filtering; clamp after.
+        take: needsInMemoryStatusFilter(status) ? undefined : limit,
+        skip: needsInMemoryStatusFilter(status) ? undefined : offset,
       });
 
-      res.json(proposals.map((proposal) => serializeProposalRecord(proposal)));
+      const serialized = proposals.map((p) => serializeProposalRecord(p, latestHeight));
+      const filtered = status
+        ? serialized.filter((s) => s.status === status)
+        : serialized;
+      const paged = needsInMemoryStatusFilter(status)
+        ? filtered.slice(offset, offset + limit)
+        : filtered;
+
+      res.json(paged);
     })
   );
 
@@ -199,10 +229,10 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
       const contract = await prisma.contract.findUnique({
         where: { address },
-        select: { id: true },
+        select: { id: true, ready: true },
       });
 
-      if (!contract) {
+      if (!contract || !contract.ready) {
         res.status(404).json({ error: 'Contract not found' });
         return;
       }
@@ -215,9 +245,9 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
           },
         },
         include: {
-          receivers: {
-            orderBy: { idx: 'asc' },
-          },
+          receivers: { orderBy: { idx: 'asc' } },
+          executions: { select: { blockHeight: true, txHash: true } },
+          _count: { select: { approvals: true } },
         },
       });
 
@@ -226,7 +256,8 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
         return;
       }
 
-      res.json(serializeProposalRecord(proposal));
+      const latestHeight = indexer.getStatus().latestChainHeight;
+      res.json(serializeProposalRecord(proposal, latestHeight));
     })
   );
 
@@ -239,10 +270,10 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
       const contract = await prisma.contract.findUnique({
         where: { address },
-        select: { id: true },
+        select: { id: true, ready: true },
       });
 
-      if (!contract) {
+      if (!contract || !contract.ready) {
         res.status(404).json({ error: 'Contract not found' });
         return;
       }
@@ -282,10 +313,10 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
       const contract = await prisma.contract.findUnique({
         where: { address },
-        select: { id: true },
+        select: { id: true, ready: true },
       });
 
-      if (!contract) {
+      if (!contract || !contract.ready) {
         res.status(404).json({ error: 'Contract not found' });
         return;
       }
@@ -401,6 +432,129 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
     }
   }));
 
+  /**
+   * Subscribes the indexer to a contract address. Lite mode only — full
+   * mode auto-discovers contracts on every tick. Idempotent: re-subscribing
+   * an already-tracked address returns the existing row unchanged (the
+   * original discoveredAtBlock is preserved).
+   *
+   * The address is not required to be deployed on-chain yet. The contract
+   * row is inserted with ready=false; the indexer tick's unready-rescan
+   * loop then scans [discoveredAtBlock, latestHeight] every tick until
+   * events are ingested and ready flips to true.
+   *
+   * Body: { address: string, fromBlock?: number }
+   *   - fromBlock, when supplied, sets discoveredAtBlock directly. Use
+   *     this for historical subscribes (e.g. fromBlock: 0 for full
+   *     history). When supplied, the address MUST already resolve to a
+   *     deployed zkApp on-chain — this path is the manual "add existing
+   *     account" flow, where a typo or wrong-network address would
+   *     otherwise silently backfill an empty address forever.
+   *   - When omitted, discoveredAtBlock defaults to
+   *     `latestHeight - SUBSCRIBE_MARGIN` so a block landing between
+   *     submitTx and this handler doesn't push the lower bound past the
+   *     deploy. The zkApp existence check is intentionally skipped here:
+   *     the auto-subscribe after a fresh deploy races the tx landing
+   *     on-chain.
+   */
+  router.post('/api/subscribe', safe(async (req, res) => {
+    if (config?.indexerMode !== 'lite') {
+      res.status(404).json({ error: 'Subscribe API is only available in lite mode' });
+      return;
+    }
+
+    const { address, fromBlock } = req.body as {
+      address?: string;
+      fromBlock?: unknown;
+    };
+    if (!address || typeof address !== 'string') {
+      res.status(400).json({ error: 'address is required' });
+      return;
+    }
+
+    try {
+      PublicKey.fromBase58(address);
+    } catch {
+      res.status(400).json({ error: 'Invalid Mina public key' });
+      return;
+    }
+
+    let fromBlockNum: number | null = null;
+    if (fromBlock !== undefined) {
+      if (
+        typeof fromBlock !== 'number' ||
+        !Number.isInteger(fromBlock) ||
+        fromBlock < 0
+      ) {
+        res.status(400).json({ error: 'fromBlock must be a non-negative integer' });
+        return;
+      }
+      fromBlockNum = fromBlock;
+    }
+
+    const existing = await prisma.contract.findUnique({ where: { address } });
+    if (existing) {
+      res.json(existing);
+      return;
+    }
+
+    if (fromBlockNum !== null) {
+      const verificationKeyHash = await fetchVerificationKeyHash(address);
+      if (!verificationKeyHash) {
+        res.status(404).json({ error: 'Account not found on-chain or not a zkApp' });
+        return;
+      }
+    }
+
+    // Safety margin on the default path: the UI calls subscribe right
+    // after submitTx, but a block may land between submitTx and this
+    // handler's fetchLatestBlockHeight. Without the margin, the unready
+    // rescan's lower bound could sit one block past the deploy and
+    // permanently miss it. Mirrors DISCOVERY_MARGIN in tick().
+    const SUBSCRIBE_MARGIN = 5;
+    const discoveredAtBlock =
+      fromBlockNum ??
+      Math.max(0, (await fetchLatestBlockHeight(config)) - SUBSCRIBE_MARGIN);
+
+    const created = await prisma.contract.create({
+      data: { address, discoveredAtBlock },
+    });
+
+    res.json(created);
+  }));
+
+  /**
+   * Unsubscribes from a contract and deletes all of its tracked history
+   * (events, configs, memberships, proposals, approvals, executions).
+   * Lite mode only.
+   */
+  router.delete('/api/subscribe/:address', addressParamsMiddleware, safe(async (req, res) => {
+    if (config?.indexerMode !== 'lite') {
+      res.status(404).json({ error: 'Subscribe API is only available in lite mode' });
+      return;
+    }
+
+    const { address } = addressParamsSchema.parse(req.params) as AddressParams;
+
+    const contract = await prisma.contract.findUnique({ where: { address } });
+    if (!contract) {
+      res.status(404).json({ error: 'Contract not found' });
+      return;
+    }
+
+    // Cascade to children: the MinaGuard hierarchy is capped at two levels, so
+    // one layer of child deletion is sufficient (no recursion needed).
+    const children = await prisma.contract.findMany({
+      where: { parent: contract.address },
+      select: { id: true },
+    });
+    for (const child of children) {
+      await deleteContract(child.id);
+    }
+    await deleteContract(contract.id);
+    res.json({ ok: true });
+  }));
+
   router.use((error: unknown, req: any, res: any, _next: any) => {
     const requestId = getRequestId(res);
     console.error(
@@ -470,4 +624,97 @@ function compactMeta(input: Record<string, unknown>): Record<string, unknown> {
       return true;
     })
   );
+}
+
+/** Returns the latest ContractConfig snapshot for a contract, or null. */
+async function latestContractConfig(contractId: number) {
+  return prisma.contractConfig.findFirst({
+    where: { contractId },
+    orderBy: [{ validFromBlock: 'desc' }, { eventOrder: 'desc' }],
+  });
+}
+
+/** Returns the count of currently-active owners for a contract. */
+async function currentOwnerCount(contractId: number): Promise<number> {
+  const owners = await listOwners(contractId, true);
+  return owners.length;
+}
+
+type ContractRow = { id: number; address: string; parent: string | null };
+
+/** Merges a Contract row with its latest config snapshot and an owners count for the API shape. */
+function decorateContract<T extends ContractRow & { _count?: Record<string, number> }>(
+  contract: T,
+  config: Awaited<ReturnType<typeof latestContractConfig>>,
+  ownerCount: number | null,
+) {
+  const { _count, ...rest } = contract;
+  return {
+    ...rest,
+    threshold: config?.threshold ?? null,
+    numOwners: config?.numOwners ?? null,
+    configNonce: config?.configNonce ?? null,
+    delegate: config?.delegate ?? null,
+    childMultiSigEnabled: config?.childMultiSigEnabled ?? null,
+    ownersCommitment: config?.ownersCommitment ?? null,
+    networkId: config?.networkId ?? null,
+    ...(_count !== undefined || ownerCount !== null
+      ? {
+          _count: {
+            ...(_count ?? {}),
+            ...(ownerCount !== null ? { owners: ownerCount } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+/**
+ * Returns current owners for a contract by collapsing OwnerMembership history
+ * to the latest row per address. If `active` is defined, filters to `added`
+ * (true) or `removed` (false); otherwise returns every address ever present.
+ */
+async function listOwners(contractId: number, active?: boolean) {
+  const memberships = await prisma.ownerMembership.findMany({
+    where: { contractId },
+    orderBy: [{ validFromBlock: 'desc' }, { eventOrder: 'desc' }, { id: 'desc' }],
+  });
+
+  const latestByAddress = new Map<string, typeof memberships[number]>();
+  for (const m of memberships) {
+    if (!latestByAddress.has(m.address)) latestByAddress.set(m.address, m);
+  }
+
+  const shaped = [...latestByAddress.values()]
+    .map((m) => ({
+      contractId: m.contractId,
+      address: m.address,
+      index: m.index,
+      ownerHash: m.ownerHash,
+      active: m.action === 'added',
+      createdAt: m.createdAt,
+    }))
+    .sort((a, b) => {
+      const ai = a.index ?? Number.MAX_SAFE_INTEGER;
+      const bi = b.index ?? Number.MAX_SAFE_INTEGER;
+      if (ai !== bi) return ai - bi;
+      return a.createdAt.getTime() - b.createdAt.getTime();
+    });
+
+  if (active === undefined) return shaped;
+  return shaped.filter((o) => o.active === active);
+}
+
+/**
+ * Maps a status filter to a Prisma `where` fragment where possible. Only
+ * `executed` is expressible directly via the `executions` relation; `pending`
+ * and `expired` require an additional in-memory pass using `latestHeight`.
+ */
+function buildProposalStatusWhere(status: string | undefined) {
+  if (status === 'executed') return { executions: { some: {} } };
+  return {};
+}
+
+function needsInMemoryStatusFilter(status: string | undefined): boolean {
+  return status === 'pending' || status === 'expired';
 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -6,7 +6,7 @@ import { prisma } from './db.js';
 import { deleteContract, type MinaGuardIndexer } from './indexer.js';
 import type { BackendConfig } from './config.js';
 import { fetchLatestBlockHeight, fetchVerificationKeyHash } from './mina-client.js';
-import { serializeProposalRecord } from './proposal-record.js';
+import { serializeProposalRecord, type ContractState } from './proposal-record.js';
 import {
   acquireLightnetAccount,
   computeFundingAmount,
@@ -187,9 +187,9 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
 
       const latestHeight = indexer.getStatus().latestChainHeight;
 
-      // Status is derived from ProposalExecution existence + expiry vs
-      // latestHeight, so filtering happens in Prisma via relation filters
-      // where possible, and in memory for the expiry-based cases.
+      // Status is derived at read time from ProposalExecution existence +
+      // expiry + nonce/config staleness vs current ContractConfig. The status
+      // filter passes through to in-memory filtering after serialization.
       const dbFilter = buildProposalStatusWhere(status);
 
       const proposals = await prisma.proposal.findMany({
@@ -208,7 +208,17 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
         skip: needsInMemoryStatusFilter(status) ? undefined : offset,
       });
 
-      const serialized = proposals.map((p) => serializeProposalRecord(p, latestHeight));
+      const parentState = toContractState(await latestContractConfig(contract.id));
+      const childStateByAddress = await buildChildStateMap(proposals);
+
+      const serialized = proposals.map((p) =>
+        serializeProposalRecord(
+          p,
+          latestHeight,
+          parentState,
+          p.childAccount ? childStateByAddress.get(p.childAccount) ?? null : null,
+        ),
+      );
       const filtered = status
         ? serialized.filter((s) => s.status === status)
         : serialized;
@@ -257,7 +267,13 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
       }
 
       const latestHeight = indexer.getStatus().latestChainHeight;
-      res.json(serializeProposalRecord(proposal, latestHeight));
+      const parentState = toContractState(await latestContractConfig(contract.id));
+      const childState =
+        proposal.destination === 'remote' && proposal.txType !== '5' && proposal.childAccount
+          ? await resolveChildState(proposal.childAccount)
+          : null;
+
+      res.json(serializeProposalRecord(proposal, latestHeight, parentState, childState));
     })
   );
 
@@ -634,6 +650,69 @@ async function latestContractConfig(contractId: number) {
   });
 }
 
+/** Projects a ContractConfig row (or null) to the slim shape the proposal
+ *  invalidation check consumes. */
+function toContractState(
+  config: Awaited<ReturnType<typeof latestContractConfig>>,
+): ContractState | null {
+  if (!config) return null;
+  return {
+    nonce: config.nonce,
+    parentNonce: config.parentNonce,
+    configNonce: config.configNonce,
+  };
+}
+
+/** One-shot lookup of a child's current state by address, used by the
+ *  single-proposal route. */
+async function resolveChildState(address: string): Promise<ContractState | null> {
+  const child = await prisma.contract.findUnique({
+    where: { address },
+    select: { id: true },
+  });
+  if (!child) return null;
+  return toContractState(await latestContractConfig(child.id));
+}
+
+/** Batches child-state lookups for a list of proposals. Only REMOTE
+ *  non-CREATE_CHILD proposals target a child guard; the rest map to null. */
+async function buildChildStateMap(
+  proposals: ReadonlyArray<{ destination: string | null; txType: string | null; childAccount: string | null }>,
+): Promise<Map<string, ContractState>> {
+  const childAddresses = [
+    ...new Set(
+      proposals
+        .filter((p) => p.destination === 'remote' && p.txType !== '5' && p.childAccount)
+        .map((p) => p.childAccount as string),
+    ),
+  ];
+  if (childAddresses.length === 0) return new Map();
+
+  const childContracts = await prisma.contract.findMany({
+    where: { address: { in: childAddresses } },
+    select: { id: true, address: true },
+  });
+  if (childContracts.length === 0) return new Map();
+
+  const configs = await prisma.contractConfig.findMany({
+    where: { contractId: { in: childContracts.map((c) => c.id) } },
+    orderBy: [{ validFromBlock: 'desc' }, { eventOrder: 'desc' }],
+  });
+
+  // Pick the first (latest) row per contract — configs is already sorted desc.
+  const latestByContractId = new Map<number, typeof configs[number]>();
+  for (const row of configs) {
+    if (!latestByContractId.has(row.contractId)) latestByContractId.set(row.contractId, row);
+  }
+
+  const result = new Map<string, ContractState>();
+  for (const child of childContracts) {
+    const state = toContractState(latestByContractId.get(child.id) ?? null);
+    if (state) result.set(child.address, state);
+  }
+  return result;
+}
+
 /** Returns the count of currently-active owners for a contract. */
 async function currentOwnerCount(contractId: number): Promise<number> {
   const owners = await listOwners(contractId, true);
@@ -653,6 +732,8 @@ function decorateContract<T extends ContractRow & { _count?: Record<string, numb
     ...rest,
     threshold: config?.threshold ?? null,
     numOwners: config?.numOwners ?? null,
+    nonce: config?.nonce ?? null,
+    parentNonce: config?.parentNonce ?? null,
     configNonce: config?.configNonce ?? null,
     delegate: config?.delegate ?? null,
     childMultiSigEnabled: config?.childMultiSigEnabled ?? null,
@@ -707,8 +788,9 @@ async function listOwners(contractId: number, active?: boolean) {
 
 /**
  * Maps a status filter to a Prisma `where` fragment where possible. Only
- * `executed` is expressible directly via the `executions` relation; `pending`
- * and `expired` require an additional in-memory pass using `latestHeight`.
+ * `executed` is expressible directly via the `executions` relation; `pending`,
+ * `expired`, and `invalidated` require an additional in-memory pass (they
+ * depend on `latestHeight` and the latest ContractConfig snapshot).
  */
 function buildProposalStatusWhere(status: string | undefined) {
   if (status === 'executed') return { executions: { some: {} } };
@@ -716,5 +798,5 @@ function buildProposalStatusWhere(status: string | undefined) {
 }
 
 function needsInMemoryStatusFilter(status: string | undefined): boolean {
-  return status === 'pending' || status === 'expired';
+  return status === 'pending' || status === 'expired' || status === 'invalidated';
 }

--- a/backend/src/tests/indexer-autosubscribe.test.ts
+++ b/backend/src/tests/indexer-autosubscribe.test.ts
@@ -1,0 +1,478 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PrivateKey } from 'o1js';
+import type { BackendConfig } from '../config.js';
+import { prisma } from '../db.js';
+import { MinaGuardIndexer } from '../indexer.js';
+import * as minaClient from '../mina-client.js';
+
+const liteConfig = {
+  minaEndpoint: 'http://stub',
+  minaFallbackEndpoint: null,
+  archiveEndpoint: 'http://stub',
+  archiveFallbackEndpoint: null,
+  indexPollIntervalMs: 1000,
+  indexStartHeight: 0,
+  minaguardVkHash: null,
+  lightnetAccountManager: null,
+  indexerMode: 'lite' as const,
+} as unknown as BackendConfig;
+
+const fullConfig = { ...liteConfig, indexerMode: 'full' as const } as BackendConfig;
+
+async function clearAll() {
+  await prisma.approval.deleteMany();
+  await prisma.proposalExecution.deleteMany();
+  await prisma.proposalReceiver.deleteMany();
+  await prisma.eventRaw.deleteMany();
+  await prisma.proposal.deleteMany();
+  await prisma.ownerMembership.deleteMany();
+  await prisma.contractConfig.deleteMany();
+  await prisma.contract.deleteMany();
+  await prisma.blockHeader.deleteMany();
+  await prisma.indexerCursor.deleteMany();
+}
+
+async function setCursor(height: number) {
+  await prisma.indexerCursor.upsert({
+    where: { key: 'indexed_height' },
+    create: { key: 'indexed_height', value: String(height) },
+    update: { value: String(height) },
+  });
+}
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+afterAll(async () => {
+  await clearAll();
+  await prisma.$disconnect();
+});
+
+describe('backfillContract window', () => {
+  test('lite mode backfills from config.indexStartHeight', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({ data: { address, ready: false } });
+    await setCursor(1000);
+
+    const calls: Array<{ from: number; to: number }> = [];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (
+        _addr: string,
+        from: number,
+        to: number,
+      ) => {
+        calls.push({ from, to });
+        return [];
+      },
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    await indexer.backfillContract(contract.id, address);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].from).toBe(0);
+    expect(calls[0].to).toBe(1000);
+  });
+
+  test('full mode backfills from indexedHeight - 300', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({ data: { address, ready: false } });
+    await setCursor(1000);
+
+    const calls: Array<{ from: number; to: number }> = [];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (
+        _addr: string,
+        from: number,
+        to: number,
+      ) => {
+        calls.push({ from, to });
+        return [];
+      },
+    }));
+
+    const indexer = new MinaGuardIndexer(fullConfig);
+    await indexer.backfillContract(contract.id, address);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].from).toBe(700);
+    expect(calls[0].to).toBe(1000);
+  });
+
+  test('leaves ready=false when backfill ingested no events (subscribe-before-deploy)', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({ data: { address, ready: false } });
+    await setCursor(500);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async () => [],
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    await indexer.backfillContract(contract.id, address);
+
+    const updated = await prisma.contract.findUniqueOrThrow({ where: { id: contract.id } });
+    expect(updated.ready).toBe(false);
+  });
+
+  test('flips ready=true when backfill ingests at least one event', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({ data: { address, ready: false } });
+    await setCursor(100);
+
+    // Any MinaGuard event is proof the contract was initialized on-chain.
+    // Use an execution event because it's the simplest to stub without
+    // triggering the deeper setup/ownerChange/etc. state machinery.
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async () => [makeExecutionEvent('hash-x', 50)],
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    await indexer.backfillContract(contract.id, address);
+
+    const updated = await prisma.contract.findUniqueOrThrow({ where: { id: contract.id } });
+    expect(updated.ready).toBe(true);
+  });
+
+  test('does not touch ready when nothing to backfill (indexedHeight <= backfillFrom)', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({ data: { address, ready: false } });
+    // indexedHeight == 0 == indexStartHeight, so no network call and no
+    // sync should run; readiness stays at its inserted value.
+    await setCursor(0);
+
+    let called = false;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async () => {
+        called = true;
+        return [];
+      },
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    await indexer.backfillContract(contract.id, address);
+
+    expect(called).toBe(false);
+    const updated = await prisma.contract.findUniqueOrThrow({ where: { id: contract.id } });
+    expect(updated.ready).toBe(false);
+  });
+});
+
+describe('eager child auto-subscribe on CREATE_CHILD proposal', () => {
+  async function seedParent(parentAddress: string) {
+    return prisma.contract.create({
+      data: { address: parentAddress, ready: true },
+    });
+  }
+
+  test('lite mode: eager-subscribes child on CREATE_CHILD proposal event', async () => {
+    const parentAddress = PrivateKey.random().toPublicKey().toBase58();
+    const childAddress = PrivateKey.random().toPublicKey().toBase58();
+    const proposalHash = '42';
+    await seedParent(parentAddress);
+    await setCursor(100);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (addr: string) =>
+        addr === parentAddress
+          ? [makeCreateChildProposalEvent(proposalHash, childAddress, 20)]
+          : [],
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    const parent = await prisma.contract.findUniqueOrThrow({ where: { address: parentAddress } });
+    await indexer.backfillContract(parent.id, parentAddress);
+
+    const child = await prisma.contract.findUnique({ where: { address: childAddress } });
+    expect(child).not.toBeNull();
+    expect(child?.parent).toBe(parentAddress);
+    // discoveredAtBlock is the propose-event block height. The child's
+    // deploy and its own setup events land at or after this block, so
+    // the rescan's lower bound stays below them.
+    expect(child?.discoveredAtBlock).toBe(20);
+    expect(child?.ready).toBe(false);
+  });
+
+  test('full mode: does NOT eager-subscribe children on proposal', async () => {
+    const parentAddress = PrivateKey.random().toPublicKey().toBase58();
+    const childAddress = PrivateKey.random().toPublicKey().toBase58();
+    const proposalHash = '43';
+    await seedParent(parentAddress);
+    await setCursor(100);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (addr: string) =>
+        addr === parentAddress
+          ? [makeCreateChildProposalEvent(proposalHash, childAddress, 20)]
+          : [],
+    }));
+
+    const indexer = new MinaGuardIndexer(fullConfig);
+    const parent = await prisma.contract.findUniqueOrThrow({ where: { address: parentAddress } });
+    await indexer.backfillContract(parent.id, parentAddress);
+
+    const child = await prisma.contract.findUnique({ where: { address: childAddress } });
+    expect(child).toBeNull();
+  });
+
+  test('idempotent: running twice does not create a duplicate child', async () => {
+    const parentAddress = PrivateKey.random().toPublicKey().toBase58();
+    const childAddress = PrivateKey.random().toPublicKey().toBase58();
+    const proposalHash = '44';
+    await seedParent(parentAddress);
+    await setCursor(100);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (addr: string) =>
+        addr === parentAddress
+          ? [makeCreateChildProposalEvent(proposalHash, childAddress, 20)]
+          : [],
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    const parent = await prisma.contract.findUniqueOrThrow({ where: { address: parentAddress } });
+    await indexer.backfillContract(parent.id, parentAddress);
+    await indexer.backfillContract(parent.id, parentAddress);
+
+    const childCount = await prisma.contract.count({ where: { address: childAddress } });
+    expect(childCount).toBe(1);
+  });
+
+  test('non-CREATE_CHILD proposals do not eager-subscribe anything', async () => {
+    const parentAddress = PrivateKey.random().toPublicKey().toBase58();
+    await seedParent(parentAddress);
+    await setCursor(100);
+
+    // txType='1' (addOwner) should not trigger any child insertion.
+    const proposalHash = '99';
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (addr: string) =>
+        addr === parentAddress
+          ? [makeAddOwnerProposalEvent(proposalHash, 20)]
+          : [],
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+    const parent = await prisma.contract.findUniqueOrThrow({ where: { address: parentAddress } });
+    await indexer.backfillContract(parent.id, parentAddress);
+
+    // Only the parent should exist; no eager child insert for governance.
+    const count = await prisma.contract.count();
+    expect(count).toBe(1);
+  });
+
+  test('REMOTE path records execution once child is tracked (end-to-end)', async () => {
+    // Simulates the full subaccount flow: parent emits CREATE_CHILD proposal
+    // (eager-inserts child), then the child eventually emits an execution
+    // event. applyExecutionEvent's REMOTE path must walk back to the parent
+    // and upsert ProposalExecution so the proposal flips to executed.
+    const parentAddress = PrivateKey.random().toPublicKey().toBase58();
+    const childAddress = PrivateKey.random().toPublicKey().toBase58();
+    const proposalHash = '77';
+    await seedParent(parentAddress);
+    await setCursor(100);
+
+    const eventsByAddress: Record<string, unknown[]> = {
+      [parentAddress]: [makeCreateChildProposalEvent(proposalHash, childAddress, 20)],
+      [childAddress]: [makeExecutionEvent(proposalHash, 25)],
+    };
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async (addr: string) => eventsByAddress[addr] ?? [],
+    }));
+
+    const indexer = new MinaGuardIndexer(liteConfig);
+
+    // Step 1: sync parent → eager-inserts child + creates proposal row.
+    const parent = await prisma.contract.findUniqueOrThrow({ where: { address: parentAddress } });
+    await indexer.backfillContract(parent.id, parentAddress);
+
+    const child = await prisma.contract.findUniqueOrThrow({ where: { address: childAddress } });
+    expect(child.parent).toBe(parentAddress);
+
+    // Step 2: sync child → ingests execution event; REMOTE path walks back
+    // to parent's proposal and upserts ProposalExecution.
+    await indexer.backfillContract(child.id, childAddress);
+
+    const proposal = await prisma.proposal.findUniqueOrThrow({
+      where: {
+        contractId_proposalHash: { contractId: parent.id, proposalHash },
+      },
+      include: { executions: true },
+    });
+    expect(proposal.executions).toHaveLength(1);
+    expect(proposal.executions[0].blockHeight).toBe(25);
+  });
+});
+
+function makeExecutionEvent(proposalHash: string, blockHeight: number) {
+  return {
+    type: 'execution',
+    event: { proposalHash },
+    blockHeight,
+    blockHash: `h${blockHeight}`,
+    parentHash: `h${blockHeight - 1}`,
+    txHash: `tx-${proposalHash}`,
+  };
+}
+
+function makeCreateChildProposalEvent(
+  proposalHash: string,
+  childAddress: string,
+  blockHeight: number,
+) {
+  return {
+    type: 'proposal',
+    event: {
+      proposalHash,
+      txType: '5',
+      childAccount: childAddress,
+      // Other proposal fields left as nullish — applyProposalEvent only
+      // reads the fields that matter for this test.
+    },
+    blockHeight,
+    blockHash: `h${blockHeight}`,
+    parentHash: `h${blockHeight - 1}`,
+    txHash: `tx-propose-${proposalHash}`,
+  };
+}
+
+function makeAddOwnerProposalEvent(proposalHash: string, blockHeight: number) {
+  return {
+    type: 'proposal',
+    event: {
+      proposalHash,
+      txType: '1',
+    },
+    blockHeight,
+    blockHash: `h${blockHeight}`,
+    parentHash: `h${blockHeight - 1}`,
+    txHash: `tx-propose-${proposalHash}`,
+  };
+}
+
+describe('tick: rescanUnreadyContracts', () => {
+  async function runSingleTick(config: BackendConfig): Promise<MinaGuardIndexer> {
+    const indexer = new MinaGuardIndexer(config);
+    await indexer.start();
+    indexer.stop();
+    return indexer;
+  }
+
+  test('unready contract with no archive events stays unready', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({
+      data: { address, ready: false, discoveredAtBlock: 50 },
+    });
+    await setCursor(100);
+
+    let callCount = 0;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 100,
+      fetchBestChainHeaders: async () => [],
+      fetchDecodedContractEvents: async () => {
+        callCount += 1;
+        return [];
+      },
+    }));
+
+    await runSingleTick(liteConfig);
+
+    const updated = await prisma.contract.findUniqueOrThrow({ where: { id: contract.id } });
+    expect(updated.ready).toBe(false);
+    // The rescan should have queried events for the unready contract at
+    // least once during the tick.
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  test('unready contract flips to ready on tick once events are present', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const contract = await prisma.contract.create({
+      data: { address, ready: false, discoveredAtBlock: 50 },
+    });
+    await setCursor(100);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 100,
+      fetchBestChainHeaders: async () => [],
+      // Return a MinaGuard execution event for the unready contract's
+      // address — any event is proof the contract was initialized.
+      fetchDecodedContractEvents: async (_addr: string, from: number) => {
+        if (from <= 60) return [makeExecutionEvent('rescan-hash', 60)];
+        return [];
+      },
+    }));
+
+    await runSingleTick(liteConfig);
+
+    const updated = await prisma.contract.findUniqueOrThrow({ where: { id: contract.id } });
+    expect(updated.ready).toBe(true);
+  });
+
+  test('uses discoveredAtBlock as the lower bound of the rescan range', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    await prisma.contract.create({
+      data: { address, ready: false, discoveredAtBlock: 77 },
+    });
+    await setCursor(100);
+
+    const rescanRanges: Array<{ from: number; to: number }> = [];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 100,
+      fetchBestChainHeaders: async () => [],
+      fetchDecodedContractEvents: async (_addr: string, from: number, to: number) => {
+        rescanRanges.push({ from, to });
+        return [];
+      },
+    }));
+
+    await runSingleTick(liteConfig);
+
+    // The rescan-path call is the one with from === discoveredAtBlock.
+    const rescan = rescanRanges.find((r) => r.from === 77);
+    expect(rescan).toBeDefined();
+    expect(rescan?.to).toBe(100);
+  });
+
+  test('skips contracts whose discoveredAtBlock is above latestHeight', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    await prisma.contract.create({
+      data: { address, ready: false, discoveredAtBlock: 9999 },
+    });
+    await setCursor(100);
+
+    const calls: string[] = [];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 100,
+      fetchBestChainHeaders: async () => [],
+      fetchDecodedContractEvents: async (addr: string) => {
+        calls.push(addr);
+        return [];
+      },
+    }));
+
+    await runSingleTick(liteConfig);
+
+    // The unready contract should not have been queried: its lower bound
+    // sits above the chain tip, so there's nothing to rescan yet.
+    expect(calls).not.toContain(address);
+  });
+});

--- a/backend/src/tests/indexer-reorg.test.ts
+++ b/backend/src/tests/indexer-reorg.test.ts
@@ -1,0 +1,506 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PrivateKey } from 'o1js';
+import { prisma } from '../db.js';
+import { MinaGuardIndexer, detectAndRollbackReorg, rollbackAboveFork } from '../indexer.js';
+import * as minaClient from '../mina-client.js';
+import type { ChainEvent } from '../mina-client.js';
+import type { BackendConfig } from '../config.js';
+
+const stubConfig = {
+  minaEndpoint: 'http://stub',
+  minaFallbackEndpoint: null,
+  archiveEndpoint: 'http://stub',
+  archiveFallbackEndpoint: null,
+  indexPollIntervalMs: 1000,
+  indexStartHeight: 0,
+  minaguardVkHash: null,
+  lightnetAccountManager: null,
+} as unknown as BackendConfig;
+
+async function clearAll() {
+  await prisma.approval.deleteMany();
+  await prisma.proposalExecution.deleteMany();
+  await prisma.proposalReceiver.deleteMany();
+  await prisma.eventRaw.deleteMany();
+  await prisma.proposal.deleteMany();
+  await prisma.ownerMembership.deleteMany();
+  await prisma.contractConfig.deleteMany();
+  await prisma.contract.deleteMany();
+  await prisma.blockHeader.deleteMany();
+  await prisma.indexerCursor.deleteMany();
+}
+
+async function seedHeaders(chain: Array<{ height: number; blockHash: string; parentHash: string }>) {
+  for (const h of chain) {
+    await prisma.blockHeader.create({ data: h });
+  }
+}
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+afterAll(async () => {
+  await clearAll();
+  await prisma.$disconnect();
+});
+
+describe('rollbackAboveFork', () => {
+  test('deletes rows strictly above fork across every per-block table', async () => {
+    const contract = await prisma.contract.create({
+      data: { address: PrivateKey.random().toPublicKey().toBase58(), discoveredAtBlock: 5 },
+    });
+    // Contract discovered above fork should be deleted; keep a reference by
+    // address rather than an unused variable so the deletion is self-evident.
+    const orphanAddress = PrivateKey.random().toPublicKey().toBase58();
+    await prisma.contract.create({
+      data: { address: orphanAddress, discoveredAtBlock: 20 },
+    });
+
+    // Seed one row per height-keyed table below and above the fork.
+    await prisma.blockHeader.createMany({
+      data: [
+        { height: 5, blockHash: 'h5', parentHash: 'h4' },
+        { height: 10, blockHash: 'h10', parentHash: 'h9' },
+        { height: 15, blockHash: 'h15', parentHash: 'h14' },
+      ],
+    });
+    await prisma.eventRaw.createMany({
+      data: [
+        { contractId: contract.id, blockHeight: 5, eventType: 'setup', payload: '{}', fingerprint: 'rollback-ev-5' },
+        { contractId: contract.id, blockHeight: 15, eventType: 'proposal', payload: '{}', fingerprint: 'rollback-ev-15' },
+      ],
+    });
+    await prisma.contractConfig.createMany({
+      data: [
+        { contractId: contract.id, validFromBlock: 5, threshold: 2 },
+        { contractId: contract.id, validFromBlock: 15, threshold: 3 },
+      ],
+    });
+    await prisma.ownerMembership.createMany({
+      data: [
+        { contractId: contract.id, address: 'addr1', action: 'added', validFromBlock: 5 },
+        { contractId: contract.id, address: 'addr1', action: 'removed', validFromBlock: 15 },
+      ],
+    });
+    await prisma.proposal.createMany({
+      data: [
+        { contractId: contract.id, proposalHash: 'below', createdAtBlock: 5 },
+        { contractId: contract.id, proposalHash: 'above', createdAtBlock: 15 },
+      ],
+    });
+    const belowProposal = await prisma.proposal.findUniqueOrThrow({
+      where: { contractId_proposalHash: { contractId: contract.id, proposalHash: 'below' } },
+    });
+    await prisma.proposalExecution.create({
+      data: { proposalId: belowProposal.id, blockHeight: 15 },
+    });
+    await prisma.approval.createMany({
+      data: [
+        { proposalId: belowProposal.id, approver: 'a1', blockHeight: 6 },
+        { proposalId: belowProposal.id, approver: 'a2', blockHeight: 15 },
+      ],
+    });
+    await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '15' } });
+
+    await rollbackAboveFork(10);
+
+    expect(await prisma.blockHeader.findMany()).toHaveLength(2);
+    expect(await prisma.eventRaw.findMany()).toHaveLength(1);
+    expect(await prisma.contractConfig.findMany()).toHaveLength(1);
+    expect(await prisma.ownerMembership.findMany()).toHaveLength(1);
+    expect(await prisma.proposal.findMany()).toHaveLength(1);
+    expect(await prisma.proposalExecution.findMany()).toHaveLength(0);
+    expect(await prisma.approval.findMany()).toHaveLength(1);
+    // orphanContract.discoveredAtBlock=20 > 10, so it goes. contract was discovered at 5, stays.
+    expect((await prisma.contract.findMany()).map((c) => c.id)).toEqual([contract.id]);
+
+    const cursor = await prisma.indexerCursor.findUnique({ where: { key: 'indexed_height' } });
+    expect(cursor?.value).toBe('10');
+  });
+
+  test('is a no-op when nothing is above fork', async () => {
+    const contract = await prisma.contract.create({
+      data: { address: PrivateKey.random().toPublicKey().toBase58(), discoveredAtBlock: 5 },
+    });
+    await seedHeaders([
+      { height: 5, blockHash: 'h5', parentHash: 'h4' },
+      { height: 10, blockHash: 'h10', parentHash: 'h9' },
+    ]);
+    await prisma.eventRaw.create({
+      data: { contractId: contract.id, blockHeight: 5, eventType: 'setup', payload: '{}', fingerprint: 'noop-ev-5' },
+    });
+    await prisma.contractConfig.create({
+      data: { contractId: contract.id, validFromBlock: 5, threshold: 2 },
+    });
+    await prisma.ownerMembership.create({
+      data: { contractId: contract.id, address: 'addr-noop', action: 'added', validFromBlock: 5 },
+    });
+    await prisma.proposal.create({
+      data: { contractId: contract.id, proposalHash: 'p-noop', createdAtBlock: 5 },
+    });
+    await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '10' } });
+
+    await rollbackAboveFork(20);
+
+    // All rows below fork must survive untouched.
+    expect(await prisma.blockHeader.count()).toBe(2);
+    expect(await prisma.eventRaw.count()).toBe(1);
+    expect(await prisma.contractConfig.count()).toBe(1);
+    expect(await prisma.ownerMembership.count()).toBe(1);
+    expect(await prisma.proposal.count()).toBe(1);
+    expect(await prisma.contract.count()).toBe(1);
+    // Cursor is rewound to the fork even on a no-op rollback. This is the
+    // current rollback contract: caller passes a fork height, cursor reflects it.
+    const cursor = await prisma.indexerCursor.findUnique({ where: { key: 'indexed_height' } });
+    expect(cursor?.value).toBe('20');
+  });
+});
+
+describe('detectAndRollbackReorg', () => {
+  test('returns null when stored headers agree with chain', async () => {
+    await seedHeaders([
+      { height: 5, blockHash: 'h5', parentHash: 'h4' },
+      { height: 6, blockHash: 'h6', parentHash: 'h5' },
+    ]);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => [
+        { height: 5, blockHash: 'h5', parentHash: 'h4' },
+        { height: 6, blockHash: 'h6', parentHash: 'h5' },
+      ],
+    }));
+
+    const result = await detectAndRollbackReorg(stubConfig);
+    expect(result).toBeNull();
+  });
+
+  test('returns null when no stored headers overlap the chain window', async () => {
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => [
+        { height: 100, blockHash: 'h100', parentHash: 'h99' },
+      ],
+    }));
+
+    const result = await detectAndRollbackReorg(stubConfig);
+    expect(result).toBeNull();
+  });
+
+  test('detects single-block mismatch: fork is the last agreed height', async () => {
+    await seedHeaders([
+      { height: 5, blockHash: 'h5', parentHash: 'h4' },
+      { height: 6, blockHash: 'h6', parentHash: 'h5' },
+      { height: 7, blockHash: 'h7', parentHash: 'h6' },
+      { height: 8, blockHash: 'h8-old', parentHash: 'h7' },
+    ]);
+    await prisma.eventRaw.create({
+      data: { blockHeight: 8, eventType: 'x', payload: '{}', fingerprint: 'post-fork-event' },
+    });
+    await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '8' } });
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => [
+        { height: 5, blockHash: 'h5', parentHash: 'h4' },
+        { height: 6, blockHash: 'h6', parentHash: 'h5' },
+        { height: 7, blockHash: 'h7', parentHash: 'h6' },
+        { height: 8, blockHash: 'h8-NEW', parentHash: 'h7' },
+      ],
+    }));
+
+    const fork = await detectAndRollbackReorg(stubConfig);
+    expect(fork).toBe(7);
+
+    const remaining = await prisma.blockHeader.findMany({ orderBy: { height: 'asc' } });
+    expect(remaining.map((r) => r.height)).toEqual([5, 6, 7]);
+    expect(await prisma.eventRaw.findMany()).toHaveLength(0);
+    const cursor = await prisma.indexerCursor.findUnique({ where: { key: 'indexed_height' } });
+    expect(cursor?.value).toBe('7');
+  });
+
+  test('detects multi-block reorg: fork is the deepest agreed height, not tip-1', async () => {
+    // Stored: 5, 6 agree. 7, 8, 9 are all on the losing fork.
+    // Correct fork = 6. A naive "first mismatch - 1" would incorrectly return 8
+    // and leave the stale h7-old row in the DB.
+    await seedHeaders([
+      { height: 5, blockHash: 'h5', parentHash: 'h4' },
+      { height: 6, blockHash: 'h6', parentHash: 'h5' },
+      { height: 7, blockHash: 'h7-old', parentHash: 'h6' },
+      { height: 8, blockHash: 'h8-old', parentHash: 'h7-old' },
+      { height: 9, blockHash: 'h9-old', parentHash: 'h8-old' },
+    ]);
+    await prisma.eventRaw.createMany({
+      data: [
+        { blockHeight: 7, eventType: 'x', payload: '{}', fingerprint: 'ev-7' },
+        { blockHeight: 8, eventType: 'x', payload: '{}', fingerprint: 'ev-8' },
+        { blockHeight: 9, eventType: 'x', payload: '{}', fingerprint: 'ev-9' },
+      ],
+    });
+    await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '9' } });
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => [
+        { height: 5, blockHash: 'h5', parentHash: 'h4' },
+        { height: 6, blockHash: 'h6', parentHash: 'h5' },
+        { height: 7, blockHash: 'h7-NEW', parentHash: 'h6' },
+        { height: 8, blockHash: 'h8-NEW', parentHash: 'h7-NEW' },
+        { height: 9, blockHash: 'h9-NEW', parentHash: 'h8-NEW' },
+      ],
+    }));
+
+    const fork = await detectAndRollbackReorg(stubConfig);
+    expect(fork).toBe(6);
+
+    const remaining = await prisma.blockHeader.findMany({ orderBy: { height: 'asc' } });
+    expect(remaining.map((r) => r.height)).toEqual([5, 6]);
+    expect(await prisma.eventRaw.findMany()).toHaveLength(0);
+    const cursor = await prisma.indexerCursor.findUnique({ where: { key: 'indexed_height' } });
+    expect(cursor?.value).toBe('6');
+  });
+
+  test('bails safely when entire detection window disagrees (reorg deeper than window)', async () => {
+    await seedHeaders([
+      { height: 5, blockHash: 'h5-old', parentHash: 'h4-old' },
+      { height: 6, blockHash: 'h6-old', parentHash: 'h5-old' },
+    ]);
+    await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '6' } });
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => [
+        { height: 5, blockHash: 'h5-NEW', parentHash: 'h4-NEW' },
+        { height: 6, blockHash: 'h6-NEW', parentHash: 'h5-NEW' },
+      ],
+    }));
+
+    const fork = await detectAndRollbackReorg(stubConfig);
+    expect(fork).toBeNull();
+    // Nothing rolled back — state is preserved, operator has to intervene.
+    expect(await prisma.blockHeader.findMany()).toHaveLength(2);
+    const cursor = await prisma.indexerCursor.findUnique({ where: { key: 'indexed_height' } });
+    expect(cursor?.value).toBe('6');
+  });
+
+  test('returns null if daemon fetch throws', async () => {
+    await seedHeaders([{ height: 10, blockHash: 'h10', parentHash: 'h9' }]);
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => { throw new Error('boom'); },
+    }));
+
+    const result = await detectAndRollbackReorg(stubConfig);
+    expect(result).toBeNull();
+    expect(await prisma.blockHeader.findMany()).toHaveLength(1);
+  });
+});
+
+describe('reconstruction after rollback', () => {
+  test('ingests new canonical chain after reorg; final state matches new chain only', async () => {
+    const address = PrivateKey.random().toPublicKey().toBase58();
+    const ownerA = PrivateKey.random().toPublicKey().toBase58();
+    const ownerB = PrivateKey.random().toPublicKey().toBase58();
+
+    const contract = await prisma.contract.create({
+      data: { address, discoveredAtBlock: 4 },
+    });
+    const indexer = new MinaGuardIndexer(stubConfig);
+
+    // Old chain: hashes h5..h9. Events: setup + two setupOwner at 5,
+    // proposal 'OLD' at 7, approval at 8, execution at 9.
+    const OLD_HASH = (h: number) => `old-${h}`;
+    const oldChainEvents: ChainEvent[] = [
+      {
+        type: 'setup', blockHeight: 5, txHash: 'tx-setup',
+        blockHash: OLD_HASH(5), parentHash: OLD_HASH(4),
+        event: { parent: null, threshold: '2', numOwners: '2', networkId: 'net', ownersCommitment: 'commit-old' },
+      },
+      {
+        type: 'setupOwner', blockHeight: 5, txHash: 'tx-setup',
+        blockHash: OLD_HASH(5), parentHash: OLD_HASH(4),
+        event: { owner: ownerA, index: '0' },
+      },
+      {
+        type: 'setupOwner', blockHeight: 5, txHash: 'tx-setup',
+        blockHash: OLD_HASH(5), parentHash: OLD_HASH(4),
+        event: { owner: ownerB, index: '1' },
+      },
+      {
+        type: 'proposal', blockHeight: 7, txHash: 'tx-prop-old',
+        blockHash: OLD_HASH(7), parentHash: OLD_HASH(6),
+        event: {
+          proposalHash: 'OLD_PROPOSAL', proposer: ownerA, tokenId: '1', txType: '0',
+          data: 'd', uid: 'u1', configNonce: '0', expiryBlock: '1000',
+          networkId: 'net', guardAddress: address, destination: '0', childAccount: null,
+        },
+      },
+      {
+        type: 'approval', blockHeight: 8, txHash: 'tx-appr-old',
+        blockHash: OLD_HASH(8), parentHash: OLD_HASH(7),
+        event: { proposalHash: 'OLD_PROPOSAL', approver: ownerA, approvalCount: '1' },
+      },
+      {
+        type: 'execution', blockHeight: 9, txHash: 'tx-exec-old',
+        blockHash: OLD_HASH(9), parentHash: OLD_HASH(8),
+        event: { proposalHash: 'OLD_PROPOSAL' },
+      },
+    ];
+
+    // Also seed the block 6 header on the old chain so fork detection has
+    // something at 6 to compare against. Block 6 had no events, so ingestion
+    // wouldn't create it.
+    await prisma.blockHeader.create({
+      data: { height: 6, blockHash: OLD_HASH(6), parentHash: OLD_HASH(5) },
+    });
+
+    // PHASE 1: ingest old chain.
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async () => oldChainEvents,
+    }));
+    await indexer.syncSingleContract(contract.id, address, 0, 9);
+    await prisma.indexerCursor.upsert({
+      where: { key: 'indexed_height' },
+      create: { key: 'indexed_height', value: '9' },
+      update: { value: '9' },
+    });
+
+    // Sanity-check old-chain state.
+    const oldProposal = await prisma.proposal.findUniqueOrThrow({
+      where: { contractId_proposalHash: { contractId: contract.id, proposalHash: 'OLD_PROPOSAL' } },
+      include: { executions: true, _count: { select: { approvals: true } } },
+    });
+    expect(oldProposal.executions).toHaveLength(1);
+    expect(oldProposal._count.approvals).toBe(1);
+
+    // PHASE 2: detect reorg. New chain agrees through 6, diverges at 7.
+    const NEW_HASH = (h: number) => `new-${h}`;
+    const newChainHeaders = [
+      { height: 4, blockHash: OLD_HASH(4), parentHash: OLD_HASH(3) },
+      { height: 5, blockHash: OLD_HASH(5), parentHash: OLD_HASH(4) },
+      { height: 6, blockHash: OLD_HASH(6), parentHash: OLD_HASH(5) },
+      { height: 7, blockHash: NEW_HASH(7), parentHash: OLD_HASH(6) },
+      { height: 8, blockHash: NEW_HASH(8), parentHash: NEW_HASH(7) },
+      { height: 9, blockHash: NEW_HASH(9), parentHash: NEW_HASH(8) },
+    ];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchBestChainHeaders: async () => newChainHeaders,
+    }));
+    const fork = await detectAndRollbackReorg(stubConfig);
+    expect(fork).toBe(6);
+
+    // Post-rollback: everything above 6 gone; setup state at 5 preserved.
+    expect(await prisma.proposal.count()).toBe(0);
+    expect(await prisma.approval.count()).toBe(0);
+    expect(await prisma.proposalExecution.count()).toBe(0);
+    expect(await prisma.blockHeader.count({ where: { height: { gt: 6 } } })).toBe(0);
+    // EventRaw at block 5 (setup + two setupOwner) survives; blocks 7/8/9 gone.
+    expect(await prisma.eventRaw.count({ where: { blockHeight: { gt: 6 } } })).toBe(0);
+    expect(await prisma.eventRaw.count({ where: { blockHeight: { lte: 6 } } })).toBe(3);
+    // ContractConfig rows from setup (all at block 5) survive; none above fork.
+    expect(await prisma.contractConfig.count({ where: { validFromBlock: { gt: 6 } } })).toBe(0);
+    expect(await prisma.contractConfig.count({ where: { validFromBlock: { lte: 6 } } })).toBeGreaterThan(0);
+    // Contract row (discoveredAtBlock=4) survives.
+    expect(await prisma.contract.count()).toBe(1);
+    // Owners from setup still present (added at block 5 ≤ 6).
+    expect(await prisma.ownerMembership.count()).toBe(2);
+
+    // PHASE 3: ingest new chain. New proposal + approval at 7,8; owner B
+    // removed at 9. No execution.
+    const newChainEvents: ChainEvent[] = [
+      {
+        type: 'proposal', blockHeight: 7, txHash: 'tx-prop-new',
+        blockHash: NEW_HASH(7), parentHash: OLD_HASH(6),
+        event: {
+          proposalHash: 'NEW_PROPOSAL', proposer: ownerA, tokenId: '1', txType: '0',
+          data: 'd2', uid: 'u2', configNonce: '0', expiryBlock: '1000',
+          networkId: 'net', guardAddress: address, destination: '0', childAccount: null,
+        },
+      },
+      {
+        type: 'approval', blockHeight: 8, txHash: 'tx-appr-new',
+        blockHash: NEW_HASH(8), parentHash: NEW_HASH(7),
+        event: { proposalHash: 'NEW_PROPOSAL', approver: ownerA, approvalCount: '1' },
+      },
+      {
+        type: 'ownerChange', blockHeight: 9, txHash: 'tx-owner-new',
+        blockHash: NEW_HASH(9), parentHash: NEW_HASH(8),
+        event: { owner: ownerB, added: '0', newNumOwners: '1', configNonce: '1' },
+      },
+    ];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchDecodedContractEvents: async () => newChainEvents,
+    }));
+    await indexer.syncSingleContract(contract.id, address, 7, 9);
+
+    // Final state asserts.
+    const proposals = await prisma.proposal.findMany({
+      include: { executions: true, _count: { select: { approvals: true } } },
+    });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].proposalHash).toBe('NEW_PROPOSAL');
+    expect(proposals[0].executions).toHaveLength(0); // not executed on new chain
+    expect(proposals[0]._count.approvals).toBe(1);
+    // Globally: no stale OLD_PROPOSAL, no stale approvals (rollback wiped them).
+    expect(await prisma.proposal.count({ where: { proposalHash: 'OLD_PROPOSAL' } })).toBe(0);
+    expect(await prisma.approval.count()).toBe(1);
+    expect(await prisma.proposalExecution.count()).toBe(0);
+
+    // Owner collapse: ownerA added@5, ownerB added@5 then removed@9 → A active, B removed.
+    const memberships = await prisma.ownerMembership.findMany({
+      where: { contractId: contract.id },
+      orderBy: [{ validFromBlock: 'desc' }, { eventOrder: 'desc' }, { id: 'desc' }],
+    });
+    const latestByAddr = new Map<string, typeof memberships[number]>();
+    for (const m of memberships) {
+      if (!latestByAddr.has(m.address)) latestByAddr.set(m.address, m);
+    }
+    expect(latestByAddr.get(ownerA)?.action).toBe('added');
+    expect(latestByAddr.get(ownerB)?.action).toBe('removed');
+
+    // ContractConfig latest snapshot reflects numOwners=1 after owner removal.
+    const latestConfig = await prisma.contractConfig.findFirst({
+      where: { contractId: contract.id },
+      orderBy: [{ validFromBlock: 'desc' }, { eventOrder: 'desc' }],
+    });
+    expect(latestConfig?.numOwners).toBe(1);
+    expect(latestConfig?.configNonce).toBe(1);
+    // Threshold carried forward from setup snapshot (not changed by ownerChange).
+    expect(latestConfig?.threshold).toBe(2);
+
+    // BlockHeader rows match the new chain.
+    const headers = await prisma.blockHeader.findMany({ orderBy: { height: 'asc' } });
+    const heights = headers.map((h) => h.height);
+    expect(heights).toContain(7);
+    expect(heights).toContain(8);
+    expect(heights).toContain(9);
+    expect(headers.find((h) => h.height === 7)?.blockHash).toBe(NEW_HASH(7));
+    expect(headers.find((h) => h.height === 9)?.blockHash).toBe(NEW_HASH(9));
+
+    // PHASE 4: idempotency. Re-run new-chain ingest; row counts don't grow.
+    const countsBefore = {
+      eventRaw: await prisma.eventRaw.count(),
+      proposal: await prisma.proposal.count(),
+      approval: await prisma.approval.count(),
+      ownerMembership: await prisma.ownerMembership.count(),
+      contractConfig: await prisma.contractConfig.count(),
+      blockHeader: await prisma.blockHeader.count(),
+    };
+    await indexer.syncSingleContract(contract.id, address, 7, 9);
+    expect(await prisma.eventRaw.count()).toBe(countsBefore.eventRaw);
+    expect(await prisma.proposal.count()).toBe(countsBefore.proposal);
+    expect(await prisma.approval.count()).toBe(countsBefore.approval);
+    expect(await prisma.ownerMembership.count()).toBe(countsBefore.ownerMembership);
+    expect(await prisma.contractConfig.count()).toBe(countsBefore.contractConfig);
+    expect(await prisma.blockHeader.count()).toBe(countsBefore.blockHeader);
+  });
+});

--- a/backend/src/tests/proposal-record.test.ts
+++ b/backend/src/tests/proposal-record.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect } from 'bun:test';
+import { deriveInvalidReason, type ContractState } from '../proposal-record.js';
+
+type ProposalFixture = {
+  nonce: string | null;
+  configNonce: string | null;
+  destination: string | null;
+  txType: string | null;
+};
+
+function proposal(fields: Partial<ProposalFixture> = {}): ProposalFixture {
+  return {
+    nonce: null,
+    configNonce: null,
+    destination: null,
+    txType: null,
+    ...fields,
+  };
+}
+
+function parent(fields: Partial<ContractState> = {}): ContractState {
+  return { nonce: null, parentNonce: null, configNonce: null, ...fields };
+}
+
+describe('deriveInvalidReason', () => {
+  describe('config_nonce_stale', () => {
+    test('returns config_nonce_stale when proposal.configNonce < parent.configNonce', () => {
+      expect(
+        deriveInvalidReason(proposal({ configNonce: '0' }), parent({ configNonce: 1 }), null),
+      ).toBe('config_nonce_stale');
+    });
+
+    test('takes precedence over proposal_nonce_stale when both apply', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ configNonce: '0', nonce: '1', destination: 'local' }),
+          parent({ configNonce: 5, nonce: 10 }),
+          null,
+        ),
+      ).toBe('config_nonce_stale');
+    });
+
+    test('returns null when proposal.configNonce == parent.configNonce (strict less-than)', () => {
+      expect(
+        deriveInvalidReason(proposal({ configNonce: '3' }), parent({ configNonce: 3 }), null),
+      ).toBeNull();
+    });
+
+    test('returns null when parent.configNonce is null', () => {
+      expect(
+        deriveInvalidReason(proposal({ configNonce: '5' }), parent({ configNonce: null }), null),
+      ).toBeNull();
+    });
+
+    test('returns null when proposal.configNonce is null', () => {
+      expect(
+        deriveInvalidReason(proposal({ configNonce: null }), parent({ configNonce: 5 }), null),
+      ).toBeNull();
+    });
+  });
+
+  describe('proposal_nonce_stale (LOCAL)', () => {
+    test('flags LOCAL proposal with nonce <= parent.nonce', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '3', destination: 'local' }),
+          parent({ nonce: 3 }),
+          null,
+        ),
+      ).toBe('proposal_nonce_stale');
+    });
+
+    test('flags LOCAL when proposal.nonce strictly less', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '2', destination: 'local' }),
+          parent({ nonce: 5 }),
+          null,
+        ),
+      ).toBe('proposal_nonce_stale');
+    });
+
+    test('does not flag when proposal.nonce > parent.nonce', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '6', destination: 'local' }),
+          parent({ nonce: 5 }),
+          null,
+        ),
+      ).toBeNull();
+    });
+
+    test('does not flag when parent.nonce is null', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '1', destination: 'local' }),
+          parent({ nonce: null }),
+          null,
+        ),
+      ).toBeNull();
+    });
+
+    test('treats null destination as LOCAL (defaults to local path)', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '1', destination: null }),
+          parent({ nonce: 5 }),
+          null,
+        ),
+      ).toBe('proposal_nonce_stale');
+    });
+  });
+
+  describe('proposal_nonce_stale (REMOTE non-CREATE_CHILD)', () => {
+    test('flags REMOTE proposal with nonce <= child.parentNonce', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '2', destination: 'remote', txType: '7' }),
+          parent(),
+          { nonce: null, parentNonce: 5, configNonce: null },
+        ),
+      ).toBe('proposal_nonce_stale');
+    });
+
+    test('does not use parent.nonce for REMOTE path', () => {
+      // parent.nonce is high (would flag LOCAL), child.parentNonce is low
+      // (would not flag REMOTE). Should return null — i.e., remote path
+      // consulted child only.
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '5', destination: 'remote', txType: '7' }),
+          parent({ nonce: 100 }),
+          { nonce: null, parentNonce: 0, configNonce: null },
+        ),
+      ).toBeNull();
+    });
+
+    test('does not flag when child.parentNonce is null', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '1', destination: 'remote', txType: '7' }),
+          parent(),
+          { nonce: null, parentNonce: null, configNonce: null },
+        ),
+      ).toBeNull();
+    });
+
+    test('does not flag when child state is missing entirely', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '1', destination: 'remote', txType: '7' }),
+          parent(),
+          null,
+        ),
+      ).toBeNull();
+    });
+
+    test('does not flag when proposal.nonce > child.parentNonce', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '10', destination: 'remote', txType: '7' }),
+          parent(),
+          { nonce: null, parentNonce: 5, configNonce: null },
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe('CREATE_CHILD bypass', () => {
+    test('txType="5" skips nonce-stale check entirely, even when nonce would be stale', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '0', destination: 'remote', txType: '5' }),
+          parent({ nonce: 10 }),
+          { nonce: null, parentNonce: 10, configNonce: null },
+        ),
+      ).toBeNull();
+    });
+
+    test('CREATE_CHILD still triggers config_nonce_stale (config check runs first, bypass is only nonce)', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: '0', configNonce: '0', destination: 'remote', txType: '5' }),
+          parent({ configNonce: 1 }),
+          null,
+        ),
+      ).toBe('config_nonce_stale');
+    });
+  });
+
+  describe('null / malformed inputs', () => {
+    test('returns null when parent state is null entirely', () => {
+      expect(
+        deriveInvalidReason(proposal({ nonce: '1', destination: 'local' }), null, null),
+      ).toBeNull();
+    });
+
+    test('returns null when proposal.nonce is null', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: null, destination: 'local' }),
+          parent({ nonce: 5 }),
+          null,
+        ),
+      ).toBeNull();
+    });
+
+    test('returns null when proposal.nonce is non-numeric', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ nonce: 'not-a-number', destination: 'local' }),
+          parent({ nonce: 5 }),
+          null,
+        ),
+      ).toBeNull();
+    });
+
+    test('returns null when proposal.configNonce is non-numeric (falls through to nonce check)', () => {
+      expect(
+        deriveInvalidReason(
+          proposal({ configNonce: 'not-a-number', nonce: '6', destination: 'local' }),
+          parent({ configNonce: 1, nonce: 5 }),
+          null,
+        ),
+      ).toBeNull();
+    });
+  });
+});

--- a/backend/src/tests/routes-api.test.ts
+++ b/backend/src/tests/routes-api.test.ts
@@ -30,21 +30,24 @@ function get(path: string) {
 
 async function clearDatabase() {
   await prisma.approval.deleteMany();
+  await prisma.proposalExecution.deleteMany();
+  await prisma.proposalReceiver.deleteMany();
   await prisma.eventRaw.deleteMany();
   await prisma.proposal.deleteMany();
-  await prisma.owner.deleteMany();
+  await prisma.ownerMembership.deleteMany();
+  await prisma.contractConfig.deleteMany();
   await prisma.contract.deleteMany();
 }
 
 async function seedDatabase() {
   await prisma.contract.createMany({
     data: [
-      { address: contractAddress, networkId: '1' },
-      { address: otherContractAddress, networkId: '1' },
+      { address: contractAddress, ready: true },
+      { address: otherContractAddress, ready: true },
       // Two subaccounts of `contractAddress`. childTwo has multi-sig disabled
       // (e.g. after a destroy) so the API exposes both states.
-      { address: childOneAddress, networkId: '1', parent: contractAddress, childMultiSigEnabled: true },
-      { address: childTwoAddress, networkId: '1', parent: contractAddress, childMultiSigEnabled: false },
+      { address: childOneAddress, parent: contractAddress, ready: true },
+      { address: childTwoAddress, parent: contractAddress, ready: true },
     ],
   });
 
@@ -54,12 +57,30 @@ async function seedDatabase() {
   const otherContract = await prisma.contract.findUniqueOrThrow({
     where: { address: otherContractAddress },
   });
+  const childOne = await prisma.contract.findUniqueOrThrow({
+    where: { address: childOneAddress },
+  });
+  const childTwo = await prisma.contract.findUniqueOrThrow({
+    where: { address: childTwoAddress },
+  });
 
-  await prisma.owner.createMany({
+  await prisma.contractConfig.createMany({
     data: [
-      { contractId: contract.id, address: ownerA, index: 0, active: true },
-      { contractId: contract.id, address: ownerB, index: 1, active: false },
-      { contractId: otherContract.id, address: ownerC, index: 0, active: true },
+      { contractId: contract.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: true },
+      { contractId: otherContract.id, validFromBlock: 25, networkId: '1', childMultiSigEnabled: true },
+      { contractId: childOne.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: true },
+      { contractId: childTwo.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: false },
+    ],
+  });
+
+  // OwnerMembership history: ownerA added, ownerB added then removed. Latest
+  // action per address determines current active state.
+  await prisma.ownerMembership.createMany({
+    data: [
+      { contractId: contract.id, address: ownerA, action: 'added', index: 0, validFromBlock: 5 },
+      { contractId: contract.id, address: ownerB, action: 'added', index: 1, validFromBlock: 5 },
+      { contractId: contract.id, address: ownerB, action: 'removed', index: 1, validFromBlock: 7, eventOrder: 1 },
+      { contractId: otherContract.id, address: ownerC, action: 'added', index: 0, validFromBlock: 25 },
     ],
   });
 
@@ -68,38 +89,41 @@ async function seedDatabase() {
       {
         contractId: contract.id,
         proposalHash: proposalHashA,
-        status: 'pending',
         createdAtBlock: 10,
       },
       {
         contractId: contract.id,
         proposalHash: proposalHashB,
-        status: 'executed',
         createdAtBlock: 20,
       },
       {
         contractId: contract.id,
         proposalHash: proposalHashC,
-        status: 'pending',
         createdAtBlock: 30,
       },
       {
         contractId: otherContract.id,
         proposalHash: otherProposalHash,
-        status: 'pending',
         createdAtBlock: 40,
       },
       // REMOTE child-lifecycle proposal on the parent, targeting childOne.
       {
         contractId: contract.id,
         proposalHash: remoteProposalHash,
-        status: 'pending',
         createdAtBlock: 50,
         destination: 'remote',
         childAccount: childOneAddress,
         txType: '7', // RECLAIM_CHILD
       },
     ],
+  });
+
+  const executedProposal = await prisma.proposal.findUniqueOrThrow({
+    where: { contractId_proposalHash: { contractId: contract.id, proposalHash: proposalHashB } },
+    select: { id: true },
+  });
+  await prisma.proposalExecution.create({
+    data: { proposalId: executedProposal.id, blockHeight: 22 },
   });
 
   await prisma.eventRaw.createMany({

--- a/backend/src/tests/routes-api.test.ts
+++ b/backend/src/tests/routes-api.test.ts
@@ -13,6 +13,11 @@ const contractAddress = PrivateKey.random().toPublicKey().toBase58();
 const otherContractAddress = PrivateKey.random().toPublicKey().toBase58();
 const childOneAddress = PrivateKey.random().toPublicKey().toBase58();
 const childTwoAddress = PrivateKey.random().toPublicKey().toBase58();
+// Dedicated contract (and child) for invalidation-state tests — kept
+// isolated from the main test contract so its fixed proposal counts aren't
+// disturbed.
+const invalidStateContractAddress = PrivateKey.random().toPublicKey().toBase58();
+const invalidStateChildAddress = PrivateKey.random().toPublicKey().toBase58();
 const ownerA = PrivateKey.random().toPublicKey().toBase58();
 const ownerB = PrivateKey.random().toPublicKey().toBase58();
 const ownerC = PrivateKey.random().toPublicKey().toBase58();
@@ -23,6 +28,17 @@ const proposalHashC = '303';
 const otherProposalHash = '404';
 // REMOTE child-lifecycle proposal targeting childOne — exercises destination/childAccount.
 const remoteProposalHash = '505';
+// Proposals on invalidStateContract used to validate status=invalidated:
+//   configStaleHash — configNonce behind contract (should be config_nonce_stale)
+//   localStaleHash  — nonce behind parent.nonce (should be proposal_nonce_stale)
+//   remoteStaleHash — REMOTE w/ nonce behind child.parentNonce
+//   createChildHash — CREATE_CHILD (txType=5) nonce=0; always pending
+//   freshHash       — config+nonce fresh, stays pending
+const configStaleHash = '601';
+const localStaleHash = '602';
+const remoteStaleHash = '603';
+const createChildHash = '604';
+const freshHash = '605';
 
 function get(path: string) {
   return fetch(`${baseUrl}${path}`);
@@ -48,6 +64,8 @@ async function seedDatabase() {
       // (e.g. after a destroy) so the API exposes both states.
       { address: childOneAddress, parent: contractAddress, ready: true },
       { address: childTwoAddress, parent: contractAddress, ready: true },
+      { address: invalidStateContractAddress, ready: true },
+      { address: invalidStateChildAddress, parent: invalidStateContractAddress, ready: true },
     ],
   });
 
@@ -64,12 +82,17 @@ async function seedDatabase() {
     where: { address: childTwoAddress },
   });
 
+  // Seed explicit nonces so tests asserting proposal status are robust
+  // against future changes to null-handling in deriveInvalidReason.
+  // `contract` (parent): nonce=0 (no local proposals executed yet),
+  // configNonce=0. Children's `parentNonce=0` means a REMOTE proposal with
+  // nonce>0 is not parent-nonce-stale.
   await prisma.contractConfig.createMany({
     data: [
-      { contractId: contract.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: true },
-      { contractId: otherContract.id, validFromBlock: 25, networkId: '1', childMultiSigEnabled: true },
-      { contractId: childOne.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: true },
-      { contractId: childTwo.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: false },
+      { contractId: contract.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: true, nonce: 0, parentNonce: 0, configNonce: 0 },
+      { contractId: otherContract.id, validFromBlock: 25, networkId: '1', childMultiSigEnabled: true, nonce: 0, parentNonce: 0, configNonce: 0 },
+      { contractId: childOne.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: true, nonce: 0, parentNonce: 0, configNonce: 0 },
+      { contractId: childTwo.id, validFromBlock: 5, networkId: '1', childMultiSigEnabled: false, nonce: 0, parentNonce: 0, configNonce: 0 },
     ],
   });
 
@@ -124,6 +147,94 @@ async function seedDatabase() {
   });
   await prisma.proposalExecution.create({
     data: { proposalId: executedProposal.id, blockHeight: 22 },
+  });
+
+  // --- Invalidation fixtures ------------------------------------------------
+  // A separate contract with nonce=5, configNonce=3 so proposals behind those
+  // values show as invalidated. Its child has parentNonce=4, so REMOTE
+  // proposals with nonce<=4 are parent-nonce-stale.
+  const invalidContract = await prisma.contract.findUniqueOrThrow({
+    where: { address: invalidStateContractAddress },
+  });
+  const invalidChild = await prisma.contract.findUniqueOrThrow({
+    where: { address: invalidStateChildAddress },
+  });
+
+  await prisma.contractConfig.createMany({
+    data: [
+      {
+        contractId: invalidContract.id,
+        validFromBlock: 100,
+        networkId: '1',
+        childMultiSigEnabled: true,
+        nonce: 5,
+        parentNonce: 0,
+        configNonce: 3,
+      },
+      {
+        contractId: invalidChild.id,
+        validFromBlock: 100,
+        networkId: '1',
+        childMultiSigEnabled: true,
+        nonce: 0,
+        parentNonce: 4,
+        configNonce: 0,
+      },
+    ],
+  });
+
+  await prisma.proposal.createMany({
+    data: [
+      // config_nonce_stale: proposal.configNonce=1 < parent.configNonce=3
+      {
+        contractId: invalidContract.id,
+        proposalHash: configStaleHash,
+        createdAtBlock: 110,
+        configNonce: '1',
+        nonce: '10', // fresh enough on its own; config check wins
+        destination: 'local',
+      },
+      // proposal_nonce_stale (LOCAL): nonce=5 <= parent.nonce=5
+      {
+        contractId: invalidContract.id,
+        proposalHash: localStaleHash,
+        createdAtBlock: 111,
+        configNonce: '3',
+        nonce: '5',
+        destination: 'local',
+      },
+      // proposal_nonce_stale (REMOTE non-CREATE_CHILD): nonce=2 <= child.parentNonce=4
+      {
+        contractId: invalidContract.id,
+        proposalHash: remoteStaleHash,
+        createdAtBlock: 112,
+        configNonce: '3',
+        nonce: '2',
+        destination: 'remote',
+        childAccount: invalidStateChildAddress,
+        txType: '7', // RECLAIM_CHILD
+      },
+      // CREATE_CHILD (txType=5): nonce=0 always, never nonce-stale
+      {
+        contractId: invalidContract.id,
+        proposalHash: createChildHash,
+        createdAtBlock: 113,
+        configNonce: '3',
+        nonce: '0',
+        destination: 'remote',
+        childAccount: invalidStateChildAddress,
+        txType: '5',
+      },
+      // Fresh: nonce=6 > parent.nonce=5, configNonce=3 == parent.configNonce
+      {
+        contractId: invalidContract.id,
+        proposalHash: freshHash,
+        createdAtBlock: 114,
+        configNonce: '3',
+        nonce: '6',
+        destination: 'local',
+      },
+    ],
   });
 
   await prisma.eventRaw.createMany({
@@ -386,5 +497,99 @@ describe('GET /api/contracts/:address/events', () => {
     const body = await res.json();
     expect(body).toHaveLength(1);
     expect(body[0].blockHeight).toBe(10);
+  });
+});
+
+describe('proposal invalidation derivation', () => {
+  type ProposalRow = {
+    proposalHash: string;
+    status: string;
+    invalidReason: string | null;
+  };
+
+  async function getProposalsByContract(address: string): Promise<ProposalRow[]> {
+    const res = await get(`/api/contracts/${address}/proposals`);
+    expect(res.status).toBe(200);
+    return res.json();
+  }
+
+  async function getProposalByHash(address: string, hash: string): Promise<ProposalRow> {
+    const res = await get(`/api/contracts/${address}/proposals/${hash}`);
+    expect(res.status).toBe(200);
+    return res.json();
+  }
+
+  test('list endpoint marks config_nonce_stale proposal as invalidated', async () => {
+    const body = await getProposalsByContract(invalidStateContractAddress);
+    const configStale = body.find((p) => p.proposalHash === configStaleHash);
+    expect(configStale).toBeDefined();
+    expect(configStale?.status).toBe('invalidated');
+    expect(configStale?.invalidReason).toBe('config_nonce_stale');
+  });
+
+  test('list endpoint marks LOCAL nonce-stale proposal as invalidated', async () => {
+    const body = await getProposalsByContract(invalidStateContractAddress);
+    const localStale = body.find((p) => p.proposalHash === localStaleHash);
+    expect(localStale?.status).toBe('invalidated');
+    expect(localStale?.invalidReason).toBe('proposal_nonce_stale');
+  });
+
+  test('list endpoint marks REMOTE parent-nonce-stale proposal as invalidated', async () => {
+    const body = await getProposalsByContract(invalidStateContractAddress);
+    const remoteStale = body.find((p) => p.proposalHash === remoteStaleHash);
+    expect(remoteStale?.status).toBe('invalidated');
+    expect(remoteStale?.invalidReason).toBe('proposal_nonce_stale');
+  });
+
+  test('CREATE_CHILD proposal stays pending even with nonce=0 (bypasses nonce check)', async () => {
+    const body = await getProposalsByContract(invalidStateContractAddress);
+    const createChild = body.find((p) => p.proposalHash === createChildHash);
+    expect(createChild?.status).toBe('pending');
+    expect(createChild?.invalidReason).toBeNull();
+  });
+
+  test('fresh proposal stays pending', async () => {
+    const body = await getProposalsByContract(invalidStateContractAddress);
+    const fresh = body.find((p) => p.proposalHash === freshHash);
+    expect(fresh?.status).toBe('pending');
+    expect(fresh?.invalidReason).toBeNull();
+  });
+
+  test('single-proposal endpoint reports invalidated status + reason', async () => {
+    const body = await getProposalByHash(invalidStateContractAddress, configStaleHash);
+    expect(body.status).toBe('invalidated');
+    expect(body.invalidReason).toBe('config_nonce_stale');
+  });
+
+  test('?status=invalidated filter returns only invalidated proposals', async () => {
+    const res = await get(
+      `/api/contracts/${invalidStateContractAddress}/proposals?status=invalidated`
+    );
+    expect(res.status).toBe(200);
+    const body: ProposalRow[] = await res.json();
+    const hashes = body.map((p) => p.proposalHash).sort();
+    expect(hashes).toEqual([configStaleHash, localStaleHash, remoteStaleHash].sort());
+    expect(body.every((p) => p.status === 'invalidated')).toBe(true);
+  });
+});
+
+describe('decorateContract exposes nonce + parentNonce', () => {
+  test('GET /api/contracts/:address includes nonce and parentNonce from latest ContractConfig', async () => {
+    const res = await get(`/api/contracts/${invalidStateContractAddress}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.nonce).toBe(5);
+    expect(body.parentNonce).toBe(0);
+    expect(body.configNonce).toBe(3);
+  });
+
+  test('GET /api/contracts exposes nonce + parentNonce on each contract in the list', async () => {
+    const res = await get(`/api/contracts`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const entry = body.find((c: { address: string }) => c.address === invalidStateContractAddress);
+    expect(entry).toBeDefined();
+    expect(entry.nonce).toBe(5);
+    expect(entry.parentNonce).toBe(0);
   });
 });

--- a/backend/src/tests/routes-subscribe.test.ts
+++ b/backend/src/tests/routes-subscribe.test.ts
@@ -1,0 +1,428 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from 'bun:test';
+import express from 'express';
+import type { Server } from 'http';
+import { PrivateKey } from 'o1js';
+import type { BackendConfig } from '../config.js';
+import { prisma } from '../db.js';
+import type { MinaGuardIndexer } from '../indexer.js';
+import * as minaClient from '../mina-client.js';
+import { createApiRouter } from '../routes.js';
+
+let server: Server;
+let baseUrl = '';
+let fullModeServer: Server;
+let fullModeBaseUrl = '';
+
+const subscribedAddress = PrivateKey.random().toPublicKey().toBase58();
+
+const liteConfig = { indexerMode: 'lite' } as unknown as BackendConfig;
+const fullConfig = { indexerMode: 'full' } as unknown as BackendConfig;
+
+async function clearDatabase() {
+  await prisma.approval.deleteMany();
+  await prisma.proposalExecution.deleteMany();
+  await prisma.proposalReceiver.deleteMany();
+  await prisma.eventRaw.deleteMany();
+  await prisma.proposal.deleteMany();
+  await prisma.ownerMembership.deleteMany();
+  await prisma.contractConfig.deleteMany();
+  await prisma.contract.deleteMany();
+  await prisma.blockHeader.deleteMany();
+  await prisma.indexerCursor.deleteMany();
+}
+
+function buildStubIndexer(): MinaGuardIndexer {
+  return {
+    getStatus: () => ({
+      running: false,
+      lastRunAt: null,
+      lastSuccessfulRunAt: null,
+      latestChainHeight: 0,
+      indexedHeight: 0,
+      lastError: null,
+      discoveredContracts: 0,
+    }),
+    // No-op backfill: the route should call it but tests don't need real syncing.
+    backfillContract: async () => {},
+  } as unknown as MinaGuardIndexer;
+}
+
+function startServer(cfg: BackendConfig): Promise<{ server: Server; baseUrl: string }> {
+  const app = express();
+  app.use(express.json());
+  app.use(createApiRouter(buildStubIndexer(), cfg));
+  const s = app.listen(0);
+
+  return new Promise<{ server: Server; baseUrl: string }>((resolve, reject) => {
+    s.once('error', reject);
+    s.once('listening', () => {
+      const address = s.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Test server did not expose a numeric port'));
+        return;
+      }
+      resolve({ server: s, baseUrl: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
+beforeAll(async () => {
+  await clearDatabase();
+  // Mock network-touching helpers everywhere so subscribe doesn't hit a real node.
+  // Default VK mock returns a hash so fromBlock-path tests treat the address as a zkApp;
+  // the "not a zkApp" test overrides this to null.
+  mock.module('../mina-client.js', () => ({
+    ...minaClient,
+    fetchLatestBlockHeight: async () => 0,
+    fetchVerificationKeyHash: async () => 'vk-hash-stub',
+  }));
+
+  ({ server, baseUrl } = await startServer(liteConfig));
+  ({ server: fullModeServer, baseUrl: fullModeBaseUrl } = await startServer(fullConfig));
+});
+
+afterEach(async () => {
+  await clearDatabase();
+  // Re-establish the baseline mock after any per-test overrides.
+  mock.restore();
+  mock.module('../mina-client.js', () => ({
+    ...minaClient,
+    fetchLatestBlockHeight: async () => 0,
+    fetchVerificationKeyHash: async () => 'vk-hash-stub',
+  }));
+});
+
+afterAll(async () => {
+  await Promise.all([
+    new Promise<void>((resolve) => server?.close(() => resolve())),
+    new Promise<void>((resolve) => fullModeServer?.close(() => resolve())),
+  ]);
+  await prisma.$disconnect();
+});
+
+function post(path: string, body: unknown) {
+  return fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function del(path: string) {
+  return fetch(`${baseUrl}${path}`, { method: 'DELETE' });
+}
+
+describe('POST /api/subscribe', () => {
+  test('creates a contract entry with ready=false and discoveredAtBlock set to latestHeight - SUBSCRIBE_MARGIN', async () => {
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 1000,
+    }));
+
+    const res = await post('/api/subscribe', { address: subscribedAddress });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.address).toBe(subscribedAddress);
+
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored).not.toBeNull();
+    expect(stored?.ready).toBe(false);
+    expect(stored?.discoveredAtBlock).toBe(995);
+  });
+
+  test('accepts addresses that are not yet deployed on-chain; row stays unready until events are ingested', async () => {
+    // The subscribe route no longer ingests events or looks up the
+    // verification key. A freshly submitted deploy tx (still in the
+    // mempool) can be subscribed immediately. The row exists but is
+    // hidden from API reads via ready=false until the indexer tick's
+    // unready-rescan ingests an event.
+    const res = await post('/api/subscribe', { address: subscribedAddress });
+
+    expect(res.status).toBe(200);
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored).not.toBeNull();
+    expect(stored?.ready).toBe(false);
+
+    // And it is hidden from the contracts list endpoint.
+    const listRes = await fetch(`${baseUrl}/api/contracts`);
+    const body = (await listRes.json()) as Array<{ address: string }>;
+    expect(body.map((c) => c.address)).not.toContain(subscribedAddress);
+  });
+
+  test('accepts explicit fromBlock and uses it as discoveredAtBlock (bypassing the margin)', async () => {
+    let fetchLatestCalls = 0;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => {
+        fetchLatestCalls += 1;
+        return 9999;
+      },
+      fetchVerificationKeyHash: async () => 'vk-hash-stub',
+    }));
+
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: 0 });
+
+    expect(res.status).toBe(200);
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored?.discoveredAtBlock).toBe(0);
+    // fromBlock takes precedence, so we should not have fetched the tip.
+    expect(fetchLatestCalls).toBe(0);
+  });
+
+  test('rejects explicit fromBlock when address is not a deployed zkApp (manual add-existing path)', async () => {
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 0,
+      fetchVerificationKeyHash: async () => null,
+    }));
+
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: 0 });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Account not found on-chain or not a zkApp');
+
+    // No row created on the failure path.
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored).toBeNull();
+  });
+
+  test('does NOT require the address to be on-chain when fromBlock is omitted (auto-sub after deploy)', async () => {
+    let vkCalls = 0;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchLatestBlockHeight: async () => 0,
+      fetchVerificationKeyHash: async () => {
+        vkCalls += 1;
+        return null;
+      },
+    }));
+
+    const res = await post('/api/subscribe', { address: subscribedAddress });
+    expect(res.status).toBe(200);
+    expect(vkCalls).toBe(0);
+
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored).not.toBeNull();
+  });
+
+  test('accepts a non-zero fromBlock verbatim', async () => {
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: 500 });
+
+    expect(res.status).toBe(200);
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored?.discoveredAtBlock).toBe(500);
+  });
+
+  test('rejects negative fromBlock', async () => {
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: -1 });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('fromBlock must be a non-negative integer');
+  });
+
+  test('rejects non-integer fromBlock', async () => {
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: 1.5 });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('fromBlock must be a non-negative integer');
+  });
+
+  test('rejects non-number fromBlock', async () => {
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: '100' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('fromBlock must be a non-negative integer');
+  });
+
+  test('is idempotent when the contract is already tracked; fromBlock does not overwrite discoveredAtBlock', async () => {
+    await prisma.contract.create({
+      data: { address: subscribedAddress, discoveredAtBlock: 42 },
+    });
+
+    const res = await post('/api/subscribe', { address: subscribedAddress, fromBlock: 0 });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.address).toBe(subscribedAddress);
+    expect(body.discoveredAtBlock).toBe(42);
+
+    const count = await prisma.contract.count({ where: { address: subscribedAddress } });
+    expect(count).toBe(1);
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored?.discoveredAtBlock).toBe(42);
+  });
+
+  test('rejects missing address', async () => {
+    const res = await post('/api/subscribe', {});
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('address is required');
+  });
+
+  test('rejects invalid address', async () => {
+    const res = await post('/api/subscribe', { address: 'not-a-valid-address' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid Mina public key');
+  });
+});
+
+describe('DELETE /api/subscribe/:address', () => {
+  test('removes the contract and cascades its related rows', async () => {
+    const contract = await prisma.contract.create({
+      data: { address: subscribedAddress, ready: true },
+    });
+    await prisma.contractConfig.create({
+      data: { contractId: contract.id, validFromBlock: 1, networkId: '1' },
+    });
+    await prisma.ownerMembership.create({
+      data: {
+        contractId: contract.id,
+        address: PrivateKey.random().toPublicKey().toBase58(),
+        action: 'added',
+        validFromBlock: 1,
+      },
+    });
+    await prisma.eventRaw.create({
+      data: {
+        contractId: contract.id,
+        blockHeight: 1,
+        eventType: 'x',
+        payload: '{}',
+        fingerprint: `fp-${contract.id}`,
+      },
+    });
+
+    const res = await del(`/api/subscribe/${subscribedAddress}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    expect(await prisma.contract.findUnique({ where: { address: subscribedAddress } })).toBeNull();
+    expect(await prisma.contractConfig.count({ where: { contractId: contract.id } })).toBe(0);
+    expect(await prisma.ownerMembership.count({ where: { contractId: contract.id } })).toBe(0);
+    expect(await prisma.eventRaw.count({ where: { contractId: contract.id } })).toBe(0);
+  });
+
+  test('returns 404 when the contract is not tracked', async () => {
+    const res = await del(`/api/subscribe/${subscribedAddress}`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Contract not found');
+  });
+
+  test('rejects invalid address in path', async () => {
+    const res = await del('/api/subscribe/not-a-valid-address');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid contract address');
+  });
+});
+
+describe('DELETE /api/subscribe/:address child cascade', () => {
+  test('also deletes children and their related rows', async () => {
+    const parent = await prisma.contract.create({
+      data: { address: subscribedAddress, ready: true },
+    });
+    const childAddress = PrivateKey.random().toPublicKey().toBase58();
+    const child = await prisma.contract.create({
+      data: { address: childAddress, parent: subscribedAddress, ready: true },
+    });
+
+    await prisma.contractConfig.create({
+      data: { contractId: child.id, validFromBlock: 2, networkId: '1' },
+    });
+    await prisma.eventRaw.create({
+      data: {
+        contractId: child.id,
+        blockHeight: 2,
+        eventType: 'x',
+        payload: '{}',
+        fingerprint: `fp-child-${child.id}`,
+      },
+    });
+
+    const res = await del(`/api/subscribe/${subscribedAddress}`);
+    expect(res.status).toBe(200);
+
+    expect(await prisma.contract.findUnique({ where: { id: parent.id } })).toBeNull();
+    expect(await prisma.contract.findUnique({ where: { id: child.id } })).toBeNull();
+    expect(await prisma.contractConfig.count({ where: { contractId: child.id } })).toBe(0);
+    expect(await prisma.eventRaw.count({ where: { contractId: child.id } })).toBe(0);
+  });
+});
+
+describe('ready flag visibility', () => {
+  test('GET /api/contracts hides unready rows', async () => {
+    const readyAddress = PrivateKey.random().toPublicKey().toBase58();
+    const unreadyAddress = PrivateKey.random().toPublicKey().toBase58();
+    await prisma.contract.create({ data: { address: readyAddress, ready: true } });
+    await prisma.contract.create({ data: { address: unreadyAddress, ready: false } });
+
+    const res = await fetch(`${baseUrl}/api/contracts`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ address: string }>;
+    const addresses = body.map((c) => c.address);
+    expect(addresses).toContain(readyAddress);
+    expect(addresses).not.toContain(unreadyAddress);
+  });
+
+  test('GET /api/contracts/:address returns 404 for unready rows', async () => {
+    const unreadyAddress = PrivateKey.random().toPublicKey().toBase58();
+    await prisma.contract.create({ data: { address: unreadyAddress, ready: false } });
+
+    const res = await fetch(`${baseUrl}/api/contracts/${unreadyAddress}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /api/contracts/:parent/children hides unready children', async () => {
+    const parentAddress = PrivateKey.random().toPublicKey().toBase58();
+    const readyChild = PrivateKey.random().toPublicKey().toBase58();
+    const unreadyChild = PrivateKey.random().toPublicKey().toBase58();
+
+    await prisma.contract.create({ data: { address: parentAddress, ready: true } });
+    await prisma.contract.create({
+      data: { address: readyChild, parent: parentAddress, ready: true },
+    });
+    await prisma.contract.create({
+      data: { address: unreadyChild, parent: parentAddress, ready: false },
+    });
+
+    const res = await fetch(`${baseUrl}/api/contracts/${parentAddress}/children`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ address: string }>;
+    const addresses = body.map((c) => c.address);
+    expect(addresses).toContain(readyChild);
+    expect(addresses).not.toContain(unreadyChild);
+  });
+});
+
+describe('full-mode gating', () => {
+  test('POST /api/subscribe returns 404 in full mode', async () => {
+    const res = await fetch(`${fullModeBaseUrl}/api/subscribe`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ address: subscribedAddress }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/lite mode/i);
+
+    const stored = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stored).toBeNull();
+  });
+
+  test('DELETE /api/subscribe/:address returns 404 in full mode even when the contract exists', async () => {
+    await prisma.contract.create({ data: { address: subscribedAddress } });
+
+    const res = await fetch(`${fullModeBaseUrl}/api/subscribe/${subscribedAddress}`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/lite mode/i);
+
+    const stillThere = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
+    expect(stillThere).not.toBeNull();
+  });
+});

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -107,6 +107,7 @@ export interface IndexerStatus {
   indexedHeight: number;
   lastError: string | null;
   discoveredContracts: number;
+  indexerMode: 'full' | 'lite';
 }
 
 /** User input payload used by proposal creation forms. */


### PR DESCRIPTION
- Changed DB schema to a model that allows rollbacks (no aggregate rows, like approval count)
- Added re-org detection for on every tick
- Rollback functionality to delete all changes to the db after a certain height, and re-indexing from there
- Changed reads from DB