### PR TITLE
IndexedDB compile cache, page recycling, full e2e suite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy]
     steps:
       - name: Verify branch is main
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,7 +90,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
 
       - name: Start backend
-        run: bun run --filter backend dev &
+        run: bun run --filter backend dev > /tmp/backend.log 2>&1 &
         env:
           PORT: '4000'
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   e2e:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, e2e]
 
     services:
       postgres:
@@ -121,6 +121,7 @@ jobs:
         run: cd e2e && node node_modules/@playwright/test/cli.js test
         env:
           CI: true
+          TMPDIR: ${{ github.workspace }}/.tmp
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,7 +90,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
 
       - name: Start backend
-        run: bun run --filter backend dev > /tmp/backend.log 2>&1 &
+        run: bun run --filter backend dev &
         env:
           PORT: '4000'
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,12 +7,6 @@ on:
 
 jobs:
   e2e:
-    # TEMPORARY: job short-circuits to a no-op while the worker-recycle fix
-    # is in flight. Full subaccount suite silently hangs tx.prove() after
-    # ~20 proves in one worker (8 GB V8 bump isn't enough). Keeping the job
-    # name `e2e` so branch protection's required check still reports. Remove
-    # `if: false` once worker-recycling lands.
-    if: false
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
@@ -113,6 +107,7 @@ jobs:
           NEXT_PUBLIC_MINA_ENDPOINT: http://localhost:8080/graphql
           NEXT_PUBLIC_ARCHIVE_ENDPOINT: http://localhost:8282
           NEXT_PUBLIC_E2E_TEST: 'true'
+          NEXT_PUBLIC_POLL_INTERVAL_MS: '3000'
 
       - name: Wait for services
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -31,7 +31,7 @@ jobs:
   deploy:
     # Only run on PRs from the same repo (not forks) to prevent arbitrary code execution on the server
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,7 +113,7 @@ jobs:
 
   teardown:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   reset:
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ coverage/
 e2e/.e2e-state.json
 e2e/test-results/
 e2e/playwright-report/
+.tmp/
 
 # o1js compilation cache
 cache/

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -61,3 +61,35 @@ Instead of refreshing immediately after tx submission, `startOperation` should:
 2. Then call `refreshState`.
 
 The backend already exposes `GET /indexer/status` (returns `lastIndexedBlock`) which could be polled for this purpose. The main missing piece is knowing which block the submitted transaction landed in, which requires a separate on-chain query or waiting for tx confirmation before refreshing.
+
+---
+
+## [Resolved] WASM GC corruption causes second prove to hang when using IDB compile cache
+
+**Symptom:** "Generating proof..." hangs on the second transaction without a page refresh. Only happens when caching is enabled; works every time without cache.
+
+**Root cause:** o1js registers a `FinalizationRegistry` (`kimchi_bindings/js/bindings/util.js`) that auto-frees WASM heap memory when JS wrapper objects are garbage-collected. When `compile({ cache })` deserializes prover keys from IDB via `decodeProverKey`, intermediate JS wrappers are created that share underlying WASM pointers with the final key objects. For example, `verifierIndexFromRust(vkWasm)` converts `vkWasm` into a nested-array format — both reference the same WASM heap data. After the conversion, `vkWasm` goes out of scope and becomes GC-eligible.
+
+After the first `prove()`, V8 GC collects these intermediate wrappers. The `FinalizationRegistry` fires and calls `.free()` on their WASM pointers — but the prover still references those pointers through the converted structures. The second `prove()` hits dangling WASM memory and silently hangs.
+
+Without cache, keys are created through Pickles' Rust compilation path which manages WASM object lifetimes internally — no shared pointers, no premature finalization.
+
+```
+compile({ cache })
+    ↓
+decodeProverKey(bytes) → wasm.caml_pasta_fp_plonk_index_decode(bytes, srs)
+    ↓
+JS wrapper A (__wbg_ptr: 42) → registered with FinalizationRegistry
+    ↓
+verifierIndexFromRust(A) → nested array structure (still references ptr 42)
+    ↓
+wrapper A goes out of scope, only nested array is kept
+    ↓
+first prove() works fine
+    ↓
+GC collects wrapper A → finalizer calls .free() on ptr 42
+    ↓
+second prove() → prover reads freed memory at ptr 42 → hang
+```
+
+**Fix:** `ui/lib/disable-wasm-finalizers.ts` overrides `globalThis.FinalizationRegistry` with a no-op class before o1js loads. WASM objects are never auto-freed; memory is reclaimed when the worker is torn down on page refresh. This is imported as the first line of the worker (`import './disable-wasm-finalizers'`) so it runs before o1js's module initialization creates its registry.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -64,32 +64,105 @@ The backend already exposes `GET /indexer/status` (returns `lastIndexedBlock`) w
 
 ---
 
-## [Resolved] WASM GC corruption causes second prove to hang when using IDB compile cache
+## [Mitigated] WASM GC corruption causes second prove to hang when using IDB compile cache
 
 **Symptom:** "Generating proof..." hangs on the second transaction without a page refresh. Only happens when caching is enabled; works every time without cache.
 
-**Root cause:** o1js registers a `FinalizationRegistry` (`kimchi_bindings/js/bindings/util.js`) that auto-frees WASM heap memory when JS wrapper objects are garbage-collected. When `compile({ cache })` deserializes prover keys from IDB via `decodeProverKey`, intermediate JS wrappers are created that share underlying WASM pointers with the final key objects. For example, `verifierIndexFromRust(vkWasm)` converts `vkWasm` into a nested-array format — both reference the same WASM heap data. After the conversion, `vkWasm` goes out of scope and becomes GC-eligible.
+**Root cause:** There are two layers of `FinalizationRegistry` that interact badly during the cache restore path.
 
-After the first `prove()`, V8 GC collects these intermediate wrappers. The `FinalizationRegistry` fires and calls `.free()` on their WASM pointers — but the prover still references those pointers through the converted structures. The second `prove()` hits dangling WASM memory and silently hangs.
+All WASM structs live in linear memory (a single `ArrayBuffer`). Each JS wrapper is a thin `wasm_bindgen` object holding `__wbg_ptr` — an integer offset into that buffer.
 
-Without cache, keys are created through Pickles' Rust compilation path which manages WASM object lifetimes internally — no shared pointers, no premature finalization.
+**Layer 1 (unverified) — wasm_bindgen's per-class registry:** When `wasm_bindgen` is built with the `weak-refs` feature, each generated class has its own `FinalizationRegistry`. The static `__wrap()` method (used by property getters like `vk.srs`) creates a wrapper and registers it for automatic cleanup. **We have not confirmed whether o1js's wasm_bindgen build enables `weak-refs`** — the generated glue code (`plonk_wasm.js`) is not checked into the repo and is produced at build time. If `weak-refs` is not enabled, Bug 1 below does not apply.
 
+**Layer 2 — o1js's registry:** `freeOnFinalize` (in `conversion-core.ts` and `kimchi_bindings/js/bindings/util.js`) registers wrappers with a `FinalizationRegistry`.
+
+There are two implementations of `freeOnFinalize`:
+- `util.js` creates the representative via `x.constructor.__wrap()`, which goes through `wasm_bindgen`'s `__wrap` and may trigger a per-class registration — **double-free risk if `weak-refs` is enabled**.
+- `conversion-core.ts` creates the representative via `Object.create(Class.prototype)` (its own `wrap()` function), bypassing `wasm_bindgen` entirely — no double-free from the representative itself.
+
+### Bug 1 (unverified): Double-free from dual registry registration
+
+This bug depends on `wasm_bindgen`'s `weak-refs` feature being enabled. If it is: when `verifierIndexFromRust` (`conversion-verifier-index.ts:270`) accesses `vk.srs`, the `wasm_bindgen` getter creates a wrapper via `__wrap()` and registers it with the per-class `FinalizationRegistry`. Then `freeOnFinalize(vk.srs)` registers it with o1js's registry as well. On GC, both registries fire and free the same WASM pointer — use-after-free.
+
+### Bug 2: Dropped JS references to WASM-internal dependencies
+
+`decodeProverKey` (`prover-keys.ts`) drops JS references to objects that the WASM side still depends on:
+
+```js
+// prover-keys.ts — StepProvingKey case
+let srs = Pickles.loadSrsFp();                              // JS wrapper for SRS
+let index = wasm.caml_pasta_fp_plonk_index_decode(bytes, srs); // WASM stores SRS pointer internally
+return [KeyType.StepProvingKey, [0, index, cs]];             // srs wrapper NOT returned
+// → srs goes out of scope, GC-eligible — but WASM prover index still uses it
 ```
-compile({ cache })
-    ↓
-decodeProverKey(bytes) → wasm.caml_pasta_fp_plonk_index_decode(bytes, srs)
-    ↓
-JS wrapper A (__wbg_ptr: 42) → registered with FinalizationRegistry
-    ↓
-verifierIndexFromRust(A) → nested array structure (still references ptr 42)
-    ↓
-wrapper A goes out of scope, only nested array is kept
-    ↓
-first prove() works fine
-    ↓
-GC collects wrapper A → finalizer calls .free() on ptr 42
-    ↓
-second prove() → prover reads freed memory at ptr 42 → hang
+
+The WASM decode function stores the SRS pointer inside the prover index struct, but this is a WASM-internal reference invisible to JS GC. The `srs` wrapper becomes unreachable, gets collected, and the finalizer frees the SRS memory while the prover index still holds a dangling pointer to it.
+
+This bug only triggers if `loadSrsFp()` creates a new wrapper each time (i.e., each call returns a fresh JS object wrapping the same WASM pointer). If `loadSrsFp()` returns a globally-held singleton, the wrapper stays alive and this bug does not apply — Bug 1 (double-free) would be the actual culprit instead. We have not verified which behavior `loadSrsFp()` has.
+
+### Why this only affects the cache path
+
+Without cache, keys are created through Pickles' Rust compilation path which manages WASM object lifetimes internally — no shared pointers exposed to JS, no premature finalization.
+
+With cache, `decodeProverKey` deserializes artifacts directly, creating JS wrappers for WASM objects via `wasm_bindgen` getters and conversion functions — exposing shared pointers to the JS/finalizer boundary.
+
+Bug 1 flow (if `weak-refs` is enabled):
 ```
+vk.srs getter → wasm_bindgen __wrap() → registered with per-class FinalizationRegistry
+    ↓
+freeOnFinalize(vk.srs) → also registered with o1js's FinalizationRegistry
+    ↓
+GC collects wrapper → both registries fire → double-free on same WASM pointer
+```
+
+Bug 2 flow (if `loadSrsFp()` returns a fresh wrapper each call):
+```
+decodeProverKey(bytes)
+    ↓
+srs = loadSrsFp()  →  JS wrapper (__wbg_ptr: 100)
+    ↓
+wasm.caml_pasta_fp_plonk_index_decode(bytes, srs)
+    ↓                         ↓
+returns index wrapper    WASM prover index struct internally holds ptr 100
+    ↓
+return [StepProvingKey, [0, index, cs]]   ← srs wrapper NOT kept
+    ↓
+srs wrapper goes out of scope, GC-eligible
+    ↓
+first prove() works fine (GC hasn't run yet)
+    ↓
+GC collects srs wrapper → finalizer frees WASM memory at ptr 100
+    ↓
+second prove() → prover index reads freed memory at ptr 100 → hang
+```
+
+### Upstream fix: prevent double-free (Bug 1, unverified)
+
+Branch `fix/finalization-double-free` on [mellowcroc/o1js](https://github.com/mellowcroc/o1js/commit/4cc8f403) fixes the double-free by calling `__destroy_into_raw()` before re-registering with o1js's registry:
+
+```ts
+if (typeof (instance as any).__destroy_into_raw === 'function') {
+  (instance as any).__destroy_into_raw();  // detach from wasm_bindgen's registry
+  (instance as any).__wbg_ptr = ptr;       // restore pointer for continued use
+}
+```
+
+This ensures each WASM pointer has exactly one free path. The fix is in `conversion-core.ts`'s `freeOnFinalize`; the `util.js` variant (which uses `__wrap` for the representative) may need a similar fix.
+
+### Upstream fix: retain SRS wrapper (Bug 2)
+
+Branch `fix/retain-wasm-deps` on [mellowcroc/o1js](https://github.com/mellowcroc/o1js/tree/fix/retain-wasm-deps) fixes the dropped-reference problem by attaching the SRS wrapper as a non-enumerable property on the WASM index object:
+
+```ts
+function retainDep(owner: object, dep: object) {
+  Object.defineProperty(owner, '_wasmDep', { value: dep });
+}
+```
+
+This is called in each `decodeProverKey` case after the WASM decode, ensuring the SRS JS wrapper shares the same lifetime as the prover/verifier index. The wrapper stays alive as long as the index does, preventing the finalizer from freeing the SRS while the WASM struct still references it.
+
+### Current workaround
 
 **Fix:** `ui/lib/disable-wasm-finalizers.ts` overrides `globalThis.FinalizationRegistry` with a no-op class before o1js loads. WASM objects are never auto-freed; memory is reclaimed when the worker is torn down on page refresh. This is imported as the first line of the worker (`import './disable-wasm-finalizers'`) so it runs before o1js's module initialization creates its registry.
+
+This workaround can be removed once the upstream fixes are merged into o1js and the vendored copy is updated. Before removing, verify which bug (or both) actually applies by checking whether `wasm_bindgen`'s `weak-refs` feature is enabled in the build and whether `loadSrsFp()` returns a singleton or fresh wrapper.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,22 @@ MinaGuard is a multisig wallet zkApp for Mina built with o1js, plus a Next.js UI
 - Indexed read API for contracts, owners, proposals, approvals, and raw events.
 - Deploy + setup UI flow with session-only zkApp private key usage.
 
+## o1js dependency
+
+The monorepo depends on a [fork of o1js](https://github.com/mellowcroc/o1js/tree/mesa-srs-fix) (`mesa-srs-fix` branch) rather than the upstream `3.0.0-mesa.0` release.
+
+The upstream `srs.ts` calls `caml_{fp,fq}_srs_get_lagrange_basis` to compute and cache the lagrange basis during compilation. This WASM function is not properly implemented for the web target — it throws an uncaught error that crashes the browser tab. The upstream code has a TODO acknowledging this but no guard around it. The issue only surfaces when a writable `Cache` is provided (which we now do via IndexedDB).
+
+The fork wraps both `getLagrangeBasis` call sites in try-catch. On the first site (cache miss with writable cache), the catch falls back to `lagrangeCommitment()` which computes the basis point-by-point without the broken WASM path. On the second site (post-computation cache write), the catch silently skips the cache write. Compilation succeeds either way — the lagrange basis is still computed, just not via the batch WASM function.
+
+The fix is baked into the fork's dist files so no postinstall patching is needed. Revert to upstream once this is fixed in a future o1js release.
+
 ## Development
 
 ### First-time setup
 
 ```bash
-# Fetch submodule (fork of o1js, for now)
+# Fetch submodule (o1js source, needed for mina-signer browser build)
 git submodule update --init
 
 bun install

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,6 @@
     "contracts": "workspace:*",
     "cors": "^2.8.5",
     "express": "^4.21.2",
-    "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
     "zod": "^3.25"
   },
   "devDependencies": {

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -472,8 +472,8 @@ export class MinaGuardIndexer {
       {
         threshold: asNumber(event.threshold),
         numOwners: asNumber(event.numOwners),
-        nonce: 0,
-        parentNonce: 0,
+        nonce: isRoot ? 0 : 1,
+        parentNonce: isRoot ? 0 : 1,
         configNonce: 0,
         networkId: asString(event.networkId),
         ownersCommitment: asString(event.ownersCommitment),

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -464,8 +464,6 @@ export class MinaGuardIndexer {
       data: { parent: isRoot ? null : parent },
     });
 
-    console.log(`[indexer][diag] applySetupEvent contractId=${contractId} isRoot=${isRoot} parent=${parent} nonce=${isRoot ? 0 : 1} parentNonce=${isRoot ? 0 : 1}`);
-
     await this.appendContractConfigSnapshot(
       contractId,
       chainEvent.blockHeight,
@@ -482,10 +480,6 @@ export class MinaGuardIndexer {
         childMultiSigEnabled: true,
       },
     );
-
-    // Verify what was actually written
-    const verifyConfig = await this.getLatestConfig(contractId);
-    console.log(`[indexer][diag] after setup snapshot: contractId=${contractId} nonce=${verifyConfig?.nonce} parentNonce=${verifyConfig?.parentNonce}`);
   }
 
   /** Inserts an OwnerMembership row for a setup owner and backfills config from on-chain if needed. */
@@ -756,12 +750,11 @@ export class MinaGuardIndexer {
 
     const local = await prisma.proposal.findUnique({
       where: { contractId_proposalHash: { contractId, proposalHash } },
-      select: { id: true, nonce: true, lastExecuteTxHash: true, txType: true },
+      select: { id: true, nonce: true, lastExecuteTxHash: true },
     });
     if (local) {
       await this.upsertProposalExecution(local.id, blockHeight, txHash, eventOrder);
       const localNonce = local.nonce === null ? null : Number(local.nonce);
-      console.log(`[indexer][diag] execution LOCAL contractId=${contractId} txType=${local.txType} localNonce=${localNonce} proposalHash=${proposalHash?.slice(0, 12)}`);
       if (localNonce !== null && Number.isFinite(localNonce)) {
         await this.appendContractConfigSnapshot(
           contractId,
@@ -794,13 +787,18 @@ export class MinaGuardIndexer {
 
     const remote = await prisma.proposal.findUnique({
       where: { contractId_proposalHash: { contractId: parent.id, proposalHash } },
-      select: { id: true, nonce: true, lastExecuteTxHash: true },
+      select: { id: true, nonce: true, txType: true, lastExecuteTxHash: true },
     });
     if (!remote) return;
 
+    // executeSetupChild emits an execution event on the child contract.
+    // The parent's local path already marks the CREATE_CHILD proposal as
+    // executed — skip here to avoid overwriting the child's parentNonce
+    // (set to 1 by applySetupEvent) with the sentinel nonce 0.
+    if (remote.txType === '5') return;
+
     await this.upsertProposalExecution(remote.id, blockHeight, txHash, eventOrder);
     const remoteNonce = remote.nonce === null ? null : Number(remote.nonce);
-    console.log(`[indexer][diag] execution REMOTE contractId=${contractId} remoteNonce=${remoteNonce} proposalHash=${proposalHash?.slice(0, 12)}`);
     if (remoteNonce !== null && Number.isFinite(remoteNonce)) {
       await this.appendContractConfigSnapshot(
         contractId,

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -464,6 +464,8 @@ export class MinaGuardIndexer {
       data: { parent: isRoot ? null : parent },
     });
 
+    console.log(`[indexer][diag] applySetupEvent contractId=${contractId} isRoot=${isRoot} parent=${parent} nonce=${isRoot ? 0 : 1} parentNonce=${isRoot ? 0 : 1}`);
+
     await this.appendContractConfigSnapshot(
       contractId,
       chainEvent.blockHeight,
@@ -480,6 +482,10 @@ export class MinaGuardIndexer {
         childMultiSigEnabled: true,
       },
     );
+
+    // Verify what was actually written
+    const verifyConfig = await this.getLatestConfig(contractId);
+    console.log(`[indexer][diag] after setup snapshot: contractId=${contractId} nonce=${verifyConfig?.nonce} parentNonce=${verifyConfig?.parentNonce}`);
   }
 
   /** Inserts an OwnerMembership row for a setup owner and backfills config from on-chain if needed. */
@@ -750,11 +756,12 @@ export class MinaGuardIndexer {
 
     const local = await prisma.proposal.findUnique({
       where: { contractId_proposalHash: { contractId, proposalHash } },
-      select: { id: true, nonce: true, lastExecuteTxHash: true },
+      select: { id: true, nonce: true, lastExecuteTxHash: true, txType: true },
     });
     if (local) {
       await this.upsertProposalExecution(local.id, blockHeight, txHash, eventOrder);
       const localNonce = local.nonce === null ? null : Number(local.nonce);
+      console.log(`[indexer][diag] execution LOCAL contractId=${contractId} txType=${local.txType} localNonce=${localNonce} proposalHash=${proposalHash?.slice(0, 12)}`);
       if (localNonce !== null && Number.isFinite(localNonce)) {
         await this.appendContractConfigSnapshot(
           contractId,
@@ -793,6 +800,7 @@ export class MinaGuardIndexer {
 
     await this.upsertProposalExecution(remote.id, blockHeight, txHash, eventOrder);
     const remoteNonce = remote.nonce === null ? null : Number(remote.nonce);
+    console.log(`[indexer][diag] execution REMOTE contractId=${contractId} remoteNonce=${remoteNonce} proposalHash=${proposalHash?.slice(0, 12)}`);
     if (remoteNonce !== null && Number.isFinite(remoteNonce)) {
       await this.appendContractConfigSnapshot(
         contractId,

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -472,8 +472,8 @@ export class MinaGuardIndexer {
       {
         threshold: asNumber(event.threshold),
         numOwners: asNumber(event.numOwners),
-        nonce: isRoot ? 0 : 1,
-        parentNonce: isRoot ? 0 : 1,
+        nonce: 0,
+        parentNonce: 0,
         configNonce: 0,
         networkId: asString(event.networkId),
         ownersCommitment: asString(event.ownersCommitment),
@@ -787,15 +787,9 @@ export class MinaGuardIndexer {
 
     const remote = await prisma.proposal.findUnique({
       where: { contractId_proposalHash: { contractId: parent.id, proposalHash } },
-      select: { id: true, nonce: true, txType: true, lastExecuteTxHash: true },
+      select: { id: true, nonce: true, lastExecuteTxHash: true },
     });
     if (!remote) return;
-
-    // executeSetupChild emits an execution event on the child contract.
-    // The parent's local path already marks the CREATE_CHILD proposal as
-    // executed — skip here to avoid overwriting the child's parentNonce
-    // (set to 1 by applySetupEvent) with the sentinel nonce 0.
-    if (remote.txType === '5') return;
 
     await this.upsertProposalExecution(remote.id, blockHeight, txHash, eventOrder);
     const remoteNonce = remote.nonce === null ? null : Number(remote.nonce);

--- a/backend/src/lightnet.ts
+++ b/backend/src/lightnet.ts
@@ -125,10 +125,11 @@ export async function sendSignedLightnetPayment(params: {
   privateKey: string;
 }): Promise<string> {
   const { createRequire } = await import('module');
+  const { dirname, join } = await import('path');
   const require = createRequire(import.meta.url);
-  const { default: MinaSignerClient } = require(
-    'o1js/dist/node/mina-signer/mina-signer.js'
-  );
+  const o1jsMain = require.resolve('o1js');
+  const signerPath = join(dirname(o1jsMain), 'mina-signer', 'mina-signer.js');
+  const { default: MinaSignerClient } = await import(signerPath);
 
   const client = new MinaSignerClient({ network: 'testnet' });
   const signed = client.signPayment(

--- a/backend/src/lightnet.ts
+++ b/backend/src/lightnet.ts
@@ -124,8 +124,10 @@ export async function sendSignedLightnetPayment(params: {
   nonce: string;
   privateKey: string;
 }): Promise<string> {
-  const { default: MinaSignerClient } = await import(
-    '../node_modules/o1js/dist/node/mina-signer/mina-signer.js'
+  const { createRequire } = await import('module');
+  const require = createRequire(import.meta.url);
+  const { default: MinaSignerClient } = require(
+    'o1js/dist/node/mina-signer/mina-signer.js'
   );
 
   const client = new MinaSignerClient({ network: 'testnet' });

--- a/backend/src/proposal-record.ts
+++ b/backend/src/proposal-record.ts
@@ -95,9 +95,9 @@ export function deriveInvalidReason(
 /**
  * Derives proposal status from the append-only schema plus read-time checks.
  *
- * Precedence: `executed` (ProposalExecution row) > `invalidated`
- * (deriveInvalidReason returned non-null) > `expired` (latestHeight past
- * expiryBlock) > `pending`.
+ * Precedence: `executed` (ProposalExecution row) > `expired` (latestHeight
+ * past expiryBlock) > `invalidated` (deriveInvalidReason returned non-null)
+ * > `pending`.
  */
 function deriveStatus(
   proposal: Proposal,
@@ -106,9 +106,9 @@ function deriveStatus(
   invalidReason: InvalidReason | null,
 ): string {
   if (executed) return 'executed';
-  if (invalidReason !== null) return 'invalidated';
   const expiry = Number(proposal.expiryBlock ?? '0');
   if (Number.isFinite(expiry) && expiry > 0 && latestHeight > expiry) return 'expired';
+  if (invalidReason !== null) return 'invalidated';
   return 'pending';
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mina-guard",
       "dependencies": {
-        "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
+        "o1js": "github:mellowcroc/o1js#mesa-srs-fix",
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -21,7 +21,6 @@
         "contracts": "workspace:*",
         "cors": "^2.8.5",
         "express": "^4.21.2",
-        "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
         "zod": "^3.25",
       },
       "devDependencies": {
@@ -48,9 +47,6 @@
         "ts-jest": "^29.2.4",
         "typescript": "^5.4.5",
       },
-      "peerDependencies": {
-        "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
-      },
     },
     "dev-helpers": {
       "name": "dev-helpers",
@@ -68,7 +64,6 @@
       "name": "e2e",
       "dependencies": {
         "contracts": "workspace:*",
-        "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
       },
       "devDependencies": {
         "@playwright/test": "^1.50.0",
@@ -89,7 +84,6 @@
         "js-sha256": "^0.9.0",
         "mina-signer": "file:deps/o1js/src/mina-signer",
         "next": "^14.2.0",
-        "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
       },
@@ -1193,7 +1187,7 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "o1js": ["o1js@https://pkg.pr.new/o1-labs/o1js@2701", { "dependencies": { "blakejs": "1.2.1", "cachedir": "^2.4.0", "js-sha256": "^0.9.0", "libsodium-wrappers-sumo": "^0.7.15", "reflect-metadata": "^0.1.13", "stacktrace-js": "^2.0.2", "tslib": "^2.3.0" }, "bin": { "snarky-run": "src/build/run.js" } }],
+    "o1js": ["o1js@github:mellowcroc/o1js#e0a1022", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "1.2.1", "cachedir": "^2.4.0", "libsodium-wrappers-sumo": "^0.7.15", "reflect-metadata": "^0.1.13", "stacktrace-js": "^2.0.2", "tslib": "^2.3.0" }, "bin": { "snarky-run": "src/build/run.js" } }, "mellowcroc-o1js-e0a1022"],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1598,6 +1592,8 @@
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "contracts/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+
+    "dev-helpers/o1js": ["o1js@https://pkg.pr.new/o1-labs/o1js@2701", { "dependencies": { "blakejs": "1.2.1", "cachedir": "^2.4.0", "js-sha256": "^0.9.0", "libsodium-wrappers-sumo": "^0.7.15", "reflect-metadata": "^0.1.13", "stacktrace-js": "^2.0.2", "tslib": "^2.3.0" }, "bin": { "snarky-run": "src/build/run.js" } }],
 
     "e2e/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -37,9 +37,6 @@
     "ts-jest": "^29.2.4",
     "typescript": "^5.4.5"
   },
-  "peerDependencies": {
-    "o1js": "https://pkg.pr.new/o1-labs/o1js@2701"
-  },
   "engines": {
     "node": ">=18.14.0"
   }

--- a/contracts/src/MinaGuard.ts
+++ b/contracts/src/MinaGuard.ts
@@ -753,8 +753,8 @@ export class MinaGuard extends SmartContract {
       numOwners,
       proposal.networkId,
       parentAddress,
-      Field(1),
-      Field(1),
+      Field(0),
+      Field(0),
       initialOwners,
     );
 

--- a/contracts/src/tests/child.test.ts
+++ b/contracts/src/tests/child.test.ts
@@ -414,7 +414,7 @@ describe('MinaGuard - Child Lifecycle', () => {
 
       const reclaimAmount = UInt64.from(1_000_000_000);
       const { proposal, proposalHash, parentApprovalWitness, parentApprovalCount } =
-        await approveReclaim(reclaimAmount, Field(2));
+        await approveReclaim(reclaimAmount, Field(1));
 
       const parentBalanceBefore = getBalance(parentCtx.zkAppAddress);
       const childExecutionWitness = childExecutionWitnessFor(proposalHash);
@@ -441,7 +441,7 @@ describe('MinaGuard - Child Lifecycle', () => {
 
       const amount = UInt64.from(500_000_000);
       const { proposal, proposalHash, parentApprovalWitness, parentApprovalCount } =
-        await approveReclaim(amount, Field(2));
+        await approveReclaim(amount, Field(1));
 
       // First execution succeeds.
       const childExecutionWitness = childExecutionWitnessFor(proposalHash);
@@ -481,7 +481,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       const amount = UInt64.from(500_000_000);
       const proposal = createReclaimChildProposal(
         amount,
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -514,7 +514,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       // Disable the child's multisig first.
       const disableProposal = createEnableChildMultiSigProposal(
         Field(0),
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -543,7 +543,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       // Reclaim should still work — child-lifecycle methods bypass the flag.
       const amount = UInt64.from(1_000_000_000);
       const { proposal, proposalHash, parentApprovalWitness, parentApprovalCount } =
-        await approveReclaim(amount, Field(3));
+        await approveReclaim(amount, Field(2));
 
       const parentBalanceBefore = getBalance(parentCtx.zkAppAddress);
       const childExecutionWitness = childExecutionWitnessFor(proposalHash);
@@ -570,7 +570,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       const approvedAmount = UInt64.from(1_000_000_000);
       const wrongAmount = UInt64.from(2_000_000_000);
       const { proposal, proposalHash, parentApprovalWitness, parentApprovalCount } =
-        await approveReclaim(approvedAmount, Field(2));
+        await approveReclaim(approvedAmount, Field(1));
 
       const childExecutionWitness = childExecutionWitnessFor(proposalHash);
 
@@ -597,7 +597,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       await setupChildWithParentOwners();
 
       const destroyProposal = createDestroyChildProposal(
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -635,7 +635,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       await setupChildWithParentOwners();
 
       const destroyProposal = createDestroyChildProposal(
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -676,7 +676,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       await setupChildWithParentOwners();
 
       const destroyProposal = createDestroyChildProposal(
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -739,7 +739,7 @@ describe('MinaGuard - Child Lifecycle', () => {
 
       const proposal = createEnableChildMultiSigProposal(
         Field(0), // data = disable
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -770,7 +770,7 @@ describe('MinaGuard - Child Lifecycle', () => {
 
       const proposal = createEnableChildMultiSigProposal(
         Field(0),
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -816,7 +816,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       await setupChildWithParentOwners();
 
       // Disable.
-      await runEnable(Field(0), Field(2));
+      await runEnable(Field(0), Field(1));
       expect(childZkApp.childMultiSigEnabled.get()).toEqual(Field(0));
 
       // assertChildMultiSigEnabledIfChild() is the first check in every gated
@@ -911,7 +911,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       }
 
       // Re-enable; every gated method must now reach past the disable check.
-      await runEnable(Field(1), Field(3));
+      await runEnable(Field(1), Field(2));
       expect(childZkApp.childMultiSigEnabled.get()).toEqual(Field(1));
 
       // Helper: calls `fn` and asserts any thrown error is NOT the gate error.
@@ -1016,7 +1016,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       const amount = UInt64.from(1_000_000);
       const proposalForA = createReclaimChildProposal(
         amount,
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -1055,7 +1055,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       const amount = UInt64.from(500_000_000);
       const reclaim = createReclaimChildProposal(
         amount,
-        Field(2),
+        Field(1),
         Field(0), // parent configNonce at time of propose
         parentCtx.zkAppAddress,
         Field(0),
@@ -1120,7 +1120,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       // for ENABLE_CHILD_MULTI_SIG, so the proposal is accepted on the parent.
       const proposal = createEnableChildMultiSigProposal(
         Field(2),
-        Field(2),
+        Field(1),
         Field(0),
         parentCtx.zkAppAddress,
         Field(0),
@@ -1155,7 +1155,7 @@ describe('MinaGuard - Child Lifecycle', () => {
 
       const amount = UInt64.from(1_000_000_000);
       const reclaim = createReclaimChildProposal(
-        amount, Field(2), Field(0), parentCtx.zkAppAddress,
+        amount, Field(1), Field(0), parentCtx.zkAppAddress,
         Field(0), parentCtx.networkId, childAddress,
       );
       const { parentApprovalWitness, parentApprovalCount, proposalHash } =
@@ -1205,7 +1205,7 @@ describe('MinaGuard - Child Lifecycle', () => {
       await setupChildWithParentOwners();
 
       const destroyProposal = createDestroyChildProposal(
-        Field(2), Field(0), parentCtx.zkAppAddress,
+        Field(1), Field(0), parentCtx.zkAppAddress,
         Field(0), parentCtx.networkId, childAddress,
       );
       const { parentApprovalWitness, parentApprovalCount, proposalHash } =

--- a/dev-helpers/lightnet-up.sh
+++ b/dev-helpers/lightnet-up.sh
@@ -25,4 +25,4 @@ stop_if_running "zkao-postgres-dev"
 stop_if_running "local-lightnet-1"
 
 echo "Starting zk lightnet (mesa)..."
-zk lightnet start --mina-branch=mesa --pull=false
+zk lightnet start --mina-branch=mesa --pull=false --slot-time 3000

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -57,6 +57,7 @@ ENV NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
 ENV NEXT_PUBLIC_MINA_ENDPOINT=http://lightnet:8080/graphql
 ENV NEXT_PUBLIC_ARCHIVE_ENDPOINT=http://lightnet:8282
 ENV NEXT_PUBLIC_E2E_TEST=true
+ENV NEXT_PUBLIC_POLL_INTERVAL_MS=3000
 RUN cd ui && bun run build
 
 # Prisma client must be generated in-image; `bun run --filter backend dev`

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -64,6 +64,11 @@ RUN cd ui && bun run build
 # shells into `db:push` which expects the client to exist.
 RUN cd backend && bunx prisma generate
 
+# Chromium calculates IDB quota from the partition hosting its profile dir.
+# Default /tmp is often a small tmpfs — point it to the working directory.
+ENV TMPDIR=/app/.tmp
+RUN mkdir -p /app/.tmp
+
 COPY e2e/ e2e/
 
 ENTRYPOINT ["/app/e2e/entrypoint.sh"]

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -135,6 +135,80 @@ NETWORK=devnet bun run test:e2e:verbose
 
 This invokes Playwright directly and streams all `[e2e-setup]`, `[e2e]`, and `[e2e-teardown]` logs to your terminal.
 
+## Test coverage
+
+55 serial tests in `onchain-flow.test.ts`, split into on-chain lifecycle tests and UI validation tests. All run in a single browser page with periodic page recycles to keep WASM memory under the V8 heap limit.
+
+### Contract lifecycle (tests 1–11)
+
+- Deploy MinaGuard contract and verify initial state (1 owner, threshold 1/1)
+- Add owner → propose, execute
+- Change threshold to 2/2 → propose, execute
+- Transfer MINA → propose, approve (2nd signer), execute
+- Verify Settings and Transactions pages
+
+### Owner & threshold management (tests 12–17)
+
+- Lower threshold back to 1/2 → propose, approve, execute
+- Remove owner → propose, execute
+- Verify state after removal
+
+### Delegation (tests 18–22)
+
+- Set delegate → propose, execute, verify delegate card
+- Undelegate → propose, execute
+
+### Proposal expiry (tests 23–25)
+
+- Propose transfer with near-future expiry block
+- Wait for expiry and verify execute button is hidden
+- State checkpoint before subaccount tests
+
+### Subaccount lifecycle (tests 26–37)
+
+- Create child → propose, finalize deployment, verify in UI tree
+- Fund contracts for allocation tests
+- Allocate (parent → child) → propose, execute
+- Reclaim (child → parent) → propose, execute
+- Disable child multi-sig → propose, execute
+- Destroy child → propose, execute
+
+### Delete proposal (tests 38–39)
+
+- Propose a transfer, then create a delete proposal targeting it
+- Execute delete and verify original proposal is invalidated
+
+### Final state (test 40)
+
+- Verify owner count, threshold, transaction counts across all tabs
+
+### Form validation (tests 41–53)
+
+UI-only tests — no on-chain transactions.
+
+- **Transfer**: invalid address, negative/zero amount, missing comma, duplicate recipients, extra commas/whitespace
+- **Add owner**: duplicate owner, invalid B62 address
+- **Threshold**: value exceeding owner count, same-as-current rejection
+- **Non-existent proposal**: 404 handling for invalid proposal hash
+- **Remove owner**: removing below threshold, removing non-owner
+- **Delegate**: empty/invalid address, undelegate toggle
+- **Destroy subaccount**: confirmation checkbox required
+- **Nonce**: zero, negative, decimal, non-numeric values
+- **Action buttons**: executed/invalidated proposals have no actions, expired proposals have no execute button
+- **Tab counts**: transaction list tab counts match API response
+
+## Compile cache (IndexedDB)
+
+The frontend caches o1js prover/verifier keys in IndexedDB so that page reloads skip the expensive key-generation WASM step. Cold compile takes ~280s; cached compile takes ~155s.
+
+**Size**: ~1.7GB across ~24 entries. This is large but within the storage budgets of major browsers — Google Docs offline, Figma, VS Code for Web, Unity WebGL games, and mapping apps all store hundreds of MB to multi-GB in IndexedDB.
+
+**Storage limits**: Chrome allows each origin up to ~6% of total disk (e.g. ~15GB on a 256GB drive). Firefox and Safari have smaller budgets. The cache checks `navigator.storage.estimate()` before writing and disables writes if less than 2GB is available.
+
+**Eviction**: browsers may evict "best-effort" storage when disk pressure is high, prioritizing least-recently-used origins. Users can also clear the cache manually via Settings → Compile Cache → "Clear Compile Cache", or through browser DevTools (Application → IndexedDB → `o1js-compile-cache`).
+
+**Page recycling**: on-chain e2e tests reload the page every ~15 transactions to release accumulated WASM memory (~30-40MB per transaction). The compile cache makes this viable — without it, each reload would require a full ~280s cold compile.
+
 ## Debugging
 
 - Playwright HTML report is generated at `e2e/playwright-report/` (run `bunx playwright show-report` to view)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -203,7 +203,7 @@ The frontend caches o1js prover/verifier keys in IndexedDB so that page reloads 
 
 **Size**: ~1.7GB across ~24 entries. This is large but within the storage budgets of major browsers — Google Docs offline, Figma, VS Code for Web, Unity WebGL games, and mapping apps all store hundreds of MB to multi-GB in IndexedDB.
 
-**Storage limits**: Chrome allows each origin up to ~6% of total disk (e.g. ~15GB on a 256GB drive). Firefox and Safari have smaller budgets. The cache checks `navigator.storage.estimate()` before writing and disables writes if less than 2GB is available.
+**Storage limits**: Chrome allows each origin up to ~6% of total disk (e.g. ~15GB on a 256GB drive). Firefox and Safari have smaller budgets. The cache checks `navigator.storage.estimate()` before writing and disables writes if less than 1.8GB is available.
 
 **Eviction**: browsers may evict "best-effort" storage when disk pressure is high, prioritizing least-recently-used origins. Users can also clear the cache manually via Settings → Compile Cache → "Clear Compile Cache", or through browser DevTools (Application → IndexedDB → `o1js-compile-cache`).
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -137,7 +137,7 @@ This invokes Playwright directly and streams all `[e2e-setup]`, `[e2e]`, and `[e
 
 ## Test coverage
 
-55 serial tests in `onchain-flow.test.ts`, split into on-chain lifecycle tests and UI validation tests. All run in a single browser page with periodic page recycles to keep WASM memory under the V8 heap limit.
+53 serial tests in `onchain-flow.test.ts`, split into on-chain lifecycle tests and UI validation tests. All run in a single browser page with periodic page recycles to keep WASM memory under the V8 heap limit.
 
 ### Contract lifecycle (tests 1–11)
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -183,7 +183,7 @@ export default async function globalSetup() {
       log('Starting lightnet (this may take 1-2 minutes)...');
       try {
         // --pull=false: use the digest pinned by dev-helpers/pin-lightnet.sh.
-        execSync('zk lightnet start --pull=false', {
+        execSync('zk lightnet start --pull=false --slot-time 3000', {
           cwd: ROOT,
           stdio: 'inherit',
           timeout: 300_000,
@@ -319,6 +319,7 @@ export default async function globalSetup() {
       NEXT_PUBLIC_MINA_ENDPOINT: config.minaEndpoint,
       NEXT_PUBLIC_ARCHIVE_ENDPOINT: config.archiveEndpoint,
       NEXT_PUBLIC_E2E_TEST: 'true',
+      NEXT_PUBLIC_POLL_INTERVAL_MS: '3000',
     };
     log('Starting frontend...');
     const frontendChild = spawnService(

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -155,6 +155,7 @@ export async function waitForIndexer(
   log(`Waiting: ${description}`);
   const start = Date.now();
   let dots = 0;
+  let lastError: string | null = null;
   while (Date.now() - start < timeoutMs) {
     const ok = await check();
     if (ok) {
@@ -163,10 +164,18 @@ export async function waitForIndexer(
     }
     dots++;
     if (dots % 5 === 0) {
-      log(`  Still waiting... (${((Date.now() - start) / 1000).toFixed(0)}s)`);
+      const status = await getIndexerStatus();
+      const err = status?.lastError;
+      if (err && err !== lastError) {
+        log(`  ⚠ Indexer error: ${err}`);
+        lastError = err;
+      }
+      log(`  Still waiting... (${((Date.now() - start) / 1000).toFixed(0)}s) [height=${status?.indexedHeight ?? '?'}]`);
     }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  const finalStatus = await getIndexerStatus();
+  log(`  Indexer status at timeout: ${JSON.stringify(finalStatus)}`);
   throw new Error(
     `Timed out after ${(timeoutMs / 1000).toFixed(0)}s waiting: ${description}`
   );

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -32,6 +32,7 @@ const SHORT_WAIT = netConfig.mode === 'devnet' ? 10_000 : 3_000;
 
 let accounts: TestAccount[];
 let contractAddress: string;
+let childAddress: string;
 let proposalHashes: string[] = [];
 
 // Shared page — avoids Web Worker restart (and contract recompilation) between tests
@@ -115,6 +116,14 @@ async function gotoWithWallet(
       }
     }
   }
+}
+
+async function recyclePage(): Promise<void> {
+  log('=== Recycling page to reclaim WASM memory ===');
+  currentAccount = null;
+  await sharedPage.reload({ waitUntil: 'networkidle' });
+  await sharedPage.waitForTimeout(2_000);
+  log('Page recycled');
 }
 
 // On failure, dump backend state for debugging
@@ -969,6 +978,8 @@ test('20. Verify delegate card shows delegate', async () => { const page = share
   log('Dashboard shows delegate address');
 });
 
+test('20.5. Recycle page', async () => { await recyclePage(); });
+
 // ---------------------------------------------------------------------------
 // 21. Propose undelegate
 // ---------------------------------------------------------------------------
@@ -1151,51 +1162,1113 @@ test('24. Verify proposal expires and execute button is hidden', async () => { c
 // 25. Verify final state
 // ---------------------------------------------------------------------------
 
-test('25. Verify final state', async () => { const page = sharedPage;
-  log('=== Step 25: Verify final state ===');
+test('25. Verify state before subaccount tests', async () => { const page = sharedPage;
+  log('=== Step 25: Verify state before subaccount tests ===');
 
-  // Dashboard — delegate card should show contract self (undelegated)
   await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
   await expect(page.locator('text=Block Producer Delegate')).toBeVisible({ timeout: 10_000 });
   log('Delegate card visible on dashboard');
 
-  // Settings — 1 owner
   await navigateTo(page, '/settings');
   await page.waitForTimeout(SHORT_WAIT);
   await expect(page.locator('text=Owners (1)')).toBeVisible({ timeout: 10_000 });
   log('Settings shows 1 owner');
 
-  // Transactions — all proposals should be executed
   await navigateTo(page, '/transactions');
   await page.waitForTimeout(SHORT_WAIT);
 
   const executedTab = page.locator('button', { hasText: /Executed/i }).first();
   const executedText = await executedTab.textContent();
   log(`Executed tab: ${executedText}`);
-  expect(executedText).toContain('7'); // 5 original + delegate + undelegate
+  expect(executedText).toContain('7');
 
   const expiredTab = page.locator('button', { hasText: /Expired/i }).first();
   const expiredText = await expiredTab.textContent();
   log(`Expired tab: ${expiredText}`);
-  expect(expiredText).toContain('1'); // the expiry test proposal
+  expect(expiredText).toContain('1');
 
   const pendingTab = page.locator('button', { hasText: /Pending/i }).first();
   const pendingText = await pendingTab.textContent();
   log(`Pending tab: ${pendingText}`);
   expect(pendingText).toContain('0');
 
-  // Final dump
-  log('\n=== Final State ===');
-  await dumpState(contractAddress);
-  log('\n=== All 25 steps completed successfully! ===');
+  log('State checkpoint passed');
+});
+
+// ===========================================================================
+// SUBACCOUNT LIFECYCLE
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 26. Propose CREATE_CHILD (subaccount) on parent
+// ---------------------------------------------------------------------------
+
+test('26. Propose CREATE_CHILD on parent', async () => { const page = sharedPage;
+  log('=== Step 26: Propose CREATE_CHILD ===');
+
+  await gotoWithWallet(`/accounts/new?parent=${contractAddress}`, accounts[0]);
+
+  await page.waitForFunction(
+    (addr: string) => document.body.textContent?.includes(addr.slice(0, 6)),
+    accounts[0].publicKey,
+    { timeout: 30_000 }
+  );
+
+  log('Advancing wizard to step 2...');
+  await page.getByRole('button', { name: /^next$/i }).click();
+
+  log('Waiting for child keypair generation...');
+  await page.waitForFunction(
+    () => !document.body.textContent?.includes('Generating keypair'),
+    { timeout: 60_000 }
+  );
+
+  const addressEl = page
+    .getByText('Contract Address', { exact: true })
+    .locator('xpath=following-sibling::p[1]');
+  await addressEl.waitFor({ state: 'visible', timeout: 10_000 });
+  childAddress = (await addressEl.textContent())?.trim() ?? '';
+  expect(childAddress).toMatch(/^B62/);
+  expect(childAddress).not.toBe(contractAddress);
+  log(`Child address: ${childAddress}`);
+
+  log('Filling threshold...');
+  await page.locator('input[type="number"]').first().fill('1');
+
+  log('Clicking Propose subaccount...');
+  await page.getByRole('button', { name: /propose subaccount/i }).click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes CREATE_CHILD proposal',
+    async () => {
+      const proposals = await getProposals(contractAddress);
+      return proposals.some(
+        (p: any) => p.txType === 'createChild' && p.childAccount === childAddress
+      );
+    }
+  );
+
+  const created = (await getProposals(contractAddress)).find(
+    (p: any) => p.txType === 'createChild' && p.childAccount === childAddress
+  );
+  expect(created).toBeDefined();
+  expect(created.approvalCount).toBe(1);
+  proposalHashes.push(created.proposalHash);
+  log(`CREATE_CHILD proposal: hash=${created.proposalHash.slice(0, 12)}..., approvals=${created.approvalCount}`);
 });
 
 // ---------------------------------------------------------------------------
-// TODO: Restore tests 26-32 (CREATE_CHILD, finalize, ALLOCATE_CHILD,
-// RECLAIM_CHILD, DESTROY_CHILD, final-state verification) once worker-
-// recycling lands. The combined LOCAL + subaccount flow silently hangs
-// `tx.prove()` around the 20th proof; the 8 GB V8 heap bump tripled
-// runway but is not enough. Likely needs periodic page reload + persistent
-// VK cache to work.
+// 27. Finalize subaccount deployment (executeSetupChild on the new child)
 // ---------------------------------------------------------------------------
+
+test('27. Finalize subaccount deployment', async () => { const page = sharedPage;
+  log('=== Step 27: Finalize subaccount deployment ===');
+
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const finalizeBtn = page.getByRole('button', { name: /finalize deployment/i });
+  await finalizeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  log('Clicking Finalize deployment...');
+  await finalizeBtn.click();
+
+  log('Waiting for executeSetupChild transaction...');
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer discovers child contract + marks parent proposal executed',
+    async () => {
+      const child = await getContract(childAddress);
+      const parent = await getProposal(contractAddress, proposalHashes[proposalHashes.length - 1]);
+      return child !== null && parent?.status === 'executed';
+    },
+    180_000,
+    netConfig.indexerPollIntervalMs
+  );
+
+  const child = await getContract(childAddress);
+  expect(child.parent).toBe(contractAddress);
+  expect(child.childMultiSigEnabled).toBe(true);
+  expect(child.threshold).toBe(1);
+  expect(child.numOwners).toBe(1);
+  log(`Child contract indexed: parent=${child.parent.slice(0, 12)}..., threshold=${child.threshold}/${child.numOwners}`);
+
+  const parentProposal = await getProposal(contractAddress, proposalHashes[proposalHashes.length - 1]);
+  expect(parentProposal.status).toBe('executed');
+  log(`Parent CREATE_CHILD proposal marked executed`);
+});
+
+// ---------------------------------------------------------------------------
+// 28. Verify subaccount shows up in the UI tree + child detail page renders
+// ---------------------------------------------------------------------------
+
+test('28. Verify subaccount in UI tree', async () => { const page = sharedPage;
+  log('=== Step 28: Verify subaccount in UI ===');
+
+  await gotoWithWallet('/', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const childRow = page.locator('a', {
+    has: page.locator(`text=${childAddress.slice(0, 10)}`),
+  });
+  await expect(childRow).toBeVisible({ timeout: 15_000 });
+  log('Child row visible in account tree');
+
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+  await expect(page.locator('text=Subaccounts (1)')).toBeVisible({ timeout: 10_000 });
+  log('Subaccounts (1) card visible on parent dashboard');
+
+  await gotoWithWallet(`/accounts/${childAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+  await expect(page.locator('text=Parent Account')).toBeVisible({ timeout: 10_000 });
+  log('Child detail renders with Parent card');
+});
+
+// ---------------------------------------------------------------------------
+// 29. Fund child contract
+// ---------------------------------------------------------------------------
+
+test('29. Fund contracts for allocation tests', async () => {
+  log('=== Step 29: Fund contracts for allocation tests ===');
+  await fundContract(contractAddress, accounts[0], 10);
+  log('Parent contract topped up with 10 MINA');
+  await fundContract(childAddress, accounts[0], 5);
+  log('Child contract funded with 5 MINA');
+});
+
+// ---------------------------------------------------------------------------
+// 30. Propose ALLOCATE_CHILD (parent → child)
+// ---------------------------------------------------------------------------
+
+test('30. Propose ALLOCATE_CHILD', async () => { const page = sharedPage;
+  log('=== Step 30: Propose ALLOCATE_CHILD ===');
+  // Navigate to parent first to make it the active contract (child was active
+  // after test 28's detail-page visit).
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+  await gotoWithWallet('/transactions/new?type=allocateChild', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const recipientsTextarea = page.locator('textarea').first();
+  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
+  await recipientsTextarea.fill(`${childAddress},2`);
+
+  const expiryInput = page.locator('input[placeholder="0"]');
+  if ((await expiryInput.count()) > 0) {
+    await expiryInput.first().fill('0');
+  }
+
+  log('Submitting allocate proposal...');
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes ALLOCATE_CHILD proposal',
+    async () => {
+      const proposals = await getProposals(contractAddress, 'pending');
+      return proposals.some((p: any) => p.txType === 'allocateChild');
+    }
+  );
+
+  const proposals = await getProposals(contractAddress, 'pending');
+  const allocateProposal = proposals.find((p: any) => p.txType === 'allocateChild');
+  expect(allocateProposal).toBeDefined();
+  proposalHashes.push(allocateProposal.proposalHash);
+  log(`ALLOCATE_CHILD proposal: hash=${allocateProposal.proposalHash.slice(0, 12)}...`);
+});
+
+// ---------------------------------------------------------------------------
+// 31. Execute ALLOCATE_CHILD
+// ---------------------------------------------------------------------------
+
+test('31. Execute ALLOCATE_CHILD', async () => { const page = sharedPage;
+  log('=== Step 31: Execute ALLOCATE_CHILD ===');
+  const proposalHash = proposalHashes[proposalHashes.length - 1];
+
+  await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  log('Clicking Execute Proposal...');
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await executeBtn.click();
+
+  log('Waiting for execute transaction...');
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes ALLOCATE_CHILD execution',
+    async () => {
+      const proposal = await getProposal(contractAddress, proposalHash);
+      return proposal?.status === 'executed';
+    }
+  );
+
+  const proposal = await getProposal(contractAddress, proposalHash);
+  expect(proposal.status).toBe('executed');
+  log(`ALLOCATE_CHILD executed`);
+});
+
+// ---------------------------------------------------------------------------
+// 32. Propose RECLAIM_CHILD (child → parent)
+// ---------------------------------------------------------------------------
+
+test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
+  log('=== Step 32: Propose RECLAIM_CHILD ===');
+  await gotoWithWallet('/transactions/new?type=reclaimChild', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // Select child in radio button group
+  const childLabel = page.locator(`label:has-text("${childAddress.slice(0, 10)}")`);
+  await childLabel.waitFor({ state: 'visible', timeout: 10_000 });
+  await childLabel.click();
+
+  // Fill reclaim amount
+  const amountInput = page.locator('input[placeholder="1.0"]');
+  await amountInput.waitFor({ state: 'visible', timeout: 5_000 });
+  await amountInput.fill('1');
+
+  const expiryInput = page.locator('input[placeholder="0"]');
+  if ((await expiryInput.count()) > 0) {
+    await expiryInput.first().fill('0');
+  }
+
+  log('Submitting reclaim proposal...');
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes RECLAIM_CHILD proposal',
+    async () => {
+      const proposals = await getProposals(contractAddress, 'pending');
+      return proposals.some((p: any) => p.txType === 'reclaimChild');
+    }
+  );
+
+  const proposals = await getProposals(contractAddress, 'pending');
+  const reclaimProposal = proposals.find((p: any) => p.txType === 'reclaimChild');
+  expect(reclaimProposal).toBeDefined();
+  proposalHashes.push(reclaimProposal.proposalHash);
+  log(`RECLAIM_CHILD proposal: hash=${reclaimProposal.proposalHash.slice(0, 12)}...`);
+});
+
+// ---------------------------------------------------------------------------
+// 33. Execute RECLAIM_CHILD
+// ---------------------------------------------------------------------------
+
+test('33. Execute RECLAIM_CHILD', async () => { const page = sharedPage;
+  log('=== Step 33: Execute RECLAIM_CHILD ===');
+  const proposalHash = proposalHashes[proposalHashes.length - 1];
+
+  await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  log('Clicking Execute Proposal...');
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await executeBtn.click();
+
+  log('Waiting for execute transaction...');
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes RECLAIM_CHILD execution',
+    async () => {
+      const proposal = await getProposal(contractAddress, proposalHash);
+      return proposal?.status === 'executed';
+    },
+    360_000,
+    10_000
+  );
+
+  const proposal = await getProposal(contractAddress, proposalHash);
+  expect(proposal.status).toBe('executed');
+  log(`RECLAIM_CHILD executed`);
+});
+
+test('33.5. Recycle page', async () => { await recyclePage(); });
+
+// ---------------------------------------------------------------------------
+// 34. Propose ENABLE_CHILD_MULTI_SIG (disable)
+// ---------------------------------------------------------------------------
+
+test('34. Propose ENABLE_CHILD_MULTI_SIG (disable)', async () => { const page = sharedPage;
+  log('=== Step 34: Propose enableChildMultiSig (disable) ===');
+  // Ensure parent is the active contract after page recycle
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+  await gotoWithWallet('/transactions/new?type=enableChildMultiSig', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const childLabel = page.locator(`label:has-text("${childAddress.slice(0, 10)}")`);
+  await childLabel.waitFor({ state: 'visible', timeout: 10_000 });
+  await childLabel.click();
+
+  const expiryInput = page.locator('input[placeholder="0"]');
+  if ((await expiryInput.count()) > 0) {
+    await expiryInput.first().fill('0');
+  }
+
+  log('Submitting enableChildMultiSig proposal...');
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes enableChildMultiSig proposal',
+    async () => {
+      const proposals = await getProposals(contractAddress, 'pending');
+      return proposals.some((p: any) => p.txType === 'enableChildMultiSig');
+    }
+  );
+
+  const proposals = await getProposals(contractAddress, 'pending');
+  const toggleProposal = proposals.find((p: any) => p.txType === 'enableChildMultiSig');
+  expect(toggleProposal).toBeDefined();
+  proposalHashes.push(toggleProposal.proposalHash);
+  log(`enableChildMultiSig proposal: hash=${toggleProposal.proposalHash.slice(0, 12)}...`);
+});
+
+// ---------------------------------------------------------------------------
+// 35. Execute ENABLE_CHILD_MULTI_SIG (disable)
+// ---------------------------------------------------------------------------
+
+test('35. Execute ENABLE_CHILD_MULTI_SIG (disable)', async () => { const page = sharedPage;
+  log('=== Step 35: Execute enableChildMultiSig (disable) ===');
+  const proposalHash = proposalHashes[proposalHashes.length - 1];
+
+  await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  log('Clicking Execute Proposal...');
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await executeBtn.click();
+
+  log('Waiting for execute transaction...');
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes enableChildMultiSig execution',
+    async () => {
+      const proposal = await getProposal(contractAddress, proposalHash);
+      return proposal?.status === 'executed';
+    }
+  );
+
+  // Verify child multi-sig is now disabled
+  await waitForIndexer(
+    'child contract reflects multi-sig disabled',
+    async () => {
+      const child = await getContract(childAddress);
+      return child?.childMultiSigEnabled === false;
+    }
+  );
+
+  const child = await getContract(childAddress);
+  expect(child.childMultiSigEnabled).toBe(false);
+  log(`Child multi-sig disabled: ${child.childMultiSigEnabled}`);
+});
+
+// ---------------------------------------------------------------------------
+// 36. Propose DESTROY_CHILD
+// ---------------------------------------------------------------------------
+
+test('36. Propose DESTROY_CHILD', async () => { const page = sharedPage;
+  log('=== Step 36: Propose destroyChild ===');
+  await gotoWithWallet('/transactions/new?type=destroyChild', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const childLabel = page.locator(`label:has-text("${childAddress.slice(0, 10)}")`);
+  await childLabel.waitFor({ state: 'visible', timeout: 10_000 });
+  await childLabel.click();
+
+  // Check confirmation checkbox
+  const confirmCheckbox = page.locator('input[type="checkbox"]').first();
+  await confirmCheckbox.waitFor({ state: 'visible', timeout: 5_000 });
+  await confirmCheckbox.check();
+
+  const expiryInput = page.locator('input[placeholder="0"]');
+  if ((await expiryInput.count()) > 0) {
+    await expiryInput.first().fill('0');
+  }
+
+  log('Submitting destroy proposal...');
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes destroyChild proposal',
+    async () => {
+      const proposals = await getProposals(contractAddress, 'pending');
+      return proposals.some((p: any) => p.txType === 'destroyChild');
+    }
+  );
+
+  const proposals = await getProposals(contractAddress, 'pending');
+  const destroyProposal = proposals.find((p: any) => p.txType === 'destroyChild');
+  expect(destroyProposal).toBeDefined();
+  proposalHashes.push(destroyProposal.proposalHash);
+  log(`destroyChild proposal: hash=${destroyProposal.proposalHash.slice(0, 12)}...`);
+});
+
+// ---------------------------------------------------------------------------
+// 37. Execute DESTROY_CHILD
+// ---------------------------------------------------------------------------
+
+test('37. Execute DESTROY_CHILD', async () => { const page = sharedPage;
+  log('=== Step 37: Execute destroyChild ===');
+  const proposalHash = proposalHashes[proposalHashes.length - 1];
+
+  await gotoWithWallet(`/transactions/${proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  log('Clicking Execute Proposal...');
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await executeBtn.click();
+
+  log('Waiting for execute transaction...');
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes destroyChild execution',
+    async () => {
+      const proposal = await getProposal(contractAddress, proposalHash);
+      return proposal?.status === 'executed';
+    },
+    360_000,
+    10_000
+  );
+
+  const proposal = await getProposal(contractAddress, proposalHash);
+  expect(proposal.status).toBe('executed');
+  log(`destroyChild executed`);
+});
+
+// ===========================================================================
+// DELETE PROPOSAL FLOW
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 38. Propose a transfer, then create a delete proposal for it
+// ---------------------------------------------------------------------------
+
+test('38. Propose transfer then delete it', async () => { const page = sharedPage;
+  log('=== Step 38: Propose transfer + delete ===');
+
+  // Ensure parent is the active contract after page recycle
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // First, create a normal transfer proposal
+  await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const recipientsTextarea = page.locator('textarea').first();
+  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
+  await recipientsTextarea.fill(`${accounts[2].publicKey},0.1`);
+
+  const expiryInput = page.locator('input[placeholder="0"]');
+  if ((await expiryInput.count()) > 0) {
+    await expiryInput.first().fill('0');
+  }
+
+  log('Submitting transfer proposal to delete later...');
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes transfer proposal (to be deleted)',
+    async () => {
+      const proposals = await getProposals(contractAddress, 'pending');
+      return proposals.some((p: any) => p.txType === 'transfer');
+    }
+  );
+
+  const proposals = await getProposals(contractAddress, 'pending');
+  const targetProposal = proposals.find((p: any) => p.txType === 'transfer');
+  expect(targetProposal).toBeDefined();
+  const targetHash = targetProposal.proposalHash;
+  const targetNonce = targetProposal.nonce;
+  proposalHashes.push(targetHash);
+  log(`Target proposal: hash=${targetHash.slice(0, 12)}..., nonce=${targetNonce}`);
+
+  // Navigate to the proposal detail and click Delete
+  await gotoWithWallet(`/transactions/${targetHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  log('Clicking Delete Proposal...');
+  const deleteBtn = page.getByRole('button', { name: /delete proposal/i });
+  await deleteBtn.waitFor({ state: 'visible', timeout: 10_000 });
+  await deleteBtn.click();
+
+  // Should redirect to /transactions/new?mode=delete&...
+  await page.waitForFunction(
+    () => window.location.search.includes('mode=delete'),
+    { timeout: 10_000 }
+  );
+
+  // Verify delete mode UI
+  await expect(page.locator('text=Delete pending proposal')).toBeVisible({ timeout: 5_000 });
+  log('Delete mode UI visible');
+
+  // Submit the delete proposal
+  log('Submitting delete proposal...');
+  const deleteSubmitBtn = page.getByRole('button', { name: /create delete proposal/i });
+  await deleteSubmitBtn.waitFor({ state: 'visible', timeout: 10_000 });
+  await deleteSubmitBtn.click();
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes delete proposal',
+    async () => {
+      const allProposals = await getProposals(contractAddress, 'pending');
+      return allProposals.some((p: any) => p.txType === 'transfer' && p.proposalHash !== targetHash);
+    }
+  );
+
+  const allProposals = await getProposals(contractAddress, 'pending');
+  const deleteProposal = allProposals.find(
+    (p: any) => p.txType === 'transfer' && p.proposalHash !== targetHash
+  );
+  expect(deleteProposal).toBeDefined();
+  proposalHashes.push(deleteProposal.proposalHash);
+  log(`Delete proposal created: hash=${deleteProposal.proposalHash.slice(0, 12)}...`);
+});
+
+// ---------------------------------------------------------------------------
+// 39. Execute delete proposal and verify invalidation
+// ---------------------------------------------------------------------------
+
+test('39. Execute delete proposal and verify invalidation', async () => { const page = sharedPage;
+  log('=== Step 39: Execute delete proposal ===');
+  const deleteProposalHash = proposalHashes[proposalHashes.length - 1];
+  const targetProposalHash = proposalHashes[proposalHashes.length - 2];
+
+  await gotoWithWallet(`/transactions/${deleteProposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  log('Clicking Execute Proposal...');
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await executeBtn.click();
+
+  log('Waiting for execute transaction...');
+  await waitForBanner(page, 'success');
+
+  await waitForIndexer(
+    'indexer processes delete execution + marks target invalidated',
+    async () => {
+      const deleteP = await getProposal(contractAddress, deleteProposalHash);
+      const targetP = await getProposal(contractAddress, targetProposalHash);
+      return deleteP?.status === 'executed' && targetP?.status === 'invalidated';
+    },
+    360_000,
+    10_000
+  );
+
+  const deleteP = await getProposal(contractAddress, deleteProposalHash);
+  expect(deleteP.status).toBe('executed');
+  log(`Delete proposal executed`);
+
+  const targetP = await getProposal(contractAddress, targetProposalHash);
+  expect(targetP.status).toBe('invalidated');
+  log(`Target proposal invalidated`);
+
+  // Verify Invalidated tab on transactions page
+  await navigateTo(page, '/transactions');
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
+  const invalidatedText = await invalidatedTab.textContent();
+  log(`Invalidated tab: ${invalidatedText}`);
+  expect(invalidatedText).toContain('1');
+});
+
+// ===========================================================================
+// FINAL STATE
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 40. Verify final state after all operations
+// ---------------------------------------------------------------------------
+
+test('40. Verify final state', async () => { const page = sharedPage;
+  log('=== Step 40: Verify final state ===');
+
+  // Settings — 1 owner, threshold 1
+  await gotoWithWallet('/settings', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+  await expect(page.locator('text=Owners (1)')).toBeVisible({ timeout: 10_000 });
+  log('Settings shows 1 owner');
+
+  // Transactions — count check
+  await navigateTo(page, '/transactions');
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const pendingTab = page.locator('button', { hasText: /Pending/i }).first();
+  const pendingText = await pendingTab.textContent();
+  log(`Pending tab: ${pendingText}`);
+  expect(pendingText).toContain('0');
+
+  const expiredTab = page.locator('button', { hasText: /Expired/i }).first();
+  const expiredText = await expiredTab.textContent();
+  log(`Expired tab: ${expiredText}`);
+  expect(expiredText).toContain('1');
+
+  const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
+  const invalidatedText = await invalidatedTab.textContent();
+  log(`Invalidated tab: ${invalidatedText}`);
+  expect(invalidatedText).toContain('1');
+
+  // Final dump
+  log('\n=== Final State ===');
+  await dumpState(contractAddress);
+  log('\n=== All 40 steps completed successfully! ===');
+});
+
+// ===========================================================================
+// FORM VALIDATION (no on-chain transactions)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 41. Transfer form validation
+// ---------------------------------------------------------------------------
+
+test('41. Transfer form validation', async () => { const page = sharedPage;
+  log('=== Step 41: Transfer form validation ===');
+  await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const recipientsTextarea = page.locator('textarea').first();
+  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
+
+  // Invalid address
+  await recipientsTextarea.fill('invalidaddress,1');
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+  const pageText = await page.textContent('body');
+  expect(pageText).toMatch(/invalid|error|address/i);
+  log('Invalid address rejected');
+
+  // Empty textarea
+  await recipientsTextarea.fill('');
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+  log('Empty form handled');
+});
+
+// ---------------------------------------------------------------------------
+// 42. Add owner validation
+// ---------------------------------------------------------------------------
+
+test('42. Add owner validation', async () => { const page = sharedPage;
+  log('=== Step 42: Add owner validation ===');
+  await gotoWithWallet('/transactions/new?type=addOwner', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // Try adding current owner (duplicate)
+  const ownerInput = page.locator('input[placeholder*="B62"]').first();
+  await ownerInput.waitFor({ state: 'visible', timeout: 5_000 });
+  await ownerInput.fill(accounts[0].publicKey);
+
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+  const pageText = await page.textContent('body');
+  expect(pageText).toMatch(/already.*owner/i);
+  log('Duplicate owner rejected');
+});
+
+// ---------------------------------------------------------------------------
+// 43. Threshold validation
+// ---------------------------------------------------------------------------
+
+test('43. Threshold validation', async () => { const page = sharedPage;
+  log('=== Step 43: Threshold validation ===');
+  await gotoWithWallet('/transactions/new?type=changeThreshold', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // Try threshold > numOwners (currently 1 owner)
+  const thresholdInput = page.locator('input[type="number"]').first();
+  await thresholdInput.waitFor({ state: 'visible', timeout: 5_000 });
+  await thresholdInput.fill('5');
+
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+  // The input should be clamped by max attribute or show an error
+  const inputMax = await thresholdInput.getAttribute('max');
+  log(`Threshold input max attribute: ${inputMax}`);
+
+  // Same threshold as current (1/1) → should show error
+  await thresholdInput.fill('1');
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+  const body = await page.textContent('body');
+  expect(body).toMatch(/same.*current/i);
+  log('Same-threshold rejection verified');
+});
+
+// ===========================================================================
+// CORNER CASE TESTS (UI-only, no on-chain transactions)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 44. Navigate to non-existent proposal
+// ---------------------------------------------------------------------------
+
+test('44. Navigate to non-existent proposal hash', async () => { const page = sharedPage;
+  log('=== Step 44: Non-existent proposal ===');
+  const fakeHash = '12345678901234567890';
+  await gotoWithWallet(`/transactions/${fakeHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const body = await page.textContent('body');
+  // Should show "not found" or redirect — not crash
+  const hasNotFound = /not found|no proposal|does not exist/i.test(body ?? '');
+  const onTransactionsList = page.url().includes('/transactions') && !page.url().includes(fakeHash);
+  expect(hasNotFound || onTransactionsList).toBe(true);
+  log(`Non-existent proposal handled: ${hasNotFound ? 'not-found message' : 'redirected to list'}`);
+});
+
+// ---------------------------------------------------------------------------
+// 45. Transfer form: malformed lines, zero amount, duplicate recipients
+// ---------------------------------------------------------------------------
+
+test('45. Transfer form parsing edge cases', async () => { const page = sharedPage;
+  log('=== Step 45: Transfer form parsing edge cases ===');
+  await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const textarea = page.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5_000 });
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+
+  // Missing comma → "expected address,amount"
+  await textarea.fill('B62qooZ8LNHjSomething');
+  await page.waitForTimeout(500);
+  let body = await page.textContent('body');
+  expect(body).toMatch(/expected.*address.*amount/i);
+  log('Missing comma rejected');
+
+  // Zero amount → "invalid amount" (parseMinaToNanomina rejects 0)
+  await textarea.fill(`${accounts[2].publicKey},0`);
+  await submitBtn.click();
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/invalid amount/i);
+  log('Zero amount rejected');
+
+  // Negative amount → "invalid amount"
+  await textarea.fill(`${accounts[2].publicKey},-1`);
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/invalid amount/i);
+  log('Negative amount rejected');
+
+  // Duplicate recipients → "duplicate recipient"
+  await textarea.fill(`${accounts[1].publicKey},1\n${accounts[1].publicKey},2`);
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/duplicate recipient/i);
+  log('Duplicate recipient rejected');
+
+  // Extra commas → "expected address,amount"
+  await textarea.fill(`${accounts[2].publicKey},1,extra`);
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/expected.*address.*amount/i);
+  log('Extra commas rejected');
+});
+
+// ---------------------------------------------------------------------------
+// 46. Remove owner validation: below threshold
+// ---------------------------------------------------------------------------
+
+test('46. Remove owner validation edge cases', async () => { const page = sharedPage;
+  log('=== Step 46: Remove owner validation ===');
+  await gotoWithWallet('/transactions/new?type=removeOwner', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // Currently 1 owner, threshold 1 → removing would drop below threshold
+  const removeSelect = page.locator('select').first();
+  if (await removeSelect.isVisible().catch(() => false)) {
+    await removeSelect.selectOption(accounts[0].publicKey);
+  } else {
+    const removeInput = page.locator('input[placeholder*="B62"]').first();
+    if (await removeInput.isVisible().catch(() => false)) {
+      await removeInput.fill(accounts[0].publicKey);
+    }
+  }
+
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+
+  const body = await page.textContent('body');
+  // Should show "reduce threshold first" error
+  expect(body).toMatch(/reduce.*threshold|cannot.*remove|below.*threshold/i);
+  log('Remove-below-threshold rejected');
+
+  // Try removing a non-owner address
+  const nonOwnerInput = page.locator('input[placeholder*="B62"]').first();
+  if (await nonOwnerInput.isVisible().catch(() => false)) {
+    await nonOwnerInput.fill(accounts[2].publicKey);
+    await submitBtn.click();
+    await page.waitForTimeout(1_000);
+    const bodyAfter = await page.textContent('body');
+    expect(bodyAfter).toMatch(/not.*current.*owner/i);
+    log('Non-owner removal rejected');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 47. Delegate form: invalid address, undelegate toggle
+// ---------------------------------------------------------------------------
+
+test('47. Delegate form validation', async () => { const page = sharedPage;
+  log('=== Step 47: Delegate form validation ===');
+  await gotoWithWallet('/transactions/new?type=setDelegate', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // The delegate form should have a text input for the delegate address
+  // and possibly an "undelegate" checkbox/toggle
+  const delegateInput = page.locator('input[placeholder*="B62"]').first();
+  if (await delegateInput.isVisible().catch(() => false)) {
+    // Empty delegate → should require an address
+    await delegateInput.fill('');
+    const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+    await submitBtn.click();
+    await page.waitForTimeout(500);
+    log('Empty delegate submission attempted');
+
+    // Invalid address format
+    await delegateInput.fill('notavalidaddress');
+    await submitBtn.click();
+    await page.waitForTimeout(500);
+    log('Invalid delegate address attempted');
+  }
+
+  // Check for undelegate toggle/checkbox
+  const undelegateToggle = page.locator('input[type="checkbox"]').first();
+  if (await undelegateToggle.isVisible().catch(() => false)) {
+    await undelegateToggle.check();
+    await page.waitForTimeout(500);
+    const body = await page.textContent('body');
+    // When undelegate is checked, the delegate input should be hidden/disabled
+    log(`Undelegate toggle checked, page state: ${body?.includes('Undelegate') ? 'has Undelegate label' : 'no label'}`);
+    await undelegateToggle.uncheck();
+  }
+  log('Delegate form validation checked');
+});
+
+// ---------------------------------------------------------------------------
+// 48. Destroy subaccount without confirmation checkbox
+// ---------------------------------------------------------------------------
+
+test('48. Destroy subaccount form requires confirmation', async () => { const page = sharedPage;
+  log('=== Step 48: Destroy confirmation required ===');
+
+  // Ensure parent contract is active
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+  await gotoWithWallet('/transactions/new?type=destroyChild', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const body = await page.textContent('body');
+  // If there are no children (destroyed in test 37), the form should say so
+  if (/no.*subaccount|no.*indexed/i.test(body ?? '')) {
+    log('No subaccounts available (destroyed in test 37) — validation skipped');
+    return;
+  }
+
+  // If children exist, try submitting without checking the confirm box
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+  await submitBtn.click();
+  await page.waitForTimeout(1_000);
+  const bodyAfter = await page.textContent('body');
+  expect(bodyAfter).toMatch(/confirm.*destroy|drains.*subaccount/i);
+  log('Destroy without confirmation rejected');
+});
+
+// ---------------------------------------------------------------------------
+// 49. Nonce validation: zero, negative, decimal
+// ---------------------------------------------------------------------------
+
+test('49. Nonce validation edge cases', async () => { const page = sharedPage;
+  log('=== Step 49: Nonce validation ===');
+  await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // Fill valid recipients so nonce is the only validation target
+  const textarea = page.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5_000 });
+  await textarea.fill(`${accounts[2].publicKey},1`);
+
+  const nonceInput = page.locator('input').first();
+  await nonceInput.waitFor({ state: 'visible', timeout: 5_000 });
+
+  const submitBtn = page.getByRole('button', { name: /submit proposal/i });
+
+  // Nonce = 0 → "must be a positive integer"
+  await nonceInput.fill('0');
+  await submitBtn.click();
+  await page.waitForTimeout(500);
+  let body = await page.textContent('body');
+  expect(body).toMatch(/positive integer|must be greater/i);
+  log('Nonce=0 rejected');
+
+  // Nonce = -1 → "must be a positive integer"
+  await nonceInput.fill('-1');
+  await submitBtn.click();
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/positive integer/i);
+  log('Nonce=-1 rejected');
+
+  // Nonce = 1.5 → "must be a positive integer"
+  await nonceInput.fill('1.5');
+  await submitBtn.click();
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/positive integer/i);
+  log('Nonce=1.5 rejected');
+
+  // Nonce = "abc" → "must be a positive integer"
+  await nonceInput.fill('abc');
+  await submitBtn.click();
+  await page.waitForTimeout(500);
+  body = await page.textContent('body');
+  expect(body).toMatch(/positive integer/i);
+  log('Nonce=abc rejected');
+});
+
+// ---------------------------------------------------------------------------
+// 50. Proposal detail: executed proposal has no approve/execute buttons
+// ---------------------------------------------------------------------------
+
+test('50. Executed proposal has no action buttons', async () => { const page = sharedPage;
+  log('=== Step 50: Executed proposal action buttons ===');
+
+  // Find an executed proposal
+  const proposals = await getProposals(contractAddress, 'executed');
+  expect(proposals.length).toBeGreaterThan(0);
+  const executedProposal = proposals[0];
+  log(`Checking executed proposal: ${executedProposal.proposalHash.slice(0, 12)}...`);
+
+  await gotoWithWallet(`/transactions/${executedProposal.proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // The page should show the proposal details but no approve/execute buttons
+  const approveBtn = page.getByRole('button', { name: /approve proposal/i });
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  const deleteBtn = page.getByRole('button', { name: /delete proposal/i });
+
+  expect(await approveBtn.isVisible().catch(() => false)).toBe(false);
+  expect(await executeBtn.isVisible().catch(() => false)).toBe(false);
+  expect(await deleteBtn.isVisible().catch(() => false)).toBe(false);
+  log('No action buttons on executed proposal');
+
+  // Should show "Executed" status badge
+  const body = await page.textContent('body');
+  expect(body).toMatch(/executed/i);
+  log('Executed status badge visible');
+});
+
+// ---------------------------------------------------------------------------
+// 51. Invalidated proposal has no action buttons
+// ---------------------------------------------------------------------------
+
+test('51. Invalidated proposal has no action buttons', async () => { const page = sharedPage;
+  log('=== Step 51: Invalidated proposal action buttons ===');
+
+  const proposals = await getProposals(contractAddress, 'invalidated');
+  expect(proposals.length).toBeGreaterThan(0);
+  const invalidatedProposal = proposals[0];
+  log(`Checking invalidated proposal: ${invalidatedProposal.proposalHash.slice(0, 12)}...`);
+
+  await gotoWithWallet(`/transactions/${invalidatedProposal.proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const approveBtn = page.getByRole('button', { name: /approve proposal/i });
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+
+  expect(await approveBtn.isVisible().catch(() => false)).toBe(false);
+  expect(await executeBtn.isVisible().catch(() => false)).toBe(false);
+  log('No action buttons on invalidated proposal');
+
+  const body = await page.textContent('body');
+  expect(body).toMatch(/invalidated/i);
+  log('Invalidated status badge visible');
+});
+
+// ---------------------------------------------------------------------------
+// 52. Expired proposal has no execute button
+// ---------------------------------------------------------------------------
+
+test('52. Expired proposal has no execute button', async () => { const page = sharedPage;
+  log('=== Step 52: Expired proposal action buttons ===');
+
+  const proposals = await getProposals(contractAddress, 'expired');
+  expect(proposals.length).toBeGreaterThan(0);
+  const expiredProposal = proposals[0];
+  log(`Checking expired proposal: ${expiredProposal.proposalHash.slice(0, 12)}...`);
+
+  await gotoWithWallet(`/transactions/${expiredProposal.proposalHash}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  expect(await executeBtn.isVisible().catch(() => false)).toBe(false);
+  log('No execute button on expired proposal');
+
+  const body = await page.textContent('body');
+  expect(body).toMatch(/expired/i);
+  log('Expired status badge visible');
+});
+
+// ---------------------------------------------------------------------------
+// 53. Transaction list tab counts are consistent
+// ---------------------------------------------------------------------------
+
+test('53. Transaction list tab counts match API', async () => { const page = sharedPage;
+  log('=== Step 53: Tab count consistency ===');
+
+  // Get counts from API
+  const executed = await getProposals(contractAddress, 'executed');
+  const pending = await getProposals(contractAddress, 'pending');
+  const expired = await getProposals(contractAddress, 'expired');
+  const invalidated = await getProposals(contractAddress, 'invalidated');
+  log(`API counts: executed=${executed.length}, pending=${pending.length}, expired=${expired.length}, invalidated=${invalidated.length}`);
+
+  await gotoWithWallet('/transactions', accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
+  // Verify each tab shows the correct count
+  const executedTab = page.locator('button', { hasText: /Executed/i }).first();
+  const pendingTab = page.locator('button', { hasText: /Pending/i }).first();
+  const expiredTab = page.locator('button', { hasText: /Expired/i }).first();
+  const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
+
+  const executedText = await executedTab.textContent();
+  const pendingText = await pendingTab.textContent();
+  const expiredText = await expiredTab.textContent();
+  const invalidatedText = await invalidatedTab.textContent();
+
+  log(`Tab text: Executed="${executedText}", Pending="${pendingText}", Expired="${expiredText}", Invalidated="${invalidatedText}"`);
+
+  expect(executedText).toContain(String(executed.length));
+  expect(pendingText).toContain(String(pending.length));
+  expect(expiredText).toContain(String(expired.length));
+  expect(invalidatedText).toContain(String(invalidated.length));
+  log('All tab counts match API');
+});

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -1809,7 +1809,7 @@ test('39. Execute delete proposal and verify invalidation', async () => { const 
   const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
   const invalidatedText = await invalidatedTab.textContent();
   log(`Invalidated tab: ${invalidatedText}`);
-  expect(invalidatedText).toContain('1');
+  expect(invalidatedText).toContain('2');
 });
 
 // ===========================================================================
@@ -1846,7 +1846,7 @@ test('40. Verify final state', async () => { const page = sharedPage;
   const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
   const invalidatedText = await invalidatedTab.textContent();
   log(`Invalidated tab: ${invalidatedText}`);
-  expect(invalidatedText).toContain('1');
+  expect(invalidatedText).toContain('2');
 
   // Final dump
   log('\n=== Final State ===');

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -17,6 +17,7 @@ import {
   checkTxStatus,
   fundContract,
   getIndexerStatus,
+  getChildren,
   dumpState,
   type TestAccount,
 } from './helpers';
@@ -1439,6 +1440,13 @@ test('31. Execute ALLOCATE_CHILD', async () => { const page = sharedPage;
 
 test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   log('=== Step 32: Propose RECLAIM_CHILD ===');
+
+  // Diagnostic: fetch child contract from backend to check parentNonce
+  const children = await getChildren(contractAddress);
+  const child = children.find((c: any) => c.address === childAddress);
+  log(`[diag] Backend child parentNonce=${child?.parentNonce}, nonce=${child?.nonce}, address=${childAddress?.slice(0, 12)}...`);
+  log(`[diag] All children: ${JSON.stringify(children.map((c: any) => ({ addr: c.address?.slice(0, 12), parentNonce: c.parentNonce, nonce: c.nonce })))}`);
+
   await gotoWithWallet('/transactions/new?type=reclaimChild', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -1446,6 +1454,9 @@ test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   const childLabel = page.locator(`label:has-text("${childAddress.slice(0, 10)}")`);
   await childLabel.waitFor({ state: 'visible', timeout: 10_000 });
   await childLabel.click();
+
+  // Wait for nonce field to update after child selection
+  await page.waitForTimeout(1_000);
 
   // Fill reclaim amount
   const amountInput = page.locator('input[placeholder="1.0"]');
@@ -1455,6 +1466,16 @@ test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   const expiryInput = page.locator('input[placeholder="0"]');
   if ((await expiryInput.count()) > 0) {
     await expiryInput.first().fill('0');
+  }
+
+  // Diagnostic: read the nonce input value before submitting
+  const nonceValue = await page.locator('div:has(> label:text-is("Nonce")) input').inputValue().catch(() => 'N/A');
+  log(`[diag] Nonce input value before submit: ${nonceValue}`);
+
+  // Check for validation errors
+  const validationError = await page.locator('text=/Nonce must be greater/').textContent().catch(() => null);
+  if (validationError) {
+    log(`[diag] Validation error visible: ${validationError}`);
   }
 
   log('Submitting reclaim proposal...');

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -152,7 +152,7 @@ test.afterEach(async ({}, testInfo) => {
     await dumpState(contractAddress);
   }
 
-  if (txCount >= RECYCLE_EVERY_N_TXS) {
+  if (RECYCLE_EVERY_N_TXS > 0 && txCount >= RECYCLE_EVERY_N_TXS) {
     log(`${txCount} txs since last recycle — recycling page`);
     txCount = 0;
     await recyclePage();

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -17,7 +17,6 @@ import {
   checkTxStatus,
   fundContract,
   getIndexerStatus,
-  getChildren,
   dumpState,
   type TestAccount,
 } from './helpers';
@@ -1441,17 +1440,6 @@ test('31. Execute ALLOCATE_CHILD', async () => { const page = sharedPage;
 test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   log('=== Step 32: Propose RECLAIM_CHILD ===');
 
-  // Diagnostic: fetch child contract from backend to check parentNonce
-  const children = await getChildren(contractAddress);
-  const child = children.find((c: any) => c.address === childAddress);
-  log(`[diag] Backend child parentNonce=${child?.parentNonce}, nonce=${child?.nonce}, address=${childAddress?.slice(0, 12)}...`);
-  log(`[diag] All children: ${JSON.stringify(children.map((c: any) => ({ addr: c.address?.slice(0, 12), parentNonce: c.parentNonce, nonce: c.nonce })))}`);
-  // Also fetch the child contract directly and the parent for comparison
-  const childDirect = await getContract(childAddress);
-  const parentDirect = await getContract(contractAddress);
-  log(`[diag] Child direct: ${JSON.stringify({ parentNonce: childDirect?.parentNonce, nonce: childDirect?.nonce, parent: childDirect?.parent?.slice(0, 12) })}`);
-  log(`[diag] Parent direct: ${JSON.stringify({ parentNonce: parentDirect?.parentNonce, nonce: parentDirect?.nonce, parent: parentDirect?.parent })}`);
-
   await gotoWithWallet('/transactions/new?type=reclaimChild', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
@@ -1459,9 +1447,6 @@ test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   const childLabel = page.locator(`label:has-text("${childAddress.slice(0, 10)}")`);
   await childLabel.waitFor({ state: 'visible', timeout: 10_000 });
   await childLabel.click();
-
-  // Wait for nonce field to update after child selection
-  await page.waitForTimeout(1_000);
 
   // Fill reclaim amount
   const amountInput = page.locator('input[placeholder="1.0"]');
@@ -1471,16 +1456,6 @@ test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   const expiryInput = page.locator('input[placeholder="0"]');
   if ((await expiryInput.count()) > 0) {
     await expiryInput.first().fill('0');
-  }
-
-  // Diagnostic: read the nonce input value before submitting
-  const nonceValue = await page.locator('div:has(> label:text-is("Nonce")) input').inputValue().catch(() => 'N/A');
-  log(`[diag] Nonce input value before submit: ${nonceValue}`);
-
-  // Check for validation errors
-  const validationError = await page.locator('text=/Nonce must be greater/').textContent().catch(() => null);
-  if (validationError) {
-    log(`[diag] Validation error visible: ${validationError}`);
   }
 
   log('Submitting reclaim proposal...');

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -1809,7 +1809,7 @@ test('39. Execute delete proposal and verify invalidation', async () => { const 
   const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
   const invalidatedText = await invalidatedTab.textContent();
   log(`Invalidated tab: ${invalidatedText}`);
-  expect(invalidatedText).toContain('2');
+  expect(invalidatedText).toContain('1');
 });
 
 // ===========================================================================
@@ -1846,7 +1846,7 @@ test('40. Verify final state', async () => { const page = sharedPage;
   const invalidatedTab = page.locator('button', { hasText: /Invalidated/i }).first();
   const invalidatedText = await invalidatedTab.textContent();
   log(`Invalidated tab: ${invalidatedText}`);
-  expect(invalidatedText).toContain('2');
+  expect(invalidatedText).toContain('1');
 
   // Final dump
   log('\n=== Final State ===');

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -1446,6 +1446,11 @@ test('32. Propose RECLAIM_CHILD', async () => { const page = sharedPage;
   const child = children.find((c: any) => c.address === childAddress);
   log(`[diag] Backend child parentNonce=${child?.parentNonce}, nonce=${child?.nonce}, address=${childAddress?.slice(0, 12)}...`);
   log(`[diag] All children: ${JSON.stringify(children.map((c: any) => ({ addr: c.address?.slice(0, 12), parentNonce: c.parentNonce, nonce: c.nonce })))}`);
+  // Also fetch the child contract directly and the parent for comparison
+  const childDirect = await getContract(childAddress);
+  const parentDirect = await getContract(contractAddress);
+  log(`[diag] Child direct: ${JSON.stringify({ parentNonce: childDirect?.parentNonce, nonce: childDirect?.nonce, parent: childDirect?.parent?.slice(0, 12) })}`);
+  log(`[diag] Parent direct: ${JSON.stringify({ parentNonce: parentDirect?.parentNonce, nonce: parentDirect?.nonce, parent: parentDirect?.parent })}`);
 
   await gotoWithWallet('/transactions/new?type=reclaimChild', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -6,7 +6,7 @@ import {
   activateTestKey,
   switchAccount,
   navigateTo,
-  waitForBanner,
+  waitForBanner as _waitForBanner,
   waitForIndexer,
   getContracts,
   getContract,
@@ -25,6 +25,22 @@ import { getNetworkConfig } from './network-config';
 const netConfig = getNetworkConfig();
 const SETTLE_WAIT = netConfig.settlementWaitMs;
 const SHORT_WAIT = netConfig.mode === 'devnet' ? 10_000 : 3_000;
+
+import { V8_HEAP_MB } from './playwright.config';
+
+// Each tx accumulates ~40MB of WASM state. Recycle before hitting ~50% of heap.
+// On machines with >=16GB heap (i.e. >=21GB RAM), recycling is unnecessary.
+const RECYCLE_EVERY_N_TXS = V8_HEAP_MB >= 16384 ? 0 : 15;
+let txCount = 0;
+
+log(`V8 heap: ${V8_HEAP_MB}MB — page recycling ${RECYCLE_EVERY_N_TXS ? `every ${RECYCLE_EVERY_N_TXS} txs` : 'disabled'}`);
+
+
+async function waitForBanner(...args: Parameters<typeof _waitForBanner>) {
+  const result = await _waitForBanner(...args);
+  if (args[1] !== 'error') txCount++;
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // Shared state across sequential tests
@@ -126,7 +142,6 @@ async function recyclePage(): Promise<void> {
   log('Page recycled');
 }
 
-// On failure, dump backend state for debugging
 test.afterEach(async ({}, testInfo) => {
   if (testInfo.status !== 'passed') {
     log(`TEST FAILED: ${testInfo.title}`);
@@ -135,6 +150,12 @@ test.afterEach(async ({}, testInfo) => {
       log(`Stack:\n${testInfo.error.stack}`);
     }
     await dumpState(contractAddress);
+  }
+
+  if (txCount >= RECYCLE_EVERY_N_TXS) {
+    log(`${txCount} txs since last recycle — recycling page`);
+    txCount = 0;
+    await recyclePage();
   }
 });
 
@@ -978,7 +999,6 @@ test('20. Verify delegate card shows delegate', async () => { const page = share
   log('Dashboard shows delegate address');
 });
 
-test('20.5. Recycle page', async () => { await recyclePage(); });
 
 // ---------------------------------------------------------------------------
 // 21. Propose undelegate
@@ -1490,8 +1510,6 @@ test('33. Execute RECLAIM_CHILD', async () => { const page = sharedPage;
   expect(proposal.status).toBe('executed');
   log(`RECLAIM_CHILD executed`);
 });
-
-test('33.5. Recycle page', async () => { await recyclePage(); });
 
 // ---------------------------------------------------------------------------
 // 34. Propose ENABLE_CHILD_MULTI_SIG (disable)

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,8 +6,7 @@
     "test": "node node_modules/@playwright/test/cli.js test"
   },
   "dependencies": {
-    "contracts": "workspace:*",
-    "o1js": "https://pkg.pr.new/o1-labs/o1js@2701"
+    "contracts": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,15 +1,22 @@
+import os from 'os';
 import { defineConfig } from '@playwright/test';
 import { getNetworkConfig } from './network-config';
 
 const config = getNetworkConfig();
+
+// Give Chromium's V8 up to 75% of system RAM (capped at 32 GB, floor at 8 GB).
+// On a beefy self-hosted runner this eliminates the need for page recycling;
+// on a GitHub-hosted runner (~7 GB) it stays at the 8 GB floor.
+export const V8_HEAP_MB = Math.max(
+  8192,
+  Math.min(Math.floor(os.totalmem() / 1024 / 1024 * 0.75), 32768)
+);
 
 export default defineConfig({
   testDir: '.',
   testMatch: '*.test.ts',
   timeout: config.testStepTimeoutMs,
   retries: 0,
-  // Serial: tests are sequenced and share one browser context so the
-  // contract-compile happens once for the whole run.
   workers: 1,
   globalSetup: './global-setup.ts',
   globalTeardown: './global-teardown.ts',
@@ -19,19 +26,13 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     actionTimeout: config.mode === 'devnet' ? 60_000 : 30_000,
-    // Smaller viewport = smaller renderer backing buffer.
     viewport: { width: 1024, height: 768 },
     launchOptions: {
       args: [
         '--disable-gpu',
         '--disable-features=TranslateUI',
         '--disable-blink-features=AutomationControlled',
-        // o1js proof generation accumulates ~600 MB per Mina.transaction
-        // between GC cycles. Default V8 old-space cap (~4 GB) gets hit after
-        // 5-7 txs on the same worker, causing renderer-level GC thrashing
-        // that manifests as a silent tx.prove() hang. Bumping to 8 GB is
-        // enough to clear the 25-step onchain-flow chain + subaccount tests.
-        '--js-flags=--max-old-space-size=8192',
+        `--js-flags=--max-old-space-size=${V8_HEAP_MB}`,
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "bun run --filter contracts typecheck && bun run --filter backend build"
   },
   "dependencies": {
-    "o1js": "https://pkg.pr.new/o1-labs/o1js@2701"
+    "o1js": "github:mellowcroc/o1js#mesa-srs-fix"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/preview-env/preview.sh
+++ b/preview-env/preview.sh
@@ -187,7 +187,7 @@ case "$COMMAND" in
         fi
 
         echo "Tearing down PR #${PR_NUMBER} preview..."
-        docker compose -p "pr-${PR_NUMBER}" down -v --remove-orphans --rmi local
+        docker compose -p "pr-${PR_NUMBER}" down -v --remove-orphans --rmi local 2>&1 || true
 
         # Remove route from main Caddy
         remove_caddy_route "$PR_NUMBER"

--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -5,19 +5,19 @@ import { useRouter } from 'next/navigation';
 import { useAppContext } from '@/lib/app-context';
 import OwnerList from '@/components/OwnerList';
 import ThresholdBadge from '@/components/ThresholdBadge';
-import { clearCompileCache, getCompileCacheSize, isCompileCacheEnabledIDB, setCompileCacheEnabledIDB } from '@/lib/idb-compile-cache';
+import { clearCompileCache, getCompileCacheSize, setCompileCacheEnabledIDB } from '@/lib/idb-compile-cache';
+import { isCompileCacheEnabled, setCompileCacheEnabled } from '@/lib/storage';
 
 /** Settings page for owner set and threshold governance proposal shortcuts. */
 export default function SettingsPage() {
   const router = useRouter();
   const { wallet, multisig, owners } = useAppContext();
   const [cacheSize, setCacheSize] = useState<{ entries: number; bytes: number } | null>(null);
-  const [cacheEnabled, setCacheEnabled] = useState(true);
+  const [cacheEnabled, setCacheEnabled] = useState(() => isCompileCacheEnabled());
   const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
     getCompileCacheSize().then(setCacheSize);
-    isCompileCacheEnabledIDB().then(setCacheEnabled);
   }, []);
 
   const handleClearCache = useCallback(async () => {
@@ -35,11 +35,7 @@ export default function SettingsPage() {
   return (
     <div>
       <div className="p-6 max-w-2xl space-y-6">
-        {!wallet.connected || !multisig ? (
-          <div className="text-center py-20">
-            <p className="text-safe-text">Connect wallet to manage contract settings</p>
-          </div>
-        ) : (
+        {wallet.connected && multisig ? (
           <>
             <div className="bg-safe-gray border border-safe-border rounded-xl p-6">
               <div className="flex items-center justify-between mb-4">
@@ -89,48 +85,53 @@ export default function SettingsPage() {
                 <InfoRow label="Config Nonce" value={String(multisig.configNonce ?? '-')} mono />
               </div>
             </div>
-
-            <div className="bg-safe-gray border border-safe-border rounded-xl p-6">
-              <h3 className="text-sm font-semibold mb-2">Compile Cache</h3>
-              <p className="text-xs text-safe-text mb-4">
-                Cached prover keys speed up contract compilation after page reloads.
-                {cacheSize && cacheSize.entries > 0 && (
-                  <> Currently using {(cacheSize.bytes / 1024 / 1024).toFixed(0)}MB ({cacheSize.entries} entries).</>
-                )}
-              </p>
-              <label className="flex items-center justify-between py-2 mb-3 cursor-pointer">
-                <span className="text-sm">Enable compile caching</span>
-                <button
-                  role="switch"
-                  aria-checked={cacheEnabled}
-                  onClick={() => {
-                    const next = !cacheEnabled;
-                    setCacheEnabled(next);
-                    setCompileCacheEnabledIDB(next);
-                  }}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    cacheEnabled ? 'bg-safe-green' : 'bg-safe-border'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
-                      cacheEnabled ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </label>
-              {cacheSize && cacheSize.entries > 0 && (
-                <button
-                  onClick={handleClearCache}
-                  disabled={clearing}
-                  className="w-full p-2.5 border border-safe-border rounded-lg text-sm text-safe-text hover:text-red-400 hover:border-red-400 transition-colors disabled:opacity-50"
-                >
-                  {clearing ? 'Clearing...' : 'Clear Compile Cache'}
-                </button>
-              )}
-            </div>
           </>
+        ) : (
+          <div className="text-center py-20">
+            <p className="text-safe-text">Connect wallet to manage contract settings</p>
+          </div>
         )}
+
+        <div className="bg-safe-gray border border-safe-border rounded-xl p-6">
+          <h3 className="text-sm font-semibold mb-2">Compile Cache</h3>
+          <p className="text-xs text-safe-text mb-4">
+            Cached prover keys speed up contract compilation after page reloads.
+            {cacheSize && cacheSize.entries > 0 && (
+              <> Currently using {(cacheSize.bytes / 1024 / 1024).toFixed(0)}MB ({cacheSize.entries} entries).</>
+            )}
+          </p>
+          <label className="flex items-center justify-between py-2 mb-3 cursor-pointer">
+            <span className="text-sm">Enable compile caching</span>
+            <button
+              role="switch"
+              aria-checked={cacheEnabled}
+              onClick={() => {
+                const next = !cacheEnabled;
+                setCacheEnabled(next);
+                setCompileCacheEnabled(next);
+                setCompileCacheEnabledIDB(next);
+              }}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                cacheEnabled ? 'bg-safe-green' : 'bg-safe-border'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                  cacheEnabled ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </label>
+          {cacheSize && cacheSize.entries > 0 && (
+            <button
+              onClick={handleClearCache}
+              disabled={clearing}
+              className="w-full p-2.5 border border-safe-border rounded-lg text-sm text-safe-text hover:text-red-400 hover:border-red-400 transition-colors disabled:opacity-50"
+            >
+              {clearing ? 'Clearing...' : 'Clear Compile Cache'}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useAppContext } from '@/lib/app-context';
 import OwnerList from '@/components/OwnerList';
 import ThresholdBadge from '@/components/ThresholdBadge';
-import { clearCompileCache, getCompileCacheSize, setCompileCacheEnabledIDB } from '@/lib/idb-compile-cache';
+import { checkStorageAvailable, clearCompileCache, getCompileCacheSize, setCompileCacheEnabledIDB } from '@/lib/idb-compile-cache';
 import { isCompileCacheEnabled, setCompileCacheEnabled } from '@/lib/storage';
 
 /** Settings page for owner set and threshold governance proposal shortcuts. */
@@ -14,21 +14,35 @@ export default function SettingsPage() {
   const { wallet, multisig, owners } = useAppContext();
   const [cacheSize, setCacheSize] = useState<{ entries: number; bytes: number } | null>(null);
   const [cacheEnabled, setCacheEnabled] = useState(() => isCompileCacheEnabled());
-  const [clearing, setClearing] = useState(false);
+  const [storageOk, setStorageOk] = useState<boolean | null>(null);
+  const [storageMB, setStorageMB] = useState<number>(0);
+  const [toggling, setToggling] = useState(false);
 
   useEffect(() => {
     getCompileCacheSize().then(setCacheSize);
+    checkStorageAvailable().then(({ available, remainingMB }) => {
+      setStorageOk(available);
+      setStorageMB(remainingMB);
+    });
   }, []);
 
-  const handleClearCache = useCallback(async () => {
-    setClearing(true);
+  const handleToggle = useCallback(async () => {
+    const next = !cacheEnabled;
+    setToggling(true);
     try {
-      await clearCompileCache();
-      setCacheSize({ entries: 0, bytes: 0 });
+      setCacheEnabled(next);
+      setCompileCacheEnabled(next);
+      if (!next) {
+        await clearCompileCache();
+        await setCompileCacheEnabledIDB(false);
+        setCacheSize({ entries: 0, bytes: 0 });
+      } else {
+        await setCompileCacheEnabledIDB(true);
+      }
     } finally {
-      setClearing(false);
+      setToggling(false);
     }
-  }, []);
+  }, [cacheEnabled]);
 
   const activeOwners = owners.map((owner) => owner.address);
 
@@ -96,40 +110,54 @@ export default function SettingsPage() {
           <h3 className="text-sm font-semibold mb-2">Compile Cache</h3>
           <p className="text-xs text-safe-text mb-4">
             Cached prover keys speed up contract compilation after page reloads.
-            {cacheSize && cacheSize.entries > 0 && (
+            {cacheEnabled && cacheSize && cacheSize.entries > 0 && (
               <> Currently using {(cacheSize.bytes / 1024 / 1024).toFixed(0)}MB ({cacheSize.entries} entries).</>
             )}
           </p>
-          <label className="flex items-center justify-between py-2 mb-3 cursor-pointer">
-            <span className="text-sm">Enable compile caching</span>
-            <button
-              role="switch"
-              aria-checked={cacheEnabled}
-              onClick={() => {
-                const next = !cacheEnabled;
-                setCacheEnabled(next);
-                setCompileCacheEnabled(next);
-                setCompileCacheEnabledIDB(next);
-              }}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                cacheEnabled ? 'bg-safe-green' : 'bg-safe-border'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
-                  cacheEnabled ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-          </label>
-          {cacheSize && cacheSize.entries > 0 && (
-            <button
-              onClick={handleClearCache}
-              disabled={clearing}
-              className="w-full p-2.5 border border-safe-border rounded-lg text-sm text-safe-text hover:text-red-400 hover:border-red-400 transition-colors disabled:opacity-50"
-            >
-              {clearing ? 'Clearing...' : 'Clear Compile Cache'}
-            </button>
+          {storageOk === false && !cacheEnabled ? (
+            <div className="rounded-lg border border-safe-border bg-safe-bg p-3">
+              <p className="text-xs text-safe-text">
+                Not enough storage to enable compile caching. At least 1.8 GB of free space is required
+                ({storageMB < 1024
+                  ? `${storageMB} MB available`
+                  : `${(storageMB / 1024).toFixed(1)} GB available`}).
+              </p>
+              <label className="flex items-center justify-between py-2 mt-2 cursor-not-allowed opacity-50">
+                <span className="text-sm">Enable compile caching</span>
+                <button
+                  role="switch"
+                  aria-checked={false}
+                  disabled
+                  className="relative inline-flex h-6 w-11 items-center rounded-full bg-safe-border cursor-not-allowed"
+                >
+                  <span className="inline-block h-4 w-4 rounded-full bg-white translate-x-1" />
+                </button>
+              </label>
+            </div>
+          ) : (
+            <>
+              <label className="flex items-center justify-between py-2 cursor-pointer">
+                <span className="text-sm">Enable compile caching</span>
+                <button
+                  role="switch"
+                  aria-checked={cacheEnabled}
+                  disabled={toggling}
+                  onClick={handleToggle}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                    cacheEnabled ? 'bg-safe-green' : 'bg-safe-border'
+                  } ${toggling ? 'opacity-50' : ''}`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                      cacheEnabled ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </label>
+              <p className="text-xs text-safe-text mt-1">
+                Disabling will remove any existing cached data.
+              </p>
+            </>
           )}
         </div>
       </div>

--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -1,14 +1,32 @@
 'use client';
 
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAppContext } from '@/lib/app-context';
 import OwnerList from '@/components/OwnerList';
 import ThresholdBadge from '@/components/ThresholdBadge';
+import { clearCompileCache, getCompileCacheSize } from '@/lib/idb-compile-cache';
 
 /** Settings page for owner set and threshold governance proposal shortcuts. */
 export default function SettingsPage() {
   const router = useRouter();
   const { wallet, multisig, owners } = useAppContext();
+  const [cacheSize, setCacheSize] = useState<{ entries: number; bytes: number } | null>(null);
+  const [clearing, setClearing] = useState(false);
+
+  useEffect(() => {
+    getCompileCacheSize().then(setCacheSize);
+  }, []);
+
+  const handleClearCache = useCallback(async () => {
+    setClearing(true);
+    try {
+      await clearCompileCache();
+      setCacheSize({ entries: 0, bytes: 0 });
+    } finally {
+      setClearing(false);
+    }
+  }, []);
 
   const activeOwners = owners.map((owner) => owner.address);
 
@@ -69,6 +87,23 @@ export default function SettingsPage() {
                 <InfoRow label="Config Nonce" value={String(multisig.configNonce ?? '-')} mono />
               </div>
             </div>
+
+            {cacheSize && cacheSize.entries > 0 && (
+              <div className="bg-safe-gray border border-safe-border rounded-xl p-6">
+                <h3 className="text-sm font-semibold mb-2">Compile Cache</h3>
+                <p className="text-xs text-safe-text mb-4">
+                  Cached prover keys speed up contract compilation after page reloads.
+                  Currently using {(cacheSize.bytes / 1024 / 1024).toFixed(0)}MB ({cacheSize.entries} entries).
+                </p>
+                <button
+                  onClick={handleClearCache}
+                  disabled={clearing}
+                  className="w-full p-2.5 border border-safe-border rounded-lg text-sm text-safe-text hover:text-red-400 hover:border-red-400 transition-colors disabled:opacity-50"
+                >
+                  {clearing ? 'Clearing...' : 'Clear Compile Cache'}
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -5,17 +5,19 @@ import { useRouter } from 'next/navigation';
 import { useAppContext } from '@/lib/app-context';
 import OwnerList from '@/components/OwnerList';
 import ThresholdBadge from '@/components/ThresholdBadge';
-import { clearCompileCache, getCompileCacheSize } from '@/lib/idb-compile-cache';
+import { clearCompileCache, getCompileCacheSize, isCompileCacheEnabledIDB, setCompileCacheEnabledIDB } from '@/lib/idb-compile-cache';
 
 /** Settings page for owner set and threshold governance proposal shortcuts. */
 export default function SettingsPage() {
   const router = useRouter();
   const { wallet, multisig, owners } = useAppContext();
   const [cacheSize, setCacheSize] = useState<{ entries: number; bytes: number } | null>(null);
+  const [cacheEnabled, setCacheEnabled] = useState(true);
   const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
     getCompileCacheSize().then(setCacheSize);
+    isCompileCacheEnabledIDB().then(setCacheEnabled);
   }, []);
 
   const handleClearCache = useCallback(async () => {
@@ -88,13 +90,36 @@ export default function SettingsPage() {
               </div>
             </div>
 
-            {cacheSize && cacheSize.entries > 0 && (
-              <div className="bg-safe-gray border border-safe-border rounded-xl p-6">
-                <h3 className="text-sm font-semibold mb-2">Compile Cache</h3>
-                <p className="text-xs text-safe-text mb-4">
-                  Cached prover keys speed up contract compilation after page reloads.
-                  Currently using {(cacheSize.bytes / 1024 / 1024).toFixed(0)}MB ({cacheSize.entries} entries).
-                </p>
+            <div className="bg-safe-gray border border-safe-border rounded-xl p-6">
+              <h3 className="text-sm font-semibold mb-2">Compile Cache</h3>
+              <p className="text-xs text-safe-text mb-4">
+                Cached prover keys speed up contract compilation after page reloads.
+                {cacheSize && cacheSize.entries > 0 && (
+                  <> Currently using {(cacheSize.bytes / 1024 / 1024).toFixed(0)}MB ({cacheSize.entries} entries).</>
+                )}
+              </p>
+              <label className="flex items-center justify-between py-2 mb-3 cursor-pointer">
+                <span className="text-sm">Enable compile caching</span>
+                <button
+                  role="switch"
+                  aria-checked={cacheEnabled}
+                  onClick={() => {
+                    const next = !cacheEnabled;
+                    setCacheEnabled(next);
+                    setCompileCacheEnabledIDB(next);
+                  }}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                    cacheEnabled ? 'bg-safe-green' : 'bg-safe-border'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                      cacheEnabled ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </label>
+              {cacheSize && cacheSize.entries > 0 && (
                 <button
                   onClick={handleClearCache}
                   disabled={clearing}
@@ -102,8 +127,8 @@ export default function SettingsPage() {
                 >
                   {clearing ? 'Clearing...' : 'Clear Compile Cache'}
                 </button>
-              </div>
-            )}
+              )}
+            </div>
           </>
         )}
       </div>

--- a/ui/hooks/useMultisig.ts
+++ b/ui/hooks/useMultisig.ts
@@ -130,7 +130,7 @@ export function useMultisig(walletAddress: string | null) {
     void refreshState();
     const interval = setInterval(() => {
       void refreshState();
-    }, 15_000);
+    }, Number(process.env.NEXT_PUBLIC_POLL_INTERVAL_MS) || 10_000);
 
     return () => clearInterval(interval);
   }, [refreshState]);

--- a/ui/hooks/useTransactions.ts
+++ b/ui/hooks/useTransactions.ts
@@ -41,7 +41,7 @@ export function useTransactions(multisigAddress: string | null) {
     void refresh();
     const interval = setInterval(() => {
       void refresh();
-    }, 10_000);
+    }, Number(process.env.NEXT_PUBLIC_POLL_INTERVAL_MS) || 10_000);
 
     return () => clearInterval(interval);
   }, [refresh]);

--- a/ui/lib/disable-wasm-finalizers.ts
+++ b/ui/lib/disable-wasm-finalizers.ts
@@ -1,0 +1,11 @@
+// Must be imported BEFORE o1js so that when o1js creates its
+// FinalizationRegistry (kimchi_bindings/js/bindings/util.js), it gets this
+// no-op class.  With IDB-cached compile, o1js's decodeProverKey creates WASM
+// wrappers that share underlying pointers; the original finalizer frees a
+// pointer the prover still holds after the first prove(), causing dangling
+// WASM memory on subsequent proves.  Disabling auto-free is safe — WASM heap
+// is reclaimed when the worker is torn down on page refresh.
+(globalThis as any).FinalizationRegistry = class {
+  register() {}
+  unregister() { return false; }
+};

--- a/ui/lib/idb-compile-cache.ts
+++ b/ui/lib/idb-compile-cache.ts
@@ -50,15 +50,26 @@ async function canWriteToIDB(userEnabled = true): Promise<boolean> {
 
 export async function clearCompileCache(): Promise<void> {
   const db = await openDB();
-  const enabled = (await idbGet(db, '__cache_enabled__')) === false;
   await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
     tx.objectStore(STORE_NAME).clear();
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
-  if (enabled) await setCompileCacheEnabledIDB(false);
   db.close();
+}
+
+export async function checkStorageAvailable(): Promise<{ available: boolean; remainingMB: number }> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.estimate) {
+    return { available: true, remainingMB: Infinity };
+  }
+  try {
+    const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+    const remaining = quota - usage;
+    return { available: remaining >= MIN_QUOTA_BYTES, remainingMB: Math.round(remaining / 1024 / 1024) };
+  } catch {
+    return { available: true, remainingMB: Infinity };
+  }
 }
 
 export async function getCompileCacheSize(): Promise<{

--- a/ui/lib/idb-compile-cache.ts
+++ b/ui/lib/idb-compile-cache.ts
@@ -1,0 +1,144 @@
+import type { Cache } from 'o1js';
+
+const DB_NAME = 'o1js-compile-cache';
+const STORE_NAME = 'keys';
+const DB_VERSION = 1;
+const MIN_QUOTA_BYTES = 2 * 1024 * 1024 * 1024; // 2GB free required to enable writes
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+type Entry = { uniqueId: string; data: Uint8Array };
+
+function idbGet(db: IDBDatabase, key: string): Promise<unknown> {
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(key);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(undefined);
+  });
+}
+
+async function hasStorageQuota(): Promise<boolean> {
+  if (!navigator.storage?.estimate) return true;
+  try {
+    const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+    const remaining = quota - usage;
+    if (remaining < MIN_QUOTA_BYTES) {
+      console.log(
+        `[idb-cache] skipping writes — only ${(remaining / 1024 / 1024).toFixed(0)}MB free (need ${(MIN_QUOTA_BYTES / 1024 / 1024).toFixed(0)}MB)`
+      );
+      return false;
+    }
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+export async function clearCompileCache(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function getCompileCacheSize(): Promise<{
+  entries: number;
+  bytes: number;
+}> {
+  try {
+    const db = await openDB();
+    const manifest = (await idbGet(db, '__manifest__')) as
+      | Record<string, string>
+      | undefined;
+    if (!manifest) return { entries: 0, bytes: 0 };
+
+    let bytes = 0;
+    const keys = Object.keys(manifest);
+    await Promise.all(
+      keys.map(async (id) => {
+        try {
+          const record = (await idbGet(db, id)) as { blob: Blob } | undefined;
+          if (record?.blob) bytes += record.blob.size;
+        } catch {}
+      })
+    );
+    db.close();
+    return { entries: keys.length, bytes };
+  } catch {
+    return { entries: 0, bytes: 0 };
+  }
+}
+
+export async function createIndexedDBCache(): Promise<Cache> {
+  const db = await openDB();
+  const map = new Map<string, Entry>();
+
+  const t0 = performance.now();
+
+  const manifest = (await idbGet(db, '__manifest__')) as
+    | Record<string, string>
+    | undefined;
+
+  if (manifest) {
+    const keys = Object.keys(manifest);
+    await Promise.all(
+      keys.map(async (persistentId) => {
+        try {
+          const record = (await idbGet(db, persistentId)) as
+            | { blob: Blob }
+            | undefined;
+          if (!record?.blob) return;
+          const buf = await record.blob.arrayBuffer();
+          map.set(persistentId, {
+            uniqueId: manifest[persistentId],
+            data: new Uint8Array(buf),
+          });
+        } catch {}
+      })
+    );
+  }
+
+  let totalBytes = 0;
+  for (const entry of map.values()) totalBytes += entry.data.byteLength;
+  console.log(
+    `[idb-cache] preloaded ${map.size} entries (${(totalBytes / 1024 / 1024).toFixed(1)}MB) in ${((performance.now() - t0) / 1000).toFixed(1)}s`
+  );
+
+  const writable = await hasStorageQuota();
+
+  return {
+    read(header) {
+      const entry = map.get(header.persistentId);
+      if (!entry || entry.uniqueId !== header.uniqueId) return undefined;
+      if (header.dataType === 'string') return entry.data;
+      return new Uint8Array(entry.data);
+    },
+
+    write(header, value) {
+      const data = new Uint8Array(value);
+      map.set(header.persistentId, { uniqueId: header.uniqueId, data });
+
+      if (!writable) return;
+
+      const blob = new Blob([data]);
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      store.put({ blob }, header.persistentId);
+
+      const currentManifest: Record<string, string> = {};
+      for (const [k, v] of map) currentManifest[k] = v.uniqueId;
+      store.put(currentManifest, '__manifest__');
+    },
+
+    canWrite: true,
+  };
+}

--- a/ui/lib/idb-compile-cache.ts
+++ b/ui/lib/idb-compile-cache.ts
@@ -25,17 +25,23 @@ function idbGet(db: IDBDatabase, key: string): Promise<unknown> {
   });
 }
 
-async function hasStorageQuota(): Promise<boolean> {
+async function canWriteToIDB(userEnabled = true): Promise<boolean> {
+  if (!userEnabled) {
+    console.log('[idb-cache] writes disabled by user preference');
+    return false;
+  }
   if (!navigator.storage?.estimate) return true;
   try {
     const { usage = 0, quota = 0 } = await navigator.storage.estimate();
     const remaining = quota - usage;
+    const remainingMB = (remaining / 1024 / 1024).toFixed(0);
     if (remaining < MIN_QUOTA_BYTES) {
       console.log(
-        `[idb-cache] skipping writes — only ${(remaining / 1024 / 1024).toFixed(0)}MB free (need ${(MIN_QUOTA_BYTES / 1024 / 1024).toFixed(0)}MB)`
+        `[idb-cache] skipping writes — only ${remainingMB}MB free (need ${(MIN_QUOTA_BYTES / 1024 / 1024).toFixed(0)}MB)`
       );
       return false;
     }
+    console.log(`[idb-cache] writes enabled — ${remainingMB}MB available`);
     return true;
   } catch {
     return true;
@@ -43,11 +49,13 @@ async function hasStorageQuota(): Promise<boolean> {
 }
 
 export async function clearCompileCache(): Promise<void> {
-  return new Promise((resolve, reject) => {
+  const enabled = await isCompileCacheEnabledIDB();
+  await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(DB_NAME);
     req.onsuccess = () => resolve();
     req.onerror = () => reject(req.error);
   });
+  if (!enabled) await setCompileCacheEnabledIDB(false);
 }
 
 export async function getCompileCacheSize(): Promise<{
@@ -76,6 +84,27 @@ export async function getCompileCacheSize(): Promise<{
   } catch {
     return { entries: 0, bytes: 0 };
   }
+}
+
+export async function isCompileCacheEnabledIDB(): Promise<boolean> {
+  try {
+    const db = await openDB();
+    const val = await idbGet(db, '__cache_enabled__');
+    db.close();
+    return val !== false;
+  } catch {
+    return true;
+  }
+}
+
+export async function setCompileCacheEnabledIDB(enabled: boolean): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(enabled, '__cache_enabled__');
+    tx.oncomplete = () => { db.close(); resolve(); };
+    tx.onerror = () => { db.close(); reject(tx.error); };
+  });
 }
 
 export async function createIndexedDBCache(): Promise<Cache> {
@@ -113,7 +142,8 @@ export async function createIndexedDBCache(): Promise<Cache> {
     `[idb-cache] preloaded ${map.size} entries (${(totalBytes / 1024 / 1024).toFixed(1)}MB) in ${((performance.now() - t0) / 1000).toFixed(1)}s`
   );
 
-  const writable = await hasStorageQuota();
+  const cacheEnabled = (await idbGet(db, '__cache_enabled__')) !== false;
+  const writable = await canWriteToIDB(cacheEnabled);
 
   return {
     read(header) {

--- a/ui/lib/idb-compile-cache.ts
+++ b/ui/lib/idb-compile-cache.ts
@@ -49,13 +49,16 @@ async function canWriteToIDB(userEnabled = true): Promise<boolean> {
 }
 
 export async function clearCompileCache(): Promise<void> {
-  const enabled = await isCompileCacheEnabledIDB();
+  const db = await openDB();
+  const enabled = (await idbGet(db, '__cache_enabled__')) === false;
   await new Promise<void>((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME);
-    req.onsuccess = () => resolve();
-    req.onerror = () => reject(req.error);
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
   });
-  if (!enabled) await setCompileCacheEnabledIDB(false);
+  if (enabled) await setCompileCacheEnabledIDB(false);
+  db.close();
 }
 
 export async function getCompileCacheSize(): Promise<{

--- a/ui/lib/idb-compile-cache.ts
+++ b/ui/lib/idb-compile-cache.ts
@@ -3,7 +3,7 @@ import type { Cache } from 'o1js';
 const DB_NAME = 'o1js-compile-cache';
 const STORE_NAME = 'keys';
 const DB_VERSION = 1;
-const MIN_QUOTA_BYTES = 2 * 1024 * 1024 * 1024; // 2GB free required to enable writes
+const MIN_QUOTA_BYTES = 1.8 * 1024 * 1024 * 1024; // 1.8GB free required to enable writes
 
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -1,6 +1,7 @@
 // -- Multisig Contract Worker ------------------------------------------
 // Runs o1js compilation and proof generation off the main thread.
 
+import './disable-wasm-finalizers';
 import * as Comlink from 'comlink';
 
 import {
@@ -95,26 +96,6 @@ async function getDummyProofBase64(): Promise<string> {
 async function maybeProve(tx: Awaited<ReturnType<typeof Mina.transaction>>) {
   if (!skipProofs) {
     await tx.prove();
-    // o1js registers a FinalizationRegistry (kimchi_bindings/js/bindings/util.js)
-    // that calls .free() on WASM objects (prover keys, verifier indices) when
-    // their JS wrappers are GC'd, releasing the Rust-side WASM heap memory.
-    //
-    // When compile() deserializes keys from our IDB cache (via decodeProverKey →
-    // wasm.caml_pasta_fp_plonk_index_decode), the resulting WASM wrapper objects
-    // have different reference-rooting than freshly-compiled ones. After the
-    // first prove(), V8 GC collects an intermediate wrapper and the finalizer
-    // frees the underlying pointer — but the prover still holds a reference to
-    // that same pointer. The second prove() then hits dangling WASM memory
-    // (observed as "unaligned accesses" / WasmFpPlonkVerifierIndexFinalization
-    // errors, or a silent hang).
-    //
-    // Without cache, keys are created through Pickles' Rust compilation path
-    // which roots WASM objects differently — no premature finalization.
-    //
-    // Fix: reset compile state so the next tx recompiles from warm IDB cache
-    // (~15s, not minutes), producing fresh WASM objects.
-    compileSucceeded = false;
-    compilePromise = null;
     return;
   }
   const dummyProof = await getDummyProofBase64();

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -17,6 +17,8 @@ import {
   Bool,
   MerkleMap,
   Poseidon,
+  Proof,
+  Void,
 } from 'o1js';
 
 import Client from 'mina-signer';
@@ -76,6 +78,34 @@ let compilePromise: Promise<void> | null = null;
 let testPrivateKey: InstanceType<typeof PrivateKey> | null = null;
 let skipProofs = false;
 
+class DummyProof extends Proof<void, void> {
+  static publicInputType = Void;
+  static publicOutputType = Void;
+}
+
+let _dummyProofBase64: string | null = null;
+
+async function getDummyProofBase64(): Promise<string> {
+  if (_dummyProofBase64) return _dummyProofBase64;
+  const p = await DummyProof.dummy(undefined, undefined, 2);
+  _dummyProofBase64 = p.toJSON().proof;
+  return _dummyProofBase64;
+}
+
+async function maybeProve(tx: Awaited<ReturnType<typeof Mina.transaction>>) {
+  if (!skipProofs) {
+    await tx.prove();
+    return;
+  }
+  const dummyProof = await getDummyProofBase64();
+  for (const au of (tx as any).transaction.accountUpdates) {
+    if (au.lazyAuthorization?.kind === 'lazy-proof') {
+      au.authorization = { proof: dummyProof };
+      au.lazyAuthorization = undefined;
+    }
+  }
+}
+
 /** Returns Mina.transaction sender arg — includes fee since we always set it explicitly. */
 function txSender(pub: InstanceType<typeof PublicKey>) {
   return { sender: pub, fee: ZKAPP_TX_FEE };
@@ -132,7 +162,9 @@ async function compileContract(): Promise<boolean> {
       console.log('[MultisigWorker] MinaGuard.compile() starting');
       const t0 = performance.now();
       configureNetwork();
-      await MinaGuard.compile();
+      const { createIndexedDBCache } = await import('./idb-compile-cache');
+      const cache = await createIndexedDBCache();
+      await MinaGuard.compile({ cache });
       console.log(`[MultisigWorker] MinaGuard.compile() done in ${((performance.now() - t0) / 1000).toFixed(1)}s`);
     })();
   }
@@ -654,7 +686,7 @@ const workerApi = {
     console.log('mina transaction constructed');
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     console.log('proof done');
 
@@ -681,6 +713,7 @@ const workerApi = {
     const ok = await compileContract();
     if (!ok) return null;
 
+    configureNetwork();
     progressFn('Building transaction...');
     const feePayer = PublicKey.fromBase58(params.feePayerAddress);
     const zkAppKey = PrivateKey.fromBase58(params.zkAppPrivateKeyBase58);
@@ -711,7 +744,7 @@ const workerApi = {
     });
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn, [zkAppKey]);
@@ -763,7 +796,7 @@ const workerApi = {
     });
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn);
@@ -882,7 +915,7 @@ const workerApi = {
     }));
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn);
@@ -954,7 +987,7 @@ const workerApi = {
     });
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn);
@@ -1064,7 +1097,7 @@ const workerApi = {
     });
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const executeHash = await submitTx(tx, sendFn, signFeePayerFn);
@@ -1145,7 +1178,7 @@ const workerApi = {
     });
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn, [childKey]);
@@ -1243,7 +1276,7 @@ const workerApi = {
     });
 
     progressFn('Generating proof...');
-    await tx.prove();
+    await maybeProve(tx);
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn);

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -165,7 +165,9 @@ async function compileContract(): Promise<boolean> {
       const { createIndexedDBCache } = await import('./idb-compile-cache');
       const cache = await createIndexedDBCache();
       await MinaGuard.compile({ cache });
-      console.log(`[MultisigWorker] MinaGuard.compile() done in ${((performance.now() - t0) / 1000).toFixed(1)}s`);
+      const { getCompileCacheSize } = await import('./idb-compile-cache');
+      const size = await getCompileCacheSize();
+      console.log(`[MultisigWorker] MinaGuard.compile() done in ${((performance.now() - t0) / 1000).toFixed(1)}s — cache: ${(size.bytes / 1024 / 1024).toFixed(0)}MB (${size.entries} entries)`);
     })();
   }
 

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -95,6 +95,27 @@ async function getDummyProofBase64(): Promise<string> {
 async function maybeProve(tx: Awaited<ReturnType<typeof Mina.transaction>>) {
   if (!skipProofs) {
     await tx.prove();
+    // o1js registers a FinalizationRegistry (kimchi_bindings/js/bindings/util.js)
+    // that calls .free() on WASM objects (prover keys, verifier indices) when
+    // their JS wrappers are GC'd, releasing the Rust-side WASM heap memory.
+    //
+    // When compile() deserializes keys from our IDB cache (via decodeProverKey →
+    // wasm.caml_pasta_fp_plonk_index_decode), the resulting WASM wrapper objects
+    // have different reference-rooting than freshly-compiled ones. After the
+    // first prove(), V8 GC collects an intermediate wrapper and the finalizer
+    // frees the underlying pointer — but the prover still holds a reference to
+    // that same pointer. The second prove() then hits dangling WASM memory
+    // (observed as "unaligned accesses" / WasmFpPlonkVerifierIndexFinalization
+    // errors, or a silent hang).
+    //
+    // Without cache, keys are created through Pickles' Rust compilation path
+    // which roots WASM objects differently — no premature finalization.
+    //
+    // Fix: reset compile state so the next tx recompiles from warm IDB cache
+    // (~15s, not minutes), producing fresh WASM objects.
+    compileSucceeded = false;
+    compilePromise = null;
+    compileContract().catch(() => {});
     return;
   }
   const dummyProof = await getDummyProofBase64();

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -173,6 +173,7 @@ function configureNetwork() {
 }
 
 let compileSucceeded = false;
+let idbCache: Awaited<ReturnType<typeof import('./idb-compile-cache').createIndexedDBCache>> | null = null;
 
 async function compileContract(): Promise<boolean> {
   if (compileSucceeded) return true;
@@ -182,9 +183,11 @@ async function compileContract(): Promise<boolean> {
       console.log('[MultisigWorker] MinaGuard.compile() starting');
       const t0 = performance.now();
       configureNetwork();
-      const { createIndexedDBCache } = await import('./idb-compile-cache');
-      const cache = await createIndexedDBCache();
-      await MinaGuard.compile({ cache });
+      if (!idbCache) {
+        const { createIndexedDBCache } = await import('./idb-compile-cache');
+        idbCache = await createIndexedDBCache();
+      }
+      await MinaGuard.compile({ cache: idbCache });
       const { getCompileCacheSize } = await import('./idb-compile-cache');
       const size = await getCompileCacheSize();
       console.log(`[MultisigWorker] MinaGuard.compile() done in ${((performance.now() - t0) / 1000).toFixed(1)}s — cache: ${(size.bytes / 1024 / 1024).toFixed(0)}MB (${size.entries} entries)`);

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -897,10 +897,18 @@ const workerApi = {
     // configNonce / networkId / nonce via getAndRequireEquals(); without a
     // fresh fetch of the zkApp account, o1js sees Field(0) and the circuit
     // traps with a WASM `unreachable` during prove.
-    await Promise.all([
+    const fetches: Promise<any>[] = [
       fetchAccount({ publicKey: proposer }),
       fetchAccount({ publicKey: contractAddress }),
-    ]);
+    ];
+    // REMOTE proposals read child state (parentNonce, ownersCommitment, parent)
+    // via getAndRequireEquals() inside propose(). Without a prefetch, o1js
+    // auto-fetches inside Mina.transaction() which hangs in the worker.
+    const childAccount = proposal.childAccount;
+    if (!childAccount.equals(PublicKey.empty()).toBoolean()) {
+      fetches.push(fetchAccount({ publicKey: childAccount }));
+    }
+    await Promise.all(fetches);
 
     logProposeDiagnostics({
       contract,

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -115,7 +115,6 @@ async function maybeProve(tx: Awaited<ReturnType<typeof Mina.transaction>>) {
     // (~15s, not minutes), producing fresh WASM objects.
     compileSucceeded = false;
     compilePromise = null;
-    compileContract().catch(() => {});
     return;
   }
   const dummyProof = await getDummyProofBase64();

--- a/ui/lib/storage.ts
+++ b/ui/lib/storage.ts
@@ -25,6 +25,18 @@ export function clearUiStorage(): void {
   localStorage.removeItem(getKey('selected-contract'));
 }
 
+/** Returns whether compile caching is enabled (default: true). */
+export function isCompileCacheEnabled(): boolean {
+  if (typeof window === 'undefined') return true;
+  return localStorage.getItem(getKey('compile-cache-enabled')) !== 'false';
+}
+
+/** Persists the compile cache enabled/disabled preference. */
+export function setCompileCacheEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(getKey('compile-cache-enabled'), String(enabled));
+}
+
 /** Saves a user-assigned display name for a contract address. */
 export function saveAccountName(address: string, name: string): void {
   if (typeof window === 'undefined') return;

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,6 @@
     "js-sha256": "^0.9.0",
     "mina-signer": "file:deps/o1js/src/mina-signer",
     "next": "^14.2.0",
-    "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },


### PR DESCRIPTION
IndexedDB Compile Cache                                                                                                        
  - Cache o1js prover keys in IndexedDB (~155s reload vs ~280s cold)
  - Storage quota check via navigator.storage.estimate(), skip writes if <2GB free                                               
  - Settings page toggle to enable/disable caching, with clear button and size display                                           
  - Disable WASM finalizers to avoid GC corruption instead of recompiling after every prove                                      
                                                                                                                                 
  o1js Dependency                                                                                                                
  - Switch to github fork (mellowcroc/o1js#mesa-srs-fix) with srs try-catch fix baked in (required to make caching possible)     
  - Centralize o1js to root package.json, remove from individual workspace packages                                              
  - Use createRequire for mina-signer import to work around o1js exports map
                                                                                                                                 
  E2E Test Suite                                                           
  - Re-enable CI e2e job, expand from 25 to 53 tests                                                                             
  - Page recycling with dummy proofs to stay under V8 heap limit                                                                 
  - Add subaccount lifecycle, delete proposal, and form validation tests
  - Configurable poll interval via NEXT_PUBLIC_POLL_INTERVAL_MS, sped up for e2e                                                 
  - 3s lightnet slot time                                                  
                                                                                                                                 
  Bug Fixes
  - deriveStatus: give expired precedence over invalidated — a timed-out proposal stays expired even if the config nonce later   
  advances                                                                                                                       
  - Initialize child contracts with nonce=0 and parentNonce=0; skip parentNonce update for CREATE_CHILD sentinel nonce
  - Prefetch child account for REMOTE proposals in propose flow                                                                  
  - Tolerate missing compose project in preview.sh down                    
                                                                                                                                 
  CI                                                                                                                             
  - Add deploy label to deploy, preview-deploy, and reset workflow runners                                                       
  - Remove backend log redirect in e2e CI                                                                                        