### PR TITLE
per-row recipients, parent-owner prefill, in-flight tx lock

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -474,6 +474,21 @@ export async function waitForBanner(
   return text?.trim() ?? '';
 }
 
+/**
+ * Fills the recipients section of the new-proposal form using its Bulk mode
+ * (one `address,amount` per line). The form defaults to per-row inputs; tests
+ * predate that change and rely on the legacy comma-separated format, so this
+ * helper switches to Bulk mode if needed before writing.
+ */
+export async function fillRecipients(page: Page, content: string): Promise<void> {
+  const textarea = page.locator('textarea').first();
+  if (!(await textarea.isVisible().catch(() => false))) {
+    await page.getByRole('button', { name: 'Bulk', exact: true }).click();
+    await textarea.waitFor({ state: 'visible', timeout: 5_000 });
+  }
+  await textarea.fill(content);
+}
+
 /** Waits for the operating spinner to disappear. */
 export async function waitForOperationDone(
   page: Page,

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -206,7 +206,7 @@ test('1. Deploy MinaGuard contract', async () => { const page = sharedPage;
 
   // Click deploy
   log('Clicking Deploy account...');
-  const deployBtn = page.getByRole('button', { name: /deploy account/i });
+  const deployBtn = page.getByRole('button', { name: /deploy vault/i });
   await deployBtn.click();
 
   // Wait for the operation to complete (success banner or redirect)
@@ -1464,7 +1464,7 @@ test('26. Propose CREATE_CHILD on parent', async () => { const page = sharedPage
   await page.locator('input[type="number"]').first().fill('1');
 
   log('Clicking Propose subaccount...');
-  await page.getByRole('button', { name: /propose subaccount/i }).click();
+  await page.getByRole('button', { name: /propose subvault/i }).click();
   await waitForBanner(page, 'success');
 
   await waitForIndexer(
@@ -1545,12 +1545,12 @@ test('28. Verify subaccount in UI tree', async () => { const page = sharedPage;
 
   await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
-  await expect(page.locator('text=Subaccounts (1)')).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('text=SubVaults (1)')).toBeVisible({ timeout: 10_000 });
   log('Subaccounts (1) card visible on parent dashboard');
 
   await gotoWithWallet(`/accounts/${childAddress}`, accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
-  await expect(page.locator('text=Parent Account')).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('text=Parent Vault')).toBeVisible({ timeout: 10_000 });
   log('Child detail renders with Parent card');
 });
 

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -7,6 +7,7 @@ import {
   switchAccount,
   navigateTo,
   waitForBanner as _waitForBanner,
+  fillRecipients,
   waitForIndexer,
   getContracts,
   getContract,
@@ -474,11 +475,9 @@ test('7. Propose send MINA to account3', async () => { const page = sharedPage;
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  // The transfer form uses a single textarea with `address,amount` per line
-  // (see ProposalForm.tsx — parseTransferLines). 1 MINA to account3.
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await recipientsTextarea.fill(`${accounts[2].publicKey},1`);
+  // The transfer form defaults to per-row inputs; fillRecipients flips to
+  // Bulk mode and writes the legacy `address,amount` format. 1 MINA to account3.
+  await fillRecipients(page, `${accounts[2].publicKey},1`);
 
   // Set expiry to 0
   const expiryInput = page.locator('input[placeholder="0"]');
@@ -1099,10 +1098,8 @@ test('23. Propose transfer with near-future expiry', async () => { const page = 
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  // 0.5 MINA to account3 as a single textarea line.
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await recipientsTextarea.fill(`${accounts[2].publicKey},0.5`);
+  // 0.5 MINA to account3.
+  await fillRecipients(page, `${accounts[2].publicKey},0.5`);
 
   // Set the low expiry block
   const expiryInput = page.locator('input[placeholder="0"]');
@@ -1229,9 +1226,7 @@ test('25a. Propose transfer with memo', async () => { const page = sharedPage;
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await recipientsTextarea.fill(`${accounts[2].publicKey},0.1`);
+  await fillRecipients(page, `${accounts[2].publicKey},0.1`);
 
   const memoInput = page.locator('input[placeholder*="memo"]').or(
     page.locator('input[placeholder*="Short note"]')
@@ -1328,9 +1323,7 @@ test('25c. Propose and execute with memo mismatch', async () => { const page = s
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await recipientsTextarea.fill(`${accounts[2].publicKey},0.1`);
+  await fillRecipients(page, `${accounts[2].publicKey},0.1`);
 
   const memoInput = page.locator('input[placeholder*="memo"]').or(
     page.locator('input[placeholder*="Short note"]')
@@ -1579,9 +1572,7 @@ test('30. Propose ALLOCATE_CHILD', async () => { const page = sharedPage;
   await gotoWithWallet('/transactions/new?type=allocateChild', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await recipientsTextarea.fill(`${childAddress},2`);
+  await fillRecipients(page, `${childAddress},2`);
 
   const expiryInput = page.locator('input[placeholder="0"]');
   if ((await expiryInput.count()) > 0) {
@@ -1897,9 +1888,7 @@ test('38. Propose transfer then delete it', async () => { const page = sharedPag
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await recipientsTextarea.fill(`${accounts[2].publicKey},0.1`);
+  await fillRecipients(page, `${accounts[2].publicKey},0.1`);
 
   const expiryInput = page.locator('input[placeholder="0"]');
   if ((await expiryInput.count()) > 0) {
@@ -2074,11 +2063,8 @@ test('41. Transfer form validation', async () => { const page = sharedPage;
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  const recipientsTextarea = page.locator('textarea').first();
-  await recipientsTextarea.waitFor({ state: 'visible', timeout: 5_000 });
-
   // Invalid address
-  await recipientsTextarea.fill('invalidaddress,1');
+  await fillRecipients(page, 'invalidaddress,1');
   const submitBtn = page.getByRole('button', { name: /submit proposal/i });
   await submitBtn.click();
   await page.waitForTimeout(1_000);
@@ -2086,8 +2072,8 @@ test('41. Transfer form validation', async () => { const page = sharedPage;
   expect(pageText).toMatch(/invalid|error|address/i);
   log('Invalid address rejected');
 
-  // Empty textarea
-  await recipientsTextarea.fill('');
+  // Empty recipients
+  await fillRecipients(page, '');
   await submitBtn.click();
   await page.waitForTimeout(1_000);
   log('Empty form handled');
@@ -2176,19 +2162,19 @@ test('45. Transfer form parsing edge cases', async () => { const page = sharedPa
   await gotoWithWallet('/transactions/new?type=transfer', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);
 
-  const textarea = page.locator('textarea').first();
-  await textarea.waitFor({ state: 'visible', timeout: 5_000 });
   const submitBtn = page.getByRole('button', { name: /submit proposal/i });
 
-  // Missing comma → "expected address,amount"
-  await textarea.fill('B62qooZ8LNHjSomething');
+  // Missing comma → row is parsed as address-only with empty amount.
+  // Surfaces "Invalid Mina address" (the value isn't valid base58) and/or
+  // "Amount required".
+  await fillRecipients(page, 'B62qooZ8LNHjSomething');
   await page.waitForTimeout(500);
   let body = await page.textContent('body');
-  expect(body).toMatch(/expected.*address.*amount/i);
+  expect(body).toMatch(/(invalid mina address|amount required)/i);
   log('Missing comma rejected');
 
   // Zero amount → "invalid amount" (parseMinaToNanomina rejects 0)
-  await textarea.fill(`${accounts[2].publicKey},0`);
+  await fillRecipients(page, `${accounts[2].publicKey},0`);
   await submitBtn.click();
   await page.waitForTimeout(500);
   body = await page.textContent('body');
@@ -2196,24 +2182,25 @@ test('45. Transfer form parsing edge cases', async () => { const page = sharedPa
   log('Zero amount rejected');
 
   // Negative amount → "invalid amount"
-  await textarea.fill(`${accounts[2].publicKey},-1`);
+  await fillRecipients(page, `${accounts[2].publicKey},-1`);
   await page.waitForTimeout(500);
   body = await page.textContent('body');
   expect(body).toMatch(/invalid amount/i);
   log('Negative amount rejected');
 
   // Duplicate recipients → "duplicate recipient"
-  await textarea.fill(`${accounts[1].publicKey},1\n${accounts[1].publicKey},2`);
+  await fillRecipients(page, `${accounts[1].publicKey},1\n${accounts[1].publicKey},2`);
   await page.waitForTimeout(500);
   body = await page.textContent('body');
   expect(body).toMatch(/duplicate recipient/i);
   log('Duplicate recipient rejected');
 
-  // Extra commas → "expected address,amount"
-  await textarea.fill(`${accounts[2].publicKey},1,extra`);
+  // Extra commas → only the first comma splits, so the amount becomes
+  // "1,extra" which fails the numeric regex → "Invalid amount".
+  await fillRecipients(page, `${accounts[2].publicKey},1,extra`);
   await page.waitForTimeout(500);
   body = await page.textContent('body');
-  expect(body).toMatch(/expected.*address.*amount/i);
+  expect(body).toMatch(/invalid amount/i);
   log('Extra commas rejected');
 });
 
@@ -2337,9 +2324,7 @@ test('49. Nonce validation edge cases', async () => { const page = sharedPage;
   await page.waitForTimeout(SHORT_WAIT);
 
   // Fill valid recipients so nonce is the only validation target
-  const textarea = page.locator('textarea').first();
-  await textarea.waitFor({ state: 'visible', timeout: 5_000 });
-  await textarea.fill(`${accounts[2].publicKey},1`);
+  await fillRecipients(page, `${accounts[2].publicKey},1`);
 
   const nonceInput = page.locator('input').first();
   await nonceInput.waitFor({ state: 'visible', timeout: 5_000 });

--- a/ui/app/accounts/[address]/page.tsx
+++ b/ui/app/accounts/[address]/page.tsx
@@ -147,7 +147,7 @@ export default function AccountPage() {
           <div className="space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div className="bg-safe-gray border border-safe-border rounded-xl p-5">
-                <p className="text-xs text-safe-text uppercase tracking-wider mb-1">Wallet Address</p>
+                <p className="text-xs text-safe-text uppercase tracking-wider mb-1">Vault Address</p>
                 <div className="flex items-center gap-1.5 min-w-0">
                   <span className="text-sm font-mono flex min-w-0">
                     <span className="truncate">{multisig.address.slice(0, -4)}</span>
@@ -187,7 +187,7 @@ export default function AccountPage() {
               </div>
 
               <div className="bg-safe-gray border border-safe-border rounded-xl p-5">
-                <p className="text-xs text-safe-text uppercase tracking-wider mb-1">Wallet Balance</p>
+                <p className="text-xs text-safe-text uppercase tracking-wider mb-1">Vault Balance</p>
                 <p className="text-lg font-semibold mt-1">
                   {balance !== null ? formatMina(balance) : '-'}{' '}
                   <span className="text-sm text-safe-text font-normal">MINA</span>

--- a/ui/app/accounts/[address]/page.tsx
+++ b/ui/app/accounts/[address]/page.tsx
@@ -69,7 +69,7 @@ export default function AccountPage() {
   const localProposalsEnabled = isOwner && (isRoot || childMultiSigEnabled);
   const childActionsEnabled = isRoot && isOwner;
   const localDisabledReason = !isOwner
-    ? 'You are not an owner of this account'
+    ? 'You are not an owner of this Vault'
     : !childMultiSigEnabled
       ? 'Multi-sig disabled by parent'
       : null;
@@ -227,7 +227,7 @@ export default function AccountPage() {
               <p className="text-xs text-safe-text uppercase tracking-wider mb-3">New Proposal</p>
               <div className="space-y-3">
                 <div className="flex flex-wrap items-center gap-3">
-                  <span className="text-[10px] text-safe-text uppercase tracking-wider shrink-0 w-20">Account</span>
+                  <span className="text-[10px] text-safe-text uppercase tracking-wider shrink-0 w-20">Vault</span>
                   <ProposalButtonRow
                     types={LOCAL_TX_TYPES}
                     enabled={localProposalsEnabled}
@@ -238,11 +238,11 @@ export default function AccountPage() {
                 </div>
                 {isRoot && (
                   <div className="flex flex-wrap items-center gap-3">
-                    <span className="text-[10px] text-safe-text uppercase tracking-wider shrink-0 w-20">Subaccount</span>
+                    <span className="text-[10px] text-safe-text uppercase tracking-wider shrink-0 w-20">SubVault</span>
                     <ProposalButtonRow
                       types={CHILD_TX_TYPES}
                       enabled={childActionsEnabled}
-                      disabledReason={!isOwner ? 'You are not an owner of this account' : null}
+                      disabledReason={!isOwner ? 'You are not an owner of this Vault' : null}
                       hrefPrefix={`/transactions/new?account=${multisig.address}&type=`}
                       accountAddress={multisig.address}
                     />
@@ -269,7 +269,7 @@ export default function AccountPage() {
         ) : urlAddress && !contracts.some((c) => c.address === urlAddress) ? (
           pendingDeployTxHash || isPendingIndex ? (
             <div className="rounded-xl border p-4 text-sm space-y-1 border-yellow-400/30 bg-yellow-400/10 text-yellow-200 max-w-2xl">
-              <p className="font-semibold">Deploying account — awaiting inclusion</p>
+              <p className="font-semibold">Deploying Vault — awaiting inclusion</p>
               <p className="opacity-90">
                 Your contract was broadcast to the network. It should appear here once the next block is produced (~3 min).
               </p>
@@ -292,18 +292,18 @@ export default function AccountPage() {
             </div>
           ) : (
             <div className="text-center py-20">
-              <p className="text-safe-text mb-4">Account not found.</p>
+              <p className="text-safe-text mb-4">Vault not found.</p>
               <Link
                 href="/"
                 className="inline-block bg-safe-green text-safe-dark font-semibold rounded-lg px-6 py-3 text-sm hover:brightness-110 transition-all"
               >
-                Back to accounts
+                Back to Vaults
               </Link>
             </div>
           )
         ) : (
           <div className="text-center py-20">
-            <p className="text-safe-text">Loading account…</p>
+            <p className="text-safe-text">Loading Vault…</p>
           </div>
         )}
       </div>
@@ -445,7 +445,7 @@ function ParentCard({ parent, parentContract, childMultiSigEnabled }: ParentCard
     <div className="bg-safe-gray border border-safe-border rounded-xl p-5">
       <div className="flex items-center justify-between gap-4">
         <div className="min-w-0">
-          <p className="text-xs text-safe-text uppercase tracking-wider mb-1">Parent Account</p>
+          <p className="text-xs text-safe-text uppercase tracking-wider mb-1">Parent Vault</p>
           <Link
             href={`/accounts/${parent}`}
             className="text-sm font-mono text-safe-green hover:underline truncate block"
@@ -617,7 +617,7 @@ function PendingSubaccountsBanner({
     const signer = wallet.type ? { type: wallet.type, ledgerAccountIndex: wallet.ledgerAccountIndex } : undefined;
     setFinalizingChild(child.childAddress);
     try {
-      await startOperation('Finalizing subaccount deployment…', async (onProgress) => {
+      await startOperation('Finalizing SubVault deployment…', async (onProgress) => {
         onProgress('Fetching parent CREATE_CHILD proposal…');
         const proposal = await fetchProposal(record.contractAddress, record.proposalHash);
         if (!proposal) {
@@ -657,7 +657,7 @@ function PendingSubaccountsBanner({
   return (
     <div className="bg-amber-500/10 border border-amber-500/40 rounded-xl p-5 space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-amber-200">Pending Subaccounts ({visible.length})</h3>
+        <h3 className="text-sm font-semibold text-amber-200">Pending SubVaults ({visible.length})</h3>
       </div>
       {contractLock.locked && (
         <p className="text-xs text-amber-200/90">
@@ -760,7 +760,7 @@ function SubaccountsCard({ parentAddress }: { parentAddress: string }) {
   if (children === null) {
     return (
       <div className="bg-safe-gray border border-safe-border rounded-xl p-5">
-        <p className="text-xs text-safe-text uppercase tracking-wider mb-2">Subaccounts</p>
+        <p className="text-xs text-safe-text uppercase tracking-wider mb-2">SubVaults</p>
         <p className="text-sm text-safe-text">Loading…</p>
       </div>
     );
@@ -769,8 +769,8 @@ function SubaccountsCard({ parentAddress }: { parentAddress: string }) {
   if (children.length === 0) {
     return (
       <div className="bg-safe-gray border border-safe-border rounded-xl p-5">
-        <p className="text-xs text-safe-text uppercase tracking-wider mb-2">Subaccounts</p>
-        <p className="text-sm text-safe-text">No subaccounts yet.</p>
+        <p className="text-xs text-safe-text uppercase tracking-wider mb-2">SubVaults</p>
+        <p className="text-sm text-safe-text">No SubVaults yet.</p>
       </div>
     );
   }
@@ -779,7 +779,7 @@ function SubaccountsCard({ parentAddress }: { parentAddress: string }) {
     <div className="bg-safe-gray border border-safe-border rounded-xl p-5">
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs text-safe-text uppercase tracking-wider">
-          Subaccounts ({children.length})
+          SubVaults ({children.length})
         </p>
       </div>
       <ul className="divide-y divide-safe-border">

--- a/ui/app/accounts/[address]/page.tsx
+++ b/ui/app/accounts/[address]/page.tsx
@@ -30,6 +30,7 @@ import {
   type PendingTx,
 } from '@/lib/storage';
 import { CREATE_TX_STATUS_PROBE_MIN_AGE_MS } from '@/hooks/useTransactions';
+import { useContractTxLock } from '@/hooks/useContractTxLock';
 
 /** Account detail page — reads address from URL, syncs AppContext selection. */
 export default function AccountPage() {
@@ -491,6 +492,9 @@ function PendingSubaccountsBanner({
   const [pendingDeployByChild, setPendingDeployByChild] = useState<Map<string, PendingTx>>(new Map());
   const parentThreshold = multisig?.address === parentAddress ? (multisig.threshold ?? 0) : 0;
   const explorerUrl = process.env.NEXT_PUBLIC_BLOCK_EXPLORER_URL ?? '';
+  // Indexer-lag lock for the parent guard: any in-flight tx on the parent
+  // makes Finalize's parentApprovalWitness stale, so block until indexed.
+  const contractLock = useContractTxLock(parentAddress, proposals);
 
   const loadPendingCreateChild = useCallback(
     () =>
@@ -655,6 +659,11 @@ function PendingSubaccountsBanner({
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-amber-200">Pending Subaccounts ({visible.length})</h3>
       </div>
+      {contractLock.locked && (
+        <p className="text-xs text-amber-200/90">
+          {contractLock.reason} Finalize is blocked until it lands (~3 min).
+        </p>
+      )}
       <ul className="space-y-2">
         {visible.map((record) => {
           // Filtered upstream: every `visible` row has childAccount set.
@@ -664,7 +673,7 @@ function PendingSubaccountsBanner({
           // parent's threshold before executeSetupChild can succeed.
           const thresholdMet = !!proposal && proposal.status === 'pending' && proposal.approvalCount >= parentThreshold;
           const finalizeInFlight = pendingDeployByChild.get(child.childAddress);
-          const canFinalize = thresholdMet && !finalizeInFlight;
+          const canFinalize = thresholdMet && !finalizeInFlight && !contractLock.locked;
           const buttonLabel = finalizingChild === child.childAddress
             ? 'Finalizing…'
             : finalizeInFlight
@@ -719,7 +728,9 @@ function PendingSubaccountsBanner({
                     ? 'Runs executeSetupChild on the new child address.'
                     : finalizeInFlight
                       ? 'Finalize tx broadcast — waiting for the child contract to land on-chain.'
-                      : 'Waiting for the parent CREATE_CHILD proposal to reach threshold.'}
+                      : contractLock.locked
+                        ? `${contractLock.reason} Try again once the indexer catches up.`
+                        : 'Waiting for the parent CREATE_CHILD proposal to reach threshold.'}
                 >
                   {buttonLabel}
                 </button>

--- a/ui/app/accounts/new/page.tsx
+++ b/ui/app/accounts/new/page.tsx
@@ -152,7 +152,7 @@ function CreateAccountWizard() {
     try {
       await assertLedgerReady(signer);
     } catch (err) {
-      void startOperation('Create account', async () => { throw err; });
+      void startOperation('Create Vault', async () => { throw err; });
       return;
     }
     if (name.trim()) saveAccountName(keypair.publicKey, name);
@@ -198,7 +198,7 @@ function CreateAccountWizard() {
     try {
       await assertLedgerReady(signer);
     } catch (err) {
-      void startOperation('Propose subaccount', async () => { throw err; });
+      void startOperation('Propose SubVault', async () => { throw err; });
       return;
     }
 
@@ -212,7 +212,7 @@ function CreateAccountWizard() {
     // savePendingTx call below writes a fresh entry under the new proposalHash.
     clearPendingCreateChild(parentAddress, childAddress);
 
-    void startOperation('Preparing subaccount proposal…', async (onProgress) => {
+    void startOperation('Preparing SubVault proposal…', async (onProgress) => {
       onProgress('Computing child config hash…');
       const { configHash } = await computeCreateChildConfigHash({
         childOwners: parsedOwners,
@@ -266,7 +266,7 @@ function CreateAccountWizard() {
         },
       });
 
-      return `Subaccount proposal submitted. Approve on the parent, then return to finalize deployment.`;
+      return `SubVault proposal submitted. Approve on the parent Vault, then return to finalize deployment.`;
     });
 
     router.push(`/accounts/${parentAddress}`);
@@ -277,16 +277,16 @@ function CreateAccountWizard() {
       <div className="p-6 max-w-3xl mx-auto w-full">
         {!wallet.connected ? (
           <div className="text-center py-20">
-            <p className="text-safe-text">Connect a wallet to create an account.</p>
+            <p className="text-safe-text">Connect a wallet to create a Vault.</p>
           </div>
         ) : (
           <div>
             <h1 className="text-2xl font-bold mb-2">
-              {isSubaccount ? 'Create subaccount' : 'Create new account'}
+              {isSubaccount ? 'Create SubVault' : 'Create new Vault'}
             </h1>
             {isSubaccount && parentAddress && (
               <p className="text-xs text-safe-text mb-6">
-                Subaccount of{' '}
+                SubVault of{' '}
                 <Link
                   href={`/accounts/${parentAddress}`}
                   className="text-safe-green hover:underline font-mono"
@@ -317,7 +317,7 @@ function CreateAccountWizard() {
                     </h2>
                     <p className="text-xs text-safe-text">
                       {step === 1
-                        ? 'Give the account a local nickname and pick the network to deploy to.'
+                        ? 'Give the Vault a local nickname and pick the network to deploy to.'
                         : 'Add signer addresses and the minimum approvals needed to execute a proposal.'}
                     </p>
                   </div>
@@ -344,7 +344,7 @@ function CreateAccountWizard() {
                         type="text"
                         value={name}
                         onChange={(e) => setName(e.target.value)}
-                        placeholder="My MinaGuard Account"
+                        placeholder="My MinaGuard Vault"
                         className="w-full bg-safe-dark border border-safe-border rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-safe-green"
                       />
                     </label>
@@ -357,7 +357,7 @@ function CreateAccountWizard() {
                         className="w-full bg-safe-dark border border-safe-border rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-safe-green disabled:opacity-60"
                         title={
                           isSubaccount
-                            ? 'Subaccounts inherit the parent network.'
+                            ? 'SubVaults inherit the parent Vault network.'
                             : 'Devnet and Mainnet support is coming soon.'
                         }
                       >
@@ -369,7 +369,7 @@ function CreateAccountWizard() {
                       </select>
                       <span className="text-[10px] text-safe-text">
                         {isSubaccount
-                          ? 'Locked to the parent account network.'
+                          ? 'Locked to the parent Vault network.'
                           : 'Only Testnet is available right now.'}
                       </span>
                     </label>
@@ -484,7 +484,7 @@ function CreateAccountWizard() {
                     className="bg-safe-green text-safe-dark font-semibold rounded-lg px-5 py-2 text-sm hover:brightness-110 transition-all disabled:opacity-60"
                     title={!parentContract ? 'Loading parent contract…' : undefined}
                   >
-                    {isOperating ? 'Proposing…' : 'Propose subaccount'}
+                    {isOperating ? 'Proposing…' : 'Propose SubVault'}
                   </button>
                 ) : (
                   <button
@@ -492,7 +492,7 @@ function CreateAccountWizard() {
                     onClick={handleDeploy}
                     className="bg-safe-green text-safe-dark font-semibold rounded-lg px-5 py-2 text-sm hover:brightness-110 transition-all disabled:opacity-60"
                   >
-                    {isOperating ? 'Deploying…' : 'Deploy account'}
+                    {isOperating ? 'Deploying…' : 'Deploy Vault'}
                   </button>
                 )}
               </div>

--- a/ui/app/accounts/new/page.tsx
+++ b/ui/app/accounts/new/page.tsx
@@ -38,9 +38,14 @@ function CreateAccountWizard() {
   const {
     wallet,
     contracts,
+    allContractOwners,
     startOperation,
     isOperating,
   } = useAppContext();
+  const parentOwners = useMemo(
+    () => (parentAddress ? allContractOwners.get(parentAddress) ?? [] : []),
+    [allContractOwners, parentAddress],
+  );
 
   const parentContract = useMemo(
     () => (parentAddress ? contracts.find((c) => c.address === parentAddress) ?? null : null),
@@ -61,11 +66,20 @@ function CreateAccountWizard() {
     if (match) setNetworkValue(match.value);
   }, [isSubaccount, parentContract?.networkId]);
 
-  // Step 2 fields
+  // Step 2 fields. Subaccount mode tries to prefill from the parent's owners
+  // + threshold so users start from a sensible "same governance as parent"
+  // baseline. Top-level creation keeps the connected-wallet-as-only-owner
+  // default. Lazy initializers run once at mount; the effect below upgrades
+  // the state when allContractOwners arrives later and the user hasn't typed
+  // anything yet.
   const [keypair, setKeypair] = useState<{ privateKey: string; publicKey: string } | null>(null);
   const [generating, setGenerating] = useState(false);
-  const [ownerFields, setOwnerFields] = useState<string[]>(['']);
-  const [threshold, setThreshold] = useState('');
+  const [ownerFields, setOwnerFields] = useState<string[]>(() =>
+    isSubaccount && parentOwners.length > 0 ? parentOwners : [''],
+  );
+  const [threshold, setThreshold] = useState<string>(() =>
+    isSubaccount && parentContract?.threshold != null ? String(parentContract.threshold) : '',
+  );
   const [formError, setFormError] = useState<string | null>(null);
 
   const generate = useCallback(async () => {
@@ -85,8 +99,22 @@ function CreateAccountWizard() {
   }, [wallet.connected, keypair, generating, step, generate]);
 
   useEffect(() => {
+    if (isSubaccount) return;
     if (wallet.address) setOwnerFields((prev) => (prev[0] ? prev : [wallet.address!]));
-  }, [wallet.address]);
+  }, [wallet.address, isSubaccount]);
+
+  // Subaccount: when the parent's owners load (or arrive after mount), prefill
+  // the form — but only if the user hasn't started editing the defaults.
+  useEffect(() => {
+    if (!isSubaccount) return;
+    if (parentOwners.length === 0) return;
+    setOwnerFields((prev) => (prev.some((s) => s.trim()) ? prev : parentOwners));
+  }, [isSubaccount, parentOwners]);
+  useEffect(() => {
+    if (!isSubaccount) return;
+    if (parentContract?.threshold == null) return;
+    setThreshold((prev) => (prev.trim() ? prev : String(parentContract.threshold)));
+  }, [isSubaccount, parentContract?.threshold]);
 
   const parsedOwners = useMemo(
     () => ownerFields.map((s) => s.trim()).filter(Boolean),

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -156,18 +156,18 @@ export default function AccountsListPage() {
       <div className="p-6 max-w-4xl mx-auto w-full">
         <div className="flex items-end justify-between mb-6">
           <div>
-            <h1 className="text-2xl font-bold">Your accounts</h1>
+            <h1 className="text-2xl font-bold">Your Vaults</h1>
             <p className="text-sm text-safe-text mt-1">
               {!wallet.address
-                ? 'Connect a wallet to see your accounts.'
-                : `${ownedCount} ${ownedCount === 1 ? 'account' : 'accounts'}`}
+                ? 'Connect a wallet to see your Vaults.'
+                : `${ownedCount} ${ownedCount === 1 ? 'Vault' : 'Vaults'}`}
             </p>
           </div>
           <Link
             href="/accounts/new"
             className="bg-safe-green text-safe-dark font-semibold rounded-lg px-5 py-2.5 text-sm hover:brightness-110 transition-all"
           >
-            + Create account
+            + Create Vault
           </Link>
         </div>
 
@@ -209,17 +209,17 @@ export default function AccountsListPage() {
             <div className="p-10 text-center">
               <p className="text-safe-text mb-4">
                 {!wallet.address
-                  ? 'Connect a wallet to see your accounts.'
+                  ? 'Connect a wallet to see your Vaults.'
                   : ownedCount === 0
-                    ? "You don't own any MinaGuard accounts yet."
-                    : 'No accounts match that search.'}
+                    ? "You don't own any MinaGuard Vaults yet."
+                    : 'No Vaults match that search.'}
               </p>
               {wallet.address && ownedCount === 0 && (
                 <Link
                   href="/accounts/new"
                   className="inline-block bg-safe-green text-safe-dark font-semibold rounded-lg px-5 py-2 text-sm hover:brightness-110"
                 >
-                  Create your first account
+                  Create your first Vault
                 </Link>
               )}
             </div>
@@ -439,7 +439,7 @@ function AccountRow({
             {name && <p className="text-sm font-semibold truncate">{name}</p>}
             {isChild && (
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-safe-border/40 text-safe-text shrink-0">
-                Subaccount
+                SubVault
               </span>
             )}
             {isChild && contract.childMultiSigEnabled === false && (

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -246,7 +246,7 @@ export default function TransactionDetailPage() {
       }
 
       if (captured.proposal.txType === 'createChild') {
-        return 'CREATE_CHILD proposals finalize via the parent detail page → Pending Subaccounts → Finalize deployment.';
+        return 'CREATE_CHILD proposals finalize via the parent Vault detail page → Pending SubVaults → Finalize deployment.';
       }
 
       const result = await executeProposalOnchain({
@@ -332,9 +332,9 @@ export default function TransactionDetailPage() {
       : 'Invalidates another proposal'
     : isRemote
       ? proposal.childAccount
-        ? `Executes on subaccount ${truncateAddress(proposal.childAccount)}`
-        : 'Executes on subaccount'
-      : 'Executes on this account';
+        ? `Executes on SubVault ${truncateAddress(proposal.childAccount)}`
+        : 'Executes on SubVault'
+      : 'Executes on this Vault';
 
   // Pull the pending-create entry directly so we can show its tx hash even
   // before the synthesized row carries it via `proposal.lastExecuteTxHash`.

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   getPendingTx,
   savePendingTx,
 } from '@/lib/storage';
+import { useContractTxLock } from '@/hooks/useContractTxLock';
 
 /** Proposal detail page with approve/execute actions and lifecycle status. */
 export default function TransactionDetailPage() {
@@ -117,6 +118,10 @@ export default function TransactionDetailPage() {
     proposal.status === 'pending' &&
     proposal.lastExecuteTxHash != null &&
     proposal.lastExecuteError == null;
+  // Contract-wide indexer-lag lock. Any in-flight tx on this contract (own
+  // or cross-signer) makes rebuildStoresFromBackend stale; serialize until
+  // the indexer catches up.
+  const contractLock = useContractTxLock(multisig?.address ?? null, proposals);
   const canApprove =
     !!proposal &&
     !isLocalPending &&
@@ -124,14 +129,16 @@ export default function TransactionDetailPage() {
     isOwner &&
     !hasApproved &&
     !isConfigStale &&
-    !myPendingApprove;
+    !myPendingApprove &&
+    !contractLock.locked;
   const canExecute =
     !!proposal &&
     !isLocalPending &&
     proposal.status === 'pending' &&
     proposal.approvalCount >= threshold &&
     !isConfigStale &&
-    !executeInFlight;
+    !executeInFlight &&
+    !contractLock.locked;
   const canDelete =
     !!proposal &&
     !isLocalPending &&
@@ -146,7 +153,8 @@ export default function TransactionDetailPage() {
     // While an execute is in flight, the proposal is about to be invalidated
     // either way (success → executed, failure → user retries). Surfacing
     // Delete here just invites duplicate work / wasted fees.
-    !executeInFlight;
+    !executeInFlight &&
+    !contractLock.locked;
   const isNonceStale = proposal?.status === 'invalidated' && proposal.invalidReason === 'proposal_nonce_stale';
 
   /** Submits an on-chain approveProposal transaction. */
@@ -375,6 +383,16 @@ export default function TransactionDetailPage() {
             title="Your approval is in flight"
             description="Waiting for the network to include your approval transaction."
             txHash={myPendingApprove.txHash}
+            network={wallet.network ?? null}
+          />
+        )}
+
+        {contractLock.locked && !executeInFlight && !myPendingApprove && (
+          <PendingTxBanner
+            tone="approval"
+            title="Indexer catching up"
+            description={`${contractLock.reason} New submissions on this contract are blocked until it lands (~3 min).`}
+            txHash={contractLock.txHash}
             network={wallet.network ?? null}
           />
         )}

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -133,12 +133,16 @@ export default function TransactionDetailPage() {
       cancelled = true;
     };
   }, [spendingTarget?.sourceAddress, indexerStatus?.lastSuccessfulRunAt]);
-  // Fail-open: only block when we've successfully fetched a balance below the
-  // proposal's send amount. Unknown/failed fetches let the chain decide.
+  // Fail-open: only block when we've successfully fetched a non-zero balance
+  // below the proposal's send amount. The backend coalesces missing daemon
+  // data to "0" (routes.ts), so a literal "0" is indistinguishable from "the
+  // account isn't visible to the daemon yet" — treat it as ambiguous and let
+  // the chain reject if the Vault is genuinely empty.
   const insufficientBalance =
     spendingTarget != null &&
     sourceBalance != null &&
     !balanceFetchFailed &&
+    BigInt(sourceBalance) > 0n &&
     BigInt(sourceBalance) < spendingTarget.amount;
 
   const threshold = multisig?.threshold ?? 0;
@@ -162,7 +166,29 @@ export default function TransactionDetailPage() {
   // Contract-wide indexer-lag lock. Any in-flight tx on this contract (own
   // or cross-signer) makes rebuildStoresFromBackend stale; serialize until
   // the indexer catches up.
-  const contractLock = useContractTxLock(multisig?.address ?? null, proposals);
+  //
+  // Exception: the viewed proposal's own *already-counted* approve. Approval
+  // counts are event-sourced from the indexer (see applyApprovalEvent), so
+  // `approvalCount >= threshold` proves the chain's approvalRoot reflects
+  // those approvals and is fresh enough to execute. The lingering
+  // `lastApproveTxHash` on the same record is just stale metadata when the
+  // indexer's tx-hash-match clearing doesn't fire (e.g. archive vs broadcast
+  // hash format mismatches). Mask that signal so it doesn't gate execute on
+  // this page.
+  const proposalsForLock = useMemo(
+    () =>
+      proposals.map((p) => {
+        const isViewedAndCounted =
+          proposal != null &&
+          p.proposalHash === proposal.proposalHash &&
+          p.lastApproveTxHash != null &&
+          p.lastApproveError == null &&
+          p.approvalCount >= threshold;
+        return isViewedAndCounted ? { ...p, lastApproveTxHash: null } : p;
+      }),
+    [proposals, proposal?.proposalHash, threshold],
+  );
+  const contractLock = useContractTxLock(multisig?.address ?? null, proposalsForLock);
   const canApprove =
     !!proposal &&
     !isLocalPending &&
@@ -172,6 +198,13 @@ export default function TransactionDetailPage() {
     !isConfigStale &&
     !myPendingApprove &&
     !contractLock.locked;
+  // Note on insufficientBalance: surfaced as a banner above the action row but
+  // not gated into canExecute. The UI-side balance signal can lag the daemon
+  // (the backend's /api/account/.../balance route coalesces missing data to
+  // "0" — `backend/src/routes.ts`), and a false-positive there would silently
+  // hide the Execute button. The chain still rejects an undercollateralised
+  // tx, so the cost of letting an over-eager click through is one tx fee; the
+  // cost of a stuck UI is a confused user.
   const canExecute =
     !!proposal &&
     !isLocalPending &&
@@ -179,8 +212,7 @@ export default function TransactionDetailPage() {
     proposal.approvalCount >= threshold &&
     !isConfigStale &&
     !executeInFlight &&
-    !contractLock.locked &&
-    !insufficientBalance;
+    !contractLock.locked;
   const canDelete =
     !!proposal &&
     !isLocalPending &&
@@ -553,8 +585,8 @@ export default function TransactionDetailPage() {
             <p className="opacity-90">
               The {proposal.txType === 'reclaimChild' ? 'SubVault' : 'Vault'} holds{' '}
               {formatMina(sourceBalance!)} MINA but this proposal sends{' '}
-              {formatMina(spendingTarget!.amount.toString())} MINA. Execute is blocked
-              until it is funded.
+              {formatMina(spendingTarget!.amount.toString())} MINA. Execute will
+              fail on chain until it is funded.
             </p>
           </div>
         )}

--- a/ui/app/transactions/[id]/page.tsx
+++ b/ui/app/transactions/[id]/page.tsx
@@ -10,8 +10,9 @@ import {
   formatMina,
   isDeleteProposal,
   truncateAddress,
+  type Proposal,
 } from '@/lib/types';
-import { fetchApprovals, extractTxHash, recordSubmission } from '@/lib/api';
+import { fetchApprovals, extractTxHash, fetchBalance, recordSubmission } from '@/lib/api';
 import {
   approveProposalOnchain,
   executeProposalOnchain,
@@ -35,6 +36,7 @@ export default function TransactionDetailPage() {
     owners,
     proposals,
     proposalsAddress,
+    indexerStatus,
     startOperation,
     isOperating,
   } = useAppContext();
@@ -100,6 +102,45 @@ export default function TransactionDetailPage() {
     return approvalAddresses.includes(wallet.address);
   }, [approvalAddresses, wallet.address]);
 
+  // Source Vault/SubVault that funds the proposal's outgoing MINA. For
+  // transfer/allocateChild it's the Vault we're viewing; for reclaimChild it's
+  // the SubVault being drained.
+  const spendingTarget = useMemo(
+    () => (proposal && multisig ? getSpendingTarget(proposal, multisig.address) : null),
+    [proposal, multisig?.address],
+  );
+  const [sourceBalance, setSourceBalance] = useState<string | null>(null);
+  const [balanceFetchFailed, setBalanceFetchFailed] = useState(false);
+  useEffect(() => {
+    if (!spendingTarget) {
+      setSourceBalance(null);
+      setBalanceFetchFailed(false);
+      return;
+    }
+    let cancelled = false;
+    fetchBalance(spendingTarget.sourceAddress)
+      .then((b) => {
+        if (cancelled) return;
+        setSourceBalance(b);
+        setBalanceFetchFailed(b === null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSourceBalance(null);
+        setBalanceFetchFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [spendingTarget?.sourceAddress, indexerStatus?.lastSuccessfulRunAt]);
+  // Fail-open: only block when we've successfully fetched a balance below the
+  // proposal's send amount. Unknown/failed fetches let the chain decide.
+  const insufficientBalance =
+    spendingTarget != null &&
+    sourceBalance != null &&
+    !balanceFetchFailed &&
+    BigInt(sourceBalance) < spendingTarget.amount;
+
   const threshold = multisig?.threshold ?? 0;
   const isConfigStale =
     !!proposal &&
@@ -138,7 +179,8 @@ export default function TransactionDetailPage() {
     proposal.approvalCount >= threshold &&
     !isConfigStale &&
     !executeInFlight &&
-    !contractLock.locked;
+    !contractLock.locked &&
+    !insufficientBalance;
   const canDelete =
     !!proposal &&
     !isLocalPending &&
@@ -505,6 +547,18 @@ export default function TransactionDetailPage() {
           </div>
         )}
 
+        {insufficientBalance && proposal.approvalCount >= threshold && (
+          <div className="rounded-xl border border-red-400/30 bg-red-400/10 p-4 text-red-300 text-sm">
+            <p className="font-semibold mb-1">Insufficient balance</p>
+            <p className="opacity-90">
+              The {proposal.txType === 'reclaimChild' ? 'SubVault' : 'Vault'} holds{' '}
+              {formatMina(sourceBalance!)} MINA but this proposal sends{' '}
+              {formatMina(spendingTarget!.amount.toString())} MINA. Execute is blocked
+              until it is funded.
+            </p>
+          </div>
+        )}
+
         {proposal.status === 'pending' && !isLocalPending && (
           <div className="flex gap-3 flex-wrap">
             {canApprove && (
@@ -649,4 +703,21 @@ function DetailRow({
       )}
     </div>
   );
+}
+
+/** Returns the source Vault address and outgoing nanomina amount for proposals
+ *  that move MINA out of a Vault, or null if the proposal can't underfund. */
+function getSpendingTarget(
+  proposal: Proposal,
+  contractAddress: string,
+): { sourceAddress: string; amount: bigint } | null {
+  if (isDeleteProposal(proposal)) return null;
+  if (proposal.txType === 'transfer' || proposal.txType === 'allocateChild') {
+    if (!proposal.totalAmount) return null;
+    return { sourceAddress: contractAddress, amount: BigInt(proposal.totalAmount) };
+  }
+  if (proposal.txType === 'reclaimChild' && proposal.childAccount && proposal.data) {
+    return { sourceAddress: proposal.childAccount, amount: BigInt(proposal.data) };
+  }
+  return null;
 }

--- a/ui/app/transactions/new/page.tsx
+++ b/ui/app/transactions/new/page.tsx
@@ -14,6 +14,7 @@ import {
 import TxTypeIcon from '@/components/TxTypeIcon';
 import { createOnchainProposal } from '@/lib/multisigClient';
 import { fetchChildren, fetchContract } from '@/lib/api';
+import { useContractTxLock } from '@/hooks/useContractTxLock';
 import { savePendingTx } from '@/lib/storage';
 
 export default function NewTransactionPage() {
@@ -37,6 +38,7 @@ function NewTransactionPageInner() {
   } = useAppContext();
 
   const isRoot = !!multisig && !multisig.parent;
+  const contractLock = useContractTxLock(multisig?.address ?? null, proposals);
 
   // Available tx types: LOCAL on every guard; subaccount actions only on roots.
   // CREATE_CHILD is shown on roots so the action is discoverable here, but it
@@ -237,12 +239,18 @@ function NewTransactionPageInner() {
                   There are pending governance proposals. If one executes before this proposal, the config nonce will change and this proposal will be invalidated.
                 </div>
               )}
+              {contractLock.locked && (
+                <div className="rounded-lg px-4 py-3 text-xs bg-amber-500/10 text-amber-200 border border-amber-400/30">
+                  {contractLock.reason} New submissions on this contract are blocked until it lands (~3 min).
+                </div>
+              )}
               <ProposalForm
                 owners={owners.map((owner) => owner.address)}
                 currentThreshold={multisig.threshold ?? 1}
                 numOwners={multisig.numOwners ?? owners.length}
                 onSubmit={handleSubmit}
                 isSubmitting={isOperating}
+                submitDisabledReason={contractLock.locked ? contractLock.reason : null}
                 txType={txType}
                 children={children}
                 initialNonce={initialNonce}

--- a/ui/app/transactions/new/page.tsx
+++ b/ui/app/transactions/new/page.tsx
@@ -281,9 +281,9 @@ interface TxTypePickerProps {
 function TxTypePicker({ localTypes, childTypes, selected, onSelect }: TxTypePickerProps) {
   return (
     <div className="space-y-3">
-      <PickerRow label="Account" types={localTypes} selected={selected} onSelect={onSelect} />
+      <PickerRow label="Vault" types={localTypes} selected={selected} onSelect={onSelect} />
       {childTypes.length > 0 && (
-        <PickerRow label="Subaccount" types={childTypes} selected={selected} onSelect={onSelect} />
+        <PickerRow label="SubVault" types={childTypes} selected={selected} onSelect={onSelect} />
       )}
     </div>
   );

--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -39,7 +39,7 @@ export default function Header({
       <Link
         href="/"
         className="flex items-center gap-2 hover:opacity-80 transition-opacity shrink-0"
-        title="Back to accounts"
+        title="Back to Vaults"
       >
         <div className="w-8 h-8 bg-safe-green rounded-full flex items-center justify-center">
           <span className="text-safe-dark font-bold text-sm">M</span>

--- a/ui/components/LedgerConnectModal.tsx
+++ b/ui/components/LedgerConnectModal.tsx
@@ -26,7 +26,7 @@ export default function LedgerConnectModal({ onConfirm, onClose }: LedgerConnect
         </div>
 
         <label className="block space-y-1">
-          <span className="text-xs text-safe-text">Account Index</span>
+          <span className="text-xs text-safe-text">Vault Index</span>
           <input
             type="number"
             min={0}

--- a/ui/components/ProposalForm.tsx
+++ b/ui/components/ProposalForm.tsx
@@ -23,6 +23,10 @@ interface ProposalFormProps {
   numOwners: number;
   onSubmit: (data: NewProposalInput) => void;
   isSubmitting: boolean;
+  /** External reason to keep the submit button disabled (e.g. indexer-lag
+   *  contract lock). The form just disables; the calling page renders the
+   *  user-facing banner explaining why. */
+  submitDisabledReason?: string | null;
   txType: TxType;
   /** Indexed subaccounts of this guard, used as targets for CHILD_TX_TYPES. */
   children?: ContractSummary[];
@@ -49,6 +53,7 @@ export default function ProposalForm({
   numOwners,
   onSubmit,
   isSubmitting,
+  submitDisabledReason = null,
   txType,
   children = [],
   initialNonce,
@@ -684,8 +689,9 @@ export default function ProposalForm({
 
       <button
         type="submit"
-        disabled={isSubmitting}
-        className="w-full bg-safe-green text-safe-dark font-semibold rounded-lg py-3 text-sm hover:brightness-110 transition-all disabled:opacity-50"
+        disabled={isSubmitting || !!submitDisabledReason}
+        title={submitDisabledReason ?? undefined}
+        className="w-full bg-safe-green text-safe-dark font-semibold rounded-lg py-3 text-sm hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isSubmitting ? 'Submitting Proposal...' : (deleteMode ? 'Create Delete Proposal' : 'Submit Proposal')}
       </button>

--- a/ui/components/ProposalForm.tsx
+++ b/ui/components/ProposalForm.tsx
@@ -60,7 +60,14 @@ export default function ProposalForm({
   deleteTargetProposal = null,
   onExitDeleteMode,
 }: ProposalFormProps) {
-  const [transferLines, setTransferLines] = useState('');
+  // Recipient rows are the source of truth for both transfer + allocateChild.
+  // Bulk mode renders a textarea derived from these rows (and parses back on
+  // edit); Individual mode binds inputs directly.
+  const [recipients, setRecipients] = useState<Array<{ address: string; amount: string }>>([
+    { address: '', amount: '' },
+  ]);
+  const [recipientsMode, setRecipientsMode] = useState<'individual' | 'bulk'>('individual');
+  const [bulkText, setBulkText] = useState('');
   const [newOwner, setNewOwner] = useState('');
   const [removeOwnerAddress, setRemoveOwnerAddress] = useState('');
   const [newThreshold, setNewThreshold] = useState(Math.max(1, currentThreshold));
@@ -76,7 +83,9 @@ export default function ProposalForm({
 
   useEffect(() => {
     if (!deleteMode) return;
-    setTransferLines('');
+    setRecipients([{ address: '', amount: '' }]);
+    setBulkText('');
+    setRecipientsMode('individual');
     setExpiryBlock('0');
   }, [deleteMode]);
 
@@ -182,7 +191,7 @@ export default function ProposalForm({
   }, [txType, targetChild]);
 
   const [validationError, setValidationError] = useState<string | null>(null);
-  const transferParse = parseTransferLines(transferLines);
+  const recipientsParse = useMemo(() => parseRecipients(recipients), [recipients]);
   // Live warning for nonce collisions with pending proposals — non-blocking,
   // matches the delete-mode race-to-execute semantics.
   const nonceCollisionWarning = (() => {
@@ -222,8 +231,10 @@ export default function ProposalForm({
       setValidationError(`Cannot exceed the maximum of ${MAX_OWNERS} owners.`);
       return;
     }
-    if (!deleteMode && (txType === 'transfer' || txType === 'allocateChild') && !transferParse.ok) {
-      setValidationError(transferParse.error);
+    if (!deleteMode && (txType === 'transfer' || txType === 'allocateChild') && !recipientsParse.ok) {
+      setValidationError(
+        recipientsParse.topError ?? 'Fix the highlighted recipient rows before submitting.',
+      );
       return;
     }
     if (
@@ -235,12 +246,12 @@ export default function ProposalForm({
       return;
     }
     if (!deleteMode && txType === 'reclaimChild') {
-      const nano = parseMinaToNanomina(reclaimAmount);
-      if (!nano) {
+      const parsed = parseMinaToNanomina(reclaimAmount);
+      if (!parsed) {
         setValidationError('Reclaim amount must be a positive MINA value.');
         return;
       }
-      if (targetBalance !== null && BigInt(nano) > BigInt(targetBalance)) {
+      if (targetBalance !== null && BigInt(parsed.nanomina) > BigInt(targetBalance)) {
         setValidationError(`Reclaim amount exceeds subaccount balance (${formatMina(targetBalance)} MINA).`);
         return;
       }
@@ -291,7 +302,7 @@ export default function ProposalForm({
       receivers:
         deleteReceivers ??
         (effectiveTxType === 'transfer' || effectiveTxType === 'allocateChild'
-          ? transferParse.receivers
+          ? recipientsParse.receivers
           : undefined),
       newOwner: !deleteMode && effectiveTxType === 'addOwner' ? newOwner : undefined,
       removeOwnerAddress: !deleteMode && effectiveTxType === 'removeOwner' ? removeOwnerAddress : undefined,
@@ -308,7 +319,7 @@ export default function ProposalForm({
         isRemoteDelete
           ? '0'
           : !deleteMode && txType === 'reclaimChild'
-            ? (parseMinaToNanomina(reclaimAmount) ?? '0')
+            ? (parseMinaToNanomina(reclaimAmount)?.nanomina ?? '0')
             : undefined,
       childMultiSigEnable:
         !deleteMode && txType === 'enableChildMultiSig' ? enableTarget === 'enable' : undefined,
@@ -386,69 +397,17 @@ export default function ProposalForm({
       </div>
 
       {!deleteMode && (txType === 'transfer' || txType === 'allocateChild') && (
-        <div className="space-y-3">
-          <label className="block text-sm text-safe-text">
-            {txType === 'allocateChild' ? 'Subaccount allocations' : 'Recipients'}
-          </label>
-          {txType === 'allocateChild' && children.length > 0 && (
-            <div className="rounded-lg border border-safe-border bg-safe-dark/20 px-3 py-2 text-xs space-y-1">
-              <p className="text-safe-text">Indexed subaccounts (click to copy):</p>
-              <ul className="space-y-0.5">
-                {children.map((c) => (
-                  <li key={c.address}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const next = transferLines.trim()
-                          ? `${transferLines.trim()}\n${c.address},`
-                          : `${c.address},`;
-                        setTransferLines(next);
-                      }}
-                      className="font-mono text-safe-green hover:underline truncate"
-                      title={c.address}
-                    >
-                      {c.address.slice(0, 12)}…{c.address.slice(-6)}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          <textarea
-            value={transferLines}
-            onChange={(e) => setTransferLines(e.target.value)}
-            placeholder={`B62q...,1.25\nB62q...,0.5`}
-            rows={8}
-            className="w-full bg-safe-gray border border-safe-border rounded-lg px-4 py-3 text-sm font-mono placeholder:text-safe-border focus:outline-none focus:border-safe-green transition-colors"
-            required
-          />
-          <div className="rounded-lg border border-safe-border bg-safe-dark/20 px-4 py-3 text-sm">
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-safe-text">Parsed recipients</span>
-              <span className="font-mono text-safe-green">
-                {transferParse.recipientCount}/{MAX_RECEIVERS}
-              </span>
-            </div>
-            <div className="flex items-center justify-between gap-4 mt-2">
-              <span className="text-safe-text">Total MINA</span>
-              <span className="font-mono text-safe-green">
-                {formatNanominaAsMina(transferParse.totalAmount)}
-              </span>
-            </div>
-            <div className="flex items-center justify-between gap-4 mt-2">
-              <span className="text-safe-text">Remaining slots</span>
-              <span className="font-mono text-safe-text">
-                {Math.max(0, MAX_RECEIVERS - transferParse.recipientCount)}
-              </span>
-            </div>
-          </div>
-          <p className="text-xs text-safe-text">
-            Enter one recipient per line as <span className="font-mono">address,amount</span>.
-          </p>
-          {!transferParse.ok && transferLines.trim() && (
-            <p className="text-sm text-red-400 whitespace-pre-wrap">{transferParse.error}</p>
-          )}
-        </div>
+        <RecipientsBlock
+          label={txType === 'allocateChild' ? 'Subaccount allocations' : 'Recipients'}
+          recipients={recipients}
+          setRecipients={setRecipients}
+          recipientsMode={recipientsMode}
+          setRecipientsMode={setRecipientsMode}
+          bulkText={bulkText}
+          setBulkText={setBulkText}
+          parse={recipientsParse}
+          children={txType === 'allocateChild' ? children : []}
+        />
       )}
 
       {!deleteMode && (txType === 'reclaimChild' || txType === 'destroyChild' || txType === 'enableChildMultiSig') && (
@@ -734,107 +693,381 @@ export default function ProposalForm({
   );
 }
 
-type TransferParseResult =
-  | {
-    ok: true;
-    receivers: Array<{ address: string; amount: string }>;
-    recipientCount: number;
-    totalAmount: string;
-  }
-  | {
-    ok: false;
-    receivers: Array<{ address: string; amount: string }>;
-    recipientCount: number;
-    totalAmount: string;
-    error: string;
+/** Renders the recipients block in either Individual (per-row inputs) or
+ *  Bulk (textarea) mode. `recipients` is the source of truth; bulk mode just
+ *  serializes/parses through `bulkText`. */
+function RecipientsBlock({
+  label,
+  recipients,
+  setRecipients,
+  recipientsMode,
+  setRecipientsMode,
+  bulkText,
+  setBulkText,
+  parse,
+  children,
+}: {
+  label: string;
+  recipients: Array<{ address: string; amount: string }>;
+  setRecipients: (rows: Array<{ address: string; amount: string }>) => void;
+  recipientsMode: 'individual' | 'bulk';
+  setRecipientsMode: (mode: 'individual' | 'bulk') => void;
+  bulkText: string;
+  setBulkText: (text: string) => void;
+  parse: RecipientsParseResult;
+  children: ContractSummary[];
+}) {
+  const showAddRow = recipients.length < MAX_RECEIVERS;
+
+  const updateRow = (index: number, patch: Partial<{ address: string; amount: string }>) => {
+    setRecipients(recipients.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  };
+  const addRow = () => {
+    if (recipients.length >= MAX_RECEIVERS) return;
+    setRecipients([...recipients, { address: '', amount: '' }]);
+  };
+  const removeRow = (index: number) => {
+    if (recipients.length <= 1) return;
+    setRecipients(recipients.filter((_, i) => i !== index));
   };
 
-function parseTransferLines(input: string): TransferParseResult {
-  const lines = input
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const switchToBulk = () => {
+    setBulkText(serializeRecipients(recipients));
+    setRecipientsMode('bulk');
+  };
+  const switchToIndividual = () => {
+    setRecipientsMode('individual');
+  };
+  const handleBulkChange = (text: string) => {
+    setBulkText(text);
+    setRecipients(parseBulkRecipients(text));
+  };
 
-  if (lines.length === 0) {
-    return {
-      ok: false,
-      receivers: [],
-      recipientCount: 0,
-      totalAmount: '0',
-      error: 'Add at least one recipient line.',
-    };
+  const totalDisplay = formatNanominaAsMina(parse.totalAmount);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <label className="block text-sm text-safe-text">{label}</label>
+        <div className="inline-flex rounded-lg border border-safe-border overflow-hidden text-xs">
+          <button
+            type="button"
+            onClick={switchToIndividual}
+            className={`px-3 py-1 transition-colors ${
+              recipientsMode === 'individual'
+                ? 'bg-safe-green text-safe-dark font-semibold'
+                : 'bg-transparent text-safe-text hover:bg-safe-hover'
+            }`}
+          >
+            Individual
+          </button>
+          <button
+            type="button"
+            onClick={switchToBulk}
+            className={`px-3 py-1 transition-colors ${
+              recipientsMode === 'bulk'
+                ? 'bg-safe-green text-safe-dark font-semibold'
+                : 'bg-transparent text-safe-text hover:bg-safe-hover'
+            }`}
+          >
+            Bulk
+          </button>
+        </div>
+      </div>
+
+      {recipientsMode === 'individual' ? (
+        <div className="space-y-2">
+          {recipients.map((row, index) => {
+            const validation = parse.rows[index];
+            const hasError = validation?.errors.length > 0;
+            const hasWarning = !!validation?.warning;
+            return (
+              <div key={index} className="space-y-1">
+                <div className="flex gap-2 items-start">
+                  {children.length > 0 ? (
+                    <select
+                      value={row.address}
+                      onChange={(e) => updateRow(index, { address: e.target.value })}
+                      className="flex-1 min-w-0 bg-safe-gray border border-safe-border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:border-safe-green"
+                    >
+                      <option value="">Select subaccount…</option>
+                      {children.map((c) => (
+                        <option key={c.address} value={c.address}>
+                          {c.address.slice(0, 12)}…{c.address.slice(-6)}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={row.address}
+                      onChange={(e) => updateRow(index, { address: e.target.value })}
+                      placeholder="B62q..."
+                      className="flex-1 min-w-0 bg-safe-gray border border-safe-border rounded-lg px-3 py-2 text-sm font-mono placeholder:text-safe-border focus:outline-none focus:border-safe-green"
+                    />
+                  )}
+                  <input
+                    type="text"
+                    value={row.amount}
+                    onChange={(e) => updateRow(index, { amount: e.target.value })}
+                    placeholder="0.00"
+                    inputMode="decimal"
+                    className="w-32 shrink-0 bg-safe-gray border border-safe-border rounded-lg px-3 py-2 text-sm font-mono placeholder:text-safe-border focus:outline-none focus:border-safe-green"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeRow(index)}
+                    disabled={recipients.length <= 1}
+                    title={recipients.length <= 1 ? 'At least one recipient is required.' : 'Remove recipient'}
+                    className="shrink-0 px-2 py-2 text-safe-text hover:text-red-400 disabled:opacity-30 disabled:cursor-not-allowed"
+                    aria-label="Remove recipient"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                {hasError && (
+                  <p className="text-xs text-red-400 pl-1">{validation.errors.join(' · ')}</p>
+                )}
+                {!hasError && hasWarning && (
+                  <p className="text-xs text-amber-300 pl-1">{validation.warning}</p>
+                )}
+              </div>
+            );
+          })}
+          {showAddRow && (
+            <button
+              type="button"
+              onClick={addRow}
+              className="text-xs font-medium text-safe-green hover:underline"
+            >
+              + Add recipient
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {children.length > 0 && (
+            <div className="rounded-lg border border-safe-border bg-safe-dark/20 px-3 py-2 text-xs space-y-1">
+              <p className="text-safe-text">Indexed subaccounts (click to append):</p>
+              <ul className="space-y-0.5">
+                {children.map((c) => (
+                  <li key={c.address}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const next = bulkText.trim()
+                          ? `${bulkText.trim()}\n${c.address},`
+                          : `${c.address},`;
+                        handleBulkChange(next);
+                      }}
+                      className="font-mono text-safe-green hover:underline truncate"
+                      title={c.address}
+                    >
+                      {c.address.slice(0, 12)}…{c.address.slice(-6)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <textarea
+            value={bulkText}
+            onChange={(e) => handleBulkChange(e.target.value)}
+            placeholder={`B62q...,1.25\nB62q...,0.5`}
+            rows={8}
+            className="w-full bg-safe-gray border border-safe-border rounded-lg px-4 py-3 text-sm font-mono placeholder:text-safe-border focus:outline-none focus:border-safe-green transition-colors"
+          />
+          <p className="text-xs text-safe-text">
+            One recipient per line as <span className="font-mono">address,amount</span>.
+          </p>
+          {parse.rows.some((r) => r.errors.length > 0) && (
+            <ul className="text-xs text-red-400 space-y-0.5">
+              {parse.rows.map((r, i) =>
+                r.errors.length > 0 ? (
+                  <li key={i}>Line {i + 1}: {r.errors.join(' · ')}</li>
+                ) : null,
+              )}
+            </ul>
+          )}
+          {parse.rows.some((r) => !r.errors.length && r.warning) && (
+            <ul className="text-xs text-amber-300 space-y-0.5">
+              {parse.rows.map((r, i) =>
+                !r.errors.length && r.warning ? (
+                  <li key={i}>Line {i + 1}: {r.warning}</li>
+                ) : null,
+              )}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-safe-border bg-safe-dark/20 px-4 py-3 text-sm">
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-safe-text">Parsed recipients</span>
+          <span className="font-mono text-safe-green">{parse.recipientCount}/{MAX_RECEIVERS}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4 mt-2">
+          <span className="text-safe-text">Total MINA</span>
+          <span className="font-mono text-safe-green">{totalDisplay}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4 mt-2">
+          <span className="text-safe-text">Remaining slots</span>
+          <span className="font-mono text-safe-text">
+            {Math.max(0, MAX_RECEIVERS - parse.recipientCount)}
+          </span>
+        </div>
+      </div>
+
+      {parse.topError && (
+        <p className="text-sm text-red-400">{parse.topError}</p>
+      )}
+    </div>
+  );
+}
+
+/** Per-row validation result emitted by `parseRecipients`. Empty rows return
+ *  `ok:false` with no `errors` so the UI doesn't yell at users about rows
+ *  they haven't filled in yet. */
+interface RecipientRowValidation {
+  ok: boolean;
+  /** Canonical nanomina value when both address and amount validate. */
+  nanomina: string | null;
+  /** Hard errors (red, block submission). */
+  errors: string[];
+  /** Soft warning (amber, non-blocking). Currently: amount truncated past 9 decimals. */
+  warning: string | null;
+}
+
+interface RecipientsParseResult {
+  rows: RecipientRowValidation[];
+  /** True when at least one row is filled and every filled row validates. */
+  ok: boolean;
+  /** Submission-ready array, only valid rows. */
+  receivers: Array<{ address: string; amount: string }>;
+  /** Sum of valid nanomina amounts. */
+  totalAmount: string;
+  /** Number of valid (submission-ready) rows. */
+  recipientCount: number;
+  /** Aggregate-level error (e.g. "Add at least one recipient"). Null when
+   *  only per-row errors exist; the row-level UI surfaces those. */
+  topError: string | null;
+}
+
+/** Validates a list of {address, amount} rows. The same logic powers both
+ *  Individual (per-row inputs) and Bulk (textarea) modes — the bulk mode
+ *  parses lines into rows and then defers to this. */
+function parseRecipients(rows: Array<{ address: string; amount: string }>): RecipientsParseResult {
+  const isEmpty = (r: { address: string; amount: string }) => !r.address.trim() && !r.amount.trim();
+  const filledCount = rows.filter((r) => !isEmpty(r)).length;
+
+  // Detect duplicates among filled rows so we can mark every duplicate row,
+  // not just the second occurrence.
+  const addressCounts = new Map<string, number>();
+  for (const r of rows) {
+    const a = r.address.trim();
+    if (!a) continue;
+    addressCounts.set(a, (addressCounts.get(a) ?? 0) + 1);
   }
 
-  if (lines.length > MAX_RECEIVERS) {
+  const validations: RecipientRowValidation[] = rows.map((row) => {
+    if (isEmpty(row)) return { ok: false, nanomina: null, errors: [], warning: null };
+
+    const address = row.address.trim();
+    const amountText = row.amount.trim();
+    const errors: string[] = [];
+    let warning: string | null = null;
+    let nanomina: string | null = null;
+
+    if (!address) errors.push('Address required');
+    else if (!/^B62[1-9A-HJ-NP-Za-km-z]+$/.test(address)) errors.push('Invalid Mina address');
+    else if ((addressCounts.get(address) ?? 0) > 1) errors.push('Duplicate recipient');
+
+    if (!amountText) errors.push('Amount required');
+    else {
+      const amt = parseMinaToNanomina(amountText);
+      if (!amt) errors.push('Invalid amount');
+      else {
+        nanomina = amt.nanomina;
+        if (amt.truncated) {
+          warning = `Will send ${formatNanominaAsMina(amt.nanomina)} MINA (Mina's precision is 9 decimals).`;
+        }
+      }
+    }
+
     return {
-      ok: false,
-      receivers: [],
-      recipientCount: lines.length,
-      totalAmount: '0',
-      error: `Too many recipients. The contract limit is ${MAX_RECEIVERS}.`,
+      ok: errors.length === 0 && nanomina !== null,
+      nanomina: errors.length === 0 ? nanomina : null,
+      errors,
+      warning,
     };
-  }
+  });
 
   const receivers: Array<{ address: string; amount: string }> = [];
-  const seen = new Set<string>();
-  const errors: string[] = [];
   let total = 0n;
-
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index];
-    const parts = line.split(',');
-    if (parts.length !== 2) {
-      errors.push(`Line ${index + 1}: expected "address,amount"`);
-      continue;
+  for (let i = 0; i < rows.length; i++) {
+    const v = validations[i];
+    if (v.ok && v.nanomina) {
+      receivers.push({ address: rows[i].address.trim(), amount: v.nanomina });
+      total += BigInt(v.nanomina);
     }
-
-    const address = parts[0].trim();
-    const amountText = parts[1].trim();
-    if (!/^B62[1-9A-HJ-NP-Za-km-z]+$/.test(address)) {
-      errors.push(`Line ${index + 1}: invalid Mina address`);
-      continue;
-    }
-
-    if (seen.has(address)) {
-      errors.push(`Line ${index + 1}: duplicate recipient`);
-      continue;
-    }
-
-    const amount = parseMinaToNanomina(amountText);
-    if (!amount) {
-      errors.push(`Line ${index + 1}: invalid amount`);
-      continue;
-    }
-
-    seen.add(address);
-    receivers.push({ address, amount });
-    total += BigInt(amount);
   }
 
-  if (errors.length > 0) {
-    return {
-      ok: false,
-      receivers,
-      recipientCount: receivers.length,
-      totalAmount: total.toString(),
-      error: errors.join('\n'),
-    };
-  }
+  let topError: string | null = null;
+  if (filledCount === 0) topError = 'Add at least one recipient.';
+  else if (filledCount > MAX_RECEIVERS) topError = `Too many recipients. The contract limit is ${MAX_RECEIVERS}.`;
+
+  // Aggregate ok: a) at least one filled+valid row, b) no row carries errors,
+  // c) no aggregate-level violation.
+  const ok =
+    topError === null &&
+    receivers.length > 0 &&
+    validations.every((v, i) => isEmpty(rows[i]) || v.ok);
 
   return {
-    ok: true,
+    rows: validations,
+    ok,
     receivers,
-    recipientCount: receivers.length,
     totalAmount: total.toString(),
+    recipientCount: receivers.length,
+    topError,
   };
 }
 
-function parseMinaToNanomina(value: string): string | null {
-  if (!/^\d+(\.\d{1,9})?$/.test(value)) return null;
+/** Serializes recipient rows back to the bulk textarea representation.
+ *  Drops empty rows so re-entering bulk mode starts clean. */
+function serializeRecipients(rows: Array<{ address: string; amount: string }>): string {
+  return rows
+    .filter((r) => r.address.trim() || r.amount.trim())
+    .map((r) => `${r.address.trim()},${r.amount.trim()}`)
+    .join('\n');
+}
+
+/** Parses bulk textarea content into recipient rows, preserving partially-
+ *  typed input (no early validation) so users don't lose progress mid-edit. */
+function parseBulkRecipients(text: string): Array<{ address: string; amount: string }> {
+  const lines = text.split('\n');
+  const rows = lines.map((line) => {
+    const idx = line.indexOf(',');
+    if (idx === -1) return { address: line.trim(), amount: '' };
+    return { address: line.slice(0, idx).trim(), amount: line.slice(idx + 1).trim() };
+  });
+  return rows.length > 0 ? rows : [{ address: '', amount: '' }];
+}
+
+/** Parses a MINA decimal string to canonical nanomina, truncating past 9
+ *  fractional digits (Mina's smallest unit is 1 nanomina = 1e-9 MINA).
+ *  Returns null for non-numeric input or values that round to zero. The
+ *  `truncated` flag tells the UI to surface a warning. */
+function parseMinaToNanomina(value: string): { nanomina: string; truncated: boolean } | null {
+  if (!/^\d+(\.\d*)?$/.test(value)) return null;
   const [whole, frac = ''] = value.split('.');
-  const fracPadded = frac.padEnd(9, '0');
-  const amount = `${whole}${fracPadded}`.replace(/^0+(?=\d)/, '') || '0';
-  return BigInt(amount) > 0n ? amount : null;
+  const truncated = frac.length > 9;
+  const fracTrimmed = frac.slice(0, 9).padEnd(9, '0');
+  const amount = `${whole}${fracTrimmed}`.replace(/^0+(?=\d)/, '') || '0';
+  if (BigInt(amount) === 0n) return null;
+  return { nanomina: amount, truncated };
 }
 
 function formatNanominaAsMina(value: string): string {

--- a/ui/components/ProposalForm.tsx
+++ b/ui/components/ProposalForm.tsx
@@ -222,7 +222,7 @@ export default function ProposalForm({
     // space (parent's localNonce for LOCAL, child's parentNonce for REMOTE).
     if (!deleteMode && effectiveNonceFloor !== null && parsedNonce <= effectiveNonceFloor) {
       const floorLabel = isRemoteSpaceTxType
-        ? `the selected subaccount's executed remote nonce (${effectiveNonceFloor})`
+        ? `the selected SubVault's executed remote nonce (${effectiveNonceFloor})`
         : `the current executed nonce (${effectiveNonceFloor})`;
       setValidationError(`Nonce must be greater than ${floorLabel}.`);
       return;
@@ -247,7 +247,7 @@ export default function ProposalForm({
       (txType === 'reclaimChild' || txType === 'destroyChild' || txType === 'enableChildMultiSig') &&
       !targetChild
     ) {
-      setValidationError('Pick a subaccount to target.');
+      setValidationError('Pick a SubVault to target.');
       return;
     }
     if (!deleteMode && txType === 'reclaimChild') {
@@ -257,12 +257,12 @@ export default function ProposalForm({
         return;
       }
       if (targetBalance !== null && BigInt(parsed.nanomina) > BigInt(targetBalance)) {
-        setValidationError(`Reclaim amount exceeds subaccount balance (${formatMina(targetBalance)} MINA).`);
+        setValidationError(`Reclaim amount exceeds SubVault balance (${formatMina(targetBalance)} MINA).`);
         return;
       }
     }
     if (!deleteMode && txType === 'destroyChild' && !destroyConfirm) {
-      setValidationError('Confirm the destroy action — this drains the subaccount and disables its multi-sig.');
+      setValidationError('Confirm the destroy action — this drains the SubVault and disables its multi-sig.');
       return;
     }
     if (effectiveTxType === 'addOwner' && owners.includes(newOwner.trim())) {
@@ -388,8 +388,8 @@ export default function ProposalForm({
         <p className="text-xs text-safe-text">
           {(() => {
             const floorLabel = isRemoteSpaceTxType
-              ? 'subaccount’s executed remote nonce'
-              : 'contract’s executed nonce';
+              ? 'SubVault’s executed remote nonce'
+              : 'Vault’s executed nonce';
             if (effectiveNonceFloor === null) {
               return `Use a nonce greater than the ${floorLabel}.`;
             }
@@ -403,7 +403,7 @@ export default function ProposalForm({
 
       {!deleteMode && (txType === 'transfer' || txType === 'allocateChild') && (
         <RecipientsBlock
-          label={txType === 'allocateChild' ? 'Subaccount allocations' : 'Recipients'}
+          label={txType === 'allocateChild' ? 'SubVault allocations' : 'Recipients'}
           recipients={recipients}
           setRecipients={setRecipients}
           recipientsMode={recipientsMode}
@@ -417,10 +417,10 @@ export default function ProposalForm({
 
       {!deleteMode && (txType === 'reclaimChild' || txType === 'destroyChild' || txType === 'enableChildMultiSig') && (
         <div>
-          <label className="block text-sm text-safe-text mb-2">Target Subaccount</label>
+          <label className="block text-sm text-safe-text mb-2">Target SubVault</label>
           {children.length === 0 ? (
             <p className="text-sm text-amber-400">
-              No indexed subaccounts to target. Create one first via the parent &rarr; Create Subaccount flow.
+              No indexed SubVaults to target. Create one first via the parent Vault &rarr; Create SubVault flow.
             </p>
           ) : (
             <div className="space-y-2">
@@ -501,8 +501,8 @@ export default function ProposalForm({
       {!deleteMode && txType === 'destroyChild' && (
         <div className="space-y-2 rounded-lg border border-red-400/40 bg-red-400/5 px-4 py-3">
           <p className="text-xs text-red-300">
-            Destroy drains the subaccount&apos;s full balance to the parent and disables its
-            multi-sig. The on-chain account remains but its lifecycle is permanently frozen.
+            Destroy drains the SubVault&apos;s full balance to the parent Vault and disables its
+            multi-sig. The on-chain Vault remains but its lifecycle is permanently frozen.
           </p>
           <label className="inline-flex items-center gap-2 text-sm text-safe-text">
             <input
@@ -510,7 +510,7 @@ export default function ProposalForm({
               checked={destroyConfirm}
               onChange={(e) => setDestroyConfirm(e.target.checked)}
             />
-            I understand and want to destroy this subaccount.
+            I understand and want to destroy this SubVault.
           </label>
         </div>
       )}
@@ -531,8 +531,8 @@ export default function ProposalForm({
           </div>
           <p className="text-xs text-safe-text pt-1">
             {currentMultiSigEnabled
-              ? 'Disabling blocks the subaccount from running its own LOCAL proposals (transfers, owner changes, etc.). Parent-authorized lifecycle actions remain available.'
-              : 'Enabling restores the subaccount\'s ability to run its own LOCAL proposals.'}
+              ? 'Disabling blocks the SubVault from running its own LOCAL proposals (transfers, owner changes, etc.). Parent-Vault-authorized lifecycle actions remain available.'
+              : 'Enabling restores the SubVault\'s ability to run its own LOCAL proposals.'}
           </p>
         </div>
       )}
@@ -796,7 +796,7 @@ function RecipientsBlock({
                       onChange={(e) => updateRow(index, { address: e.target.value })}
                       className="flex-1 min-w-0 bg-safe-gray border border-safe-border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:border-safe-green"
                     >
-                      <option value="">Select subaccount…</option>
+                      <option value="">Select SubVault…</option>
                       {children.map((c) => (
                         <option key={c.address} value={c.address}>
                           {c.address.slice(0, 12)}…{c.address.slice(-6)}
@@ -856,7 +856,7 @@ function RecipientsBlock({
         <div className="space-y-2">
           {children.length > 0 && (
             <div className="rounded-lg border border-safe-border bg-safe-dark/20 px-3 py-2 text-xs space-y-1">
-              <p className="text-safe-text">Indexed subaccounts (click to append):</p>
+              <p className="text-safe-text">Indexed SubVaults (click to append):</p>
               <ul className="space-y-0.5">
                 {children.map((c) => (
                   <li key={c.address}>

--- a/ui/components/TestnetFundButton.tsx
+++ b/ui/components/TestnetFundButton.tsx
@@ -87,7 +87,7 @@ export default function TestnetFundButton({ address, network, explorerUrl }: Tes
       <button
         onClick={handleFund}
         disabled={status === 'loading'}
-        title={network === 'testnet' ? 'Fund this account via lightnet account manager' : 'Open Mina faucet'}
+        title={network === 'testnet' ? 'Fund this Vault via lightnet manager' : 'Open Mina faucet'}
         className={`flex items-center gap-1.5 text-xs font-medium rounded-lg px-3 py-2 transition-all ${
           status === 'loading'
             ? 'bg-safe-gray border border-safe-border text-safe-text opacity-60 cursor-wait'

--- a/ui/components/TransactionCard.tsx
+++ b/ui/components/TransactionCard.tsx
@@ -56,9 +56,9 @@ export default function TransactionCard({
       : 'Invalidates another proposal'
     : isRemote
       ? proposal.childAccount
-        ? `Executes on subaccount ${truncateAddress(proposal.childAccount)}`
-        : 'Executes on subaccount'
-      : 'Executes on this account';
+        ? `Executes on SubVault ${truncateAddress(proposal.childAccount)}`
+        : 'Executes on SubVault'
+      : 'Executes on this Vault';
 
   return (
     <Link href={`/transactions/${proposal.proposalHash}`}>

--- a/ui/hooks/useContractTxLock.ts
+++ b/ui/hooks/useContractTxLock.ts
@@ -65,12 +65,22 @@ export function useContractTxLock(
     // never auto-cleared from localStorage today, so honoring them as a lock
     // would leave the parent permanently blocked even after the child is
     // finalized.
-    const myPending = pendingTxs.find(
-      (pt) =>
+    //
+    // Additionally: a localStorage entry whose matching proposal has already
+    // moved past `pending` (executed / invalidated / expired) is stale —
+    // useTransactions cleans these up on indexer ticks, but on a fresh
+    // navigation that cleanup may not have run yet. Don't lock on them.
+    const indexedByHash = new Map(proposals.map((p) => [p.proposalHash, p]));
+    const myPending = pendingTxs.find((pt) => {
+      const isLockable =
         (pt.kind === 'create' && !pt.childAccount) ||
         pt.kind === 'approve' ||
-        pt.kind === 'execute',
-    );
+        pt.kind === 'execute';
+      if (!isLockable) return false;
+      const matched = indexedByHash.get(pt.proposalHash);
+      if (matched && matched.status !== 'pending') return false;
+      return true;
+    });
     if (myPending) {
       return {
         locked: true,

--- a/ui/hooks/useContractTxLock.ts
+++ b/ui/hooks/useContractTxLock.ts
@@ -60,9 +60,16 @@ export function useContractTxLock(
     // (1) Anything we ourselves submitted that hasn't reconciled yet. We
     // ignore kind='deploy' here — those mutate the *new* contract's state,
     // not the parent's stores, so they don't conflict with subsequent
-    // submissions on this contract.
+    // submissions on this contract. We also ignore kind='create' entries
+    // tagged with `childAccount` (CREATE_CHILD wizard records): those are
+    // never auto-cleared from localStorage today, so honoring them as a lock
+    // would leave the parent permanently blocked even after the child is
+    // finalized.
     const myPending = pendingTxs.find(
-      (pt) => pt.kind === 'create' || pt.kind === 'approve' || pt.kind === 'execute',
+      (pt) =>
+        (pt.kind === 'create' && !pt.childAccount) ||
+        pt.kind === 'approve' ||
+        pt.kind === 'execute',
     );
     if (myPending) {
       return {

--- a/ui/hooks/useContractTxLock.ts
+++ b/ui/hooks/useContractTxLock.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { Proposal } from '@/lib/types';
+import {
+  PENDING_TXS_CHANGED,
+  getPendingTxsForContract,
+  type PendingTx,
+} from '@/lib/storage';
+
+export interface ContractTxLock {
+  /** True when a previously-broadcast tx targeting this contract is still
+   *  waiting on indexer confirmation — submitting another now would build
+   *  Merkle witnesses against stale state and fail on-chain. */
+  locked: boolean;
+  /** Plain-language reason shown in the disabled banner. */
+  reason: string | null;
+  /** Tx hash the user is waiting on, if known (own pending or server-side
+   *  cross-signer signal). */
+  txHash: string | null;
+}
+
+const NOT_LOCKED: ContractTxLock = { locked: false, reason: null, txHash: null };
+
+/** Returns whether the active contract has *any* tx waiting on indexer
+ *  confirmation — by any signer — that would invalidate `rebuildStoresFromBackend`
+ *  for the next submission. Three signals feed into this:
+ *
+ *  1. **Own pending** (localStorage): create/approve/execute entries we wrote
+ *     after broadcasting. Visible only to the originating tab/wallet.
+ *  2. **Cross-signer approve in flight** (server): any indexed proposal whose
+ *     `lastApproveTxHash` is set with no error and the proposal still pending.
+ *     This is set by `recordSubmission` from any signer.
+ *  3. **Cross-signer execute in flight** (server): same shape with
+ *     `lastExecuteTxHash`. */
+export function useContractTxLock(
+  contractAddress: string | null,
+  proposals: ReadonlyArray<Proposal>,
+): ContractTxLock {
+  const [pendingTxs, setPendingTxs] = useState<PendingTx[]>([]);
+
+  useEffect(() => {
+    if (!contractAddress) {
+      setPendingTxs([]);
+      return;
+    }
+    const reload = () => setPendingTxs(getPendingTxsForContract(contractAddress));
+    reload();
+    window.addEventListener(PENDING_TXS_CHANGED, reload);
+    window.addEventListener('storage', reload);
+    return () => {
+      window.removeEventListener(PENDING_TXS_CHANGED, reload);
+      window.removeEventListener('storage', reload);
+    };
+  }, [contractAddress]);
+
+  return useMemo<ContractTxLock>(() => {
+    if (!contractAddress) return NOT_LOCKED;
+
+    // (1) Anything we ourselves submitted that hasn't reconciled yet. We
+    // ignore kind='deploy' here — those mutate the *new* contract's state,
+    // not the parent's stores, so they don't conflict with subsequent
+    // submissions on this contract.
+    const myPending = pendingTxs.find(
+      (pt) => pt.kind === 'create' || pt.kind === 'approve' || pt.kind === 'execute',
+    );
+    if (myPending) {
+      return {
+        locked: true,
+        reason: 'Your previous transaction is awaiting indexer confirmation.',
+        txHash: myPending.txHash || null,
+      };
+    }
+
+    // (2)/(3) Cross-signer signals. These are visible to every wallet via
+    // the Proposal row served by the backend.
+    for (const p of proposals) {
+      if (p.status !== 'pending') continue;
+      if (p.lastApproveTxHash && !p.lastApproveError) {
+        return {
+          locked: true,
+          reason: 'Another signer’s approve is awaiting indexer confirmation.',
+          txHash: p.lastApproveTxHash,
+        };
+      }
+      if (p.lastExecuteTxHash && !p.lastExecuteError) {
+        return {
+          locked: true,
+          reason: 'Another signer’s execute is awaiting indexer confirmation.',
+          txHash: p.lastExecuteTxHash,
+        };
+      }
+    }
+
+    return NOT_LOCKED;
+  }, [contractAddress, pendingTxs, proposals]);
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -108,7 +108,7 @@ export async function fetchBalance(address: string): Promise<string | null> {
  *  + child lifecycle txs) — but the shape is always `<phrase> submitted: <hash>`. */
 export function extractTxHash(message: string | null): string | null {
   if (!message) return null;
-  const match = message.match(/(?:Transaction|Approval|Deploy|Subaccount action)\s+submitted:\s*(\S+)/);
+  const match = message.match(/(?:Transaction|Approval|Deploy|SubVault action)\s+submitted:\s*(\S+)/);
   return match ? match[1] : null;
 }
 

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -1208,7 +1208,7 @@ const workerApi = {
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn, [childKey]);
     if (!txHash) return null;
-    return `Subaccount deployed: ${txHash}`;
+    return `SubVault deployed: ${txHash}`;
   },
 
   /**
@@ -1307,7 +1307,7 @@ const workerApi = {
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn, [], childMemo);
     if (!txHash) return null;
-    return `Subaccount action submitted: ${txHash}`;
+    return `SubVault action submitted: ${txHash}`;
   },
 
   /**

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -704,6 +704,7 @@ const workerApi = {
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const deployHash = await submitTx(tx, sendFn, signFeePayerFn, [zkAppKey]);
     console.log('[MultisigWorker] deploy tx result:', deployHash);
+    if (!deployHash) return null;
     return `Transaction submitted: ${deployHash}`;
   },
 
@@ -759,6 +760,7 @@ const workerApi = {
 
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn, [zkAppKey]);
+    if (!txHash) return null;
     return `Transaction submitted: ${txHash}`;
   },
 
@@ -812,6 +814,7 @@ const workerApi = {
     progressFn(testPrivateKey ? 'Signing and sending transaction...' : 'Submitting transaction...');
     const txHash = await submitTx(tx, sendFn, signFeePayerFn);
     console.log('[MultisigWorker] setup tx result:', txHash);
+    if (!txHash) return null;
     return `Transaction submitted: ${txHash}`;
   },
 

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -150,11 +150,11 @@ export const TX_TYPE_LABELS: Record<TxType, string> = {
   removeOwner: 'Remove Owner',
   changeThreshold: 'Change Threshold',
   setDelegate: 'Set Delegate',
-  createChild: 'Create Subaccount',
-  allocateChild: 'Allocate to Subaccounts',
-  reclaimChild: 'Reclaim from Subaccount',
-  destroyChild: 'Destroy Subaccount',
-  enableChildMultiSig: 'Toggle Subaccount Multi-sig',
+  createChild: 'Create SubVault',
+  allocateChild: 'Allocate to SubVaults',
+  reclaimChild: 'Reclaim from SubVault',
+  destroyChild: 'Destroy SubVault',
+  enableChildMultiSig: 'Toggle SubVault Multi-sig',
 };
 
 export type TxTypeOption = { value: TxType; label: string; icon: string };
@@ -170,11 +170,11 @@ export const LOCAL_TX_TYPES: TxTypeOption[] = [
 
 /** Subaccount-management actions — only shown on root (parent) account detail pages. */
 export const CHILD_TX_TYPES: TxTypeOption[] = [
-  { value: 'createChild', label: 'Create Subaccount', icon: 'plus-circle' },
-  { value: 'allocateChild', label: 'Allocate to Subaccounts', icon: 'share' },
-  { value: 'reclaimChild', label: 'Reclaim from Subaccount', icon: 'arrow-down' },
-  { value: 'destroyChild', label: 'Destroy Subaccount', icon: 'trash' },
-  { value: 'enableChildMultiSig', label: 'Toggle Subaccount Multi-sig', icon: 'toggle' },
+  { value: 'createChild', label: 'Create SubVault', icon: 'plus-circle' },
+  { value: 'allocateChild', label: 'Allocate to SubVaults', icon: 'share' },
+  { value: 'reclaimChild', label: 'Reclaim from SubVault', icon: 'arrow-down' },
+  { value: 'destroyChild', label: 'Destroy SubVault', icon: 'trash' },
+  { value: 'enableChildMultiSig', label: 'Toggle SubVault Multi-sig', icon: 'toggle' },
 ];
 
 /** Truncates long addresses for compact UI chips and labels. */


### PR DESCRIPTION
  - **Per-row recipient input.** `ProposalForm` now defaults to one address+amount input row per recipient with a "+ Add recipient" button. A toggle switches to the existing bulk
  textarea mode (same shared state — no data loss when switching). Amounts past 9 decimals are truncated to nanomina with an inline amber warning showing what will actually be
  sent. Applies to both transfer and allocateChild.
  - **Subaccount creation prefilled from parent.** The `/accounts/new?parent=…` wizard now seeds the owners list and threshold from the parent guard's current owners and
  threshold, so subaccounts inherit the parent's governance by default. Editable before submit; once edited, indexer ticks won't clobber.
  - **Per-contract in-flight tx lock.** New `useContractTxLock` hook gates Submit / Approve / Execute / Delete / Finalize while any tx is awaiting indexer confirmation on the
  active contract — own-pending via localStorage and cross-signer via `Proposal.lastApproveTxHash` / `lastExecuteTxHash`. Without this, back-to-back txs can hit
  `rebuildStoresFromBackend` before the previous event is indexed and broadcast invalid Merkle witnesses.