### PR TITLE
Detect dropped txs via mempool polling to prevent permanent signer lock

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -14,6 +14,7 @@ import {
   fetchLatestBlockHeightFromArchive,
   fetchOnChainState,
   fetchVerificationKeyHash,
+  fetchMempoolHashes,
   fetchZkappTxStatus,
   type DiscoveryCandidate,
   type ChainEvent,
@@ -21,6 +22,11 @@ import {
 } from './mina-client.js';
 
 const REORG_DETECTION_WINDOW = 290;
+
+/** Grace period before treating a tx absent from both bestChain and mempool as
+ *  dropped. Covers the brief window between a tx leaving the mempool and its
+ *  block appearing in bestChain (~2 blocks / 6 min on mainnet). */
+const DROPPED_TX_GRACE_MS = 20 * 60 * 1000;
 
 const EMPTY_PUBLIC_KEY = PublicKey.empty().toBase58();
 
@@ -1137,9 +1143,21 @@ export class MinaGuardIndexer {
         lastApproveError: true,
         lastExecuteTxHash: true,
         lastExecuteError: true,
+        updatedAt: true,
         executions: { select: { blockHeight: true }, take: 1 },
       },
     });
+
+    const now = Date.now();
+    const submissionAgeMs = (p: typeof proposals[number]) =>
+      now - p.updatedAt.getTime();
+
+    const needsMempoolCheck = proposals.some(
+      (p) => submissionAgeMs(p) > DROPPED_TX_GRACE_MS,
+    );
+    const mempoolHashes = needsMempoolCheck
+      ? await fetchMempoolHashes(this.config)
+      : null;
 
     for (const proposal of proposals) {
       const alreadyExecuted = proposal.executions.length > 0;
@@ -1150,6 +1168,16 @@ export class MinaGuardIndexer {
             where: { id: proposal.id },
             data: { lastExecuteError: result.reason ?? 'Execution transaction failed on-chain' },
           });
+        } else if (
+          result.status === 'pending' &&
+          submissionAgeMs(proposal) > DROPPED_TX_GRACE_MS &&
+          mempoolHashes !== null &&
+          !mempoolHashes.has(proposal.lastExecuteTxHash)
+        ) {
+          await prisma.proposal.update({
+            where: { id: proposal.id },
+            data: { lastExecuteError: 'Transaction was dropped from the mempool' },
+          });
         }
       }
       if (proposal.lastApproveTxHash && !proposal.lastApproveError) {
@@ -1158,6 +1186,16 @@ export class MinaGuardIndexer {
           await prisma.proposal.update({
             where: { id: proposal.id },
             data: { lastApproveError: result.reason ?? 'Approval transaction failed on-chain' },
+          });
+        } else if (
+          result.status === 'pending' &&
+          submissionAgeMs(proposal) > DROPPED_TX_GRACE_MS &&
+          mempoolHashes !== null &&
+          !mempoolHashes.has(proposal.lastApproveTxHash)
+        ) {
+          await prisma.proposal.update({
+            where: { id: proposal.id },
+            data: { lastApproveError: 'Transaction was dropped from the mempool' },
           });
         }
       }

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -1174,6 +1174,7 @@ export class MinaGuardIndexer {
           mempoolHashes !== null &&
           !mempoolHashes.has(proposal.lastExecuteTxHash)
         ) {
+          console.warn('[indexer] execute tx dropped from mempool, proposal=%d tx=%s', proposal.id, proposal.lastExecuteTxHash);
           await prisma.proposal.update({
             where: { id: proposal.id },
             data: { lastExecuteError: 'Transaction was dropped from the mempool' },
@@ -1193,6 +1194,7 @@ export class MinaGuardIndexer {
           mempoolHashes !== null &&
           !mempoolHashes.has(proposal.lastApproveTxHash)
         ) {
+          console.warn('[indexer] approve tx dropped from mempool, proposal=%d tx=%s', proposal.id, proposal.lastApproveTxHash);
           await prisma.proposal.update({
             where: { id: proposal.id },
             data: { lastApproveError: 'Transaction was dropped from the mempool' },

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -1169,6 +1169,10 @@ export class MinaGuardIndexer {
             data: { lastExecuteError: result.reason ?? 'Execution transaction failed on-chain' },
           });
         } else if (
+          // Only mark dropped when BOTH lookups positively succeeded: a genuine
+          // 'pending' (not 'unknown' → bestChain lookup failed) AND a non-null
+          // mempool set. Either lookup failing leaves the tx untouched so a
+          // transient error can't misclassify an included tx as dropped.
           result.status === 'pending' &&
           submissionAgeMs(proposal) > DROPPED_TX_GRACE_MS &&
           mempoolHashes !== null &&
@@ -1189,6 +1193,9 @@ export class MinaGuardIndexer {
             data: { lastApproveError: result.reason ?? 'Approval transaction failed on-chain' },
           });
         } else if (
+          // See execute branch above: both lookups must positively succeed
+          // ('pending' not 'unknown', and a non-null mempool set) before we
+          // treat the tx as dropped.
           result.status === 'pending' &&
           submissionAgeMs(proposal) > DROPPED_TX_GRACE_MS &&
           mempoolHashes !== null &&

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -359,11 +359,19 @@ const TX_STATUS_SCAN_BLOCKS = 20;
  *
  *  Uses the daemon rather than the archive because only the daemon's
  *  `ZkappCommandResult.failureReason: [{index, failures: [String]}]` exposes
- *  structured failure reasons; archive-node-api has no per-hash lookup. */
+ *  structured failure reasons; archive-node-api has no per-hash lookup.
+ *
+ *  `'unknown'` means the lookup itself failed (network error, GraphQL error,
+ *  upstream 5xx) on both endpoints — the tx's on-chain state is undetermined,
+ *  NOT confirmed-absent. Callers must distinguish this from `'pending'`: a
+ *  positive `'pending'` means we scanned bestChain and the tx isn't there yet,
+ *  whereas `'unknown'` means we couldn't scan at all. Conflating the two lets a
+ *  tx that was actually included get misclassified as dropped when the (heavier)
+ *  bestChain query fails but a sibling mempool check happens to succeed. */
 export async function fetchZkappTxStatus(
   config: BackendConfig,
   txHash: string
-): Promise<{ status: 'pending' | 'included' | 'failed'; reason?: string }> {
+): Promise<{ status: 'pending' | 'included' | 'failed' | 'unknown'; reason?: string }> {
   const query = `query TxStatus($maxLength: Int!) {
     bestChain(maxLength: $maxLength) {
       transactions {
@@ -403,8 +411,10 @@ export async function fetchZkappTxStatus(
     }
     return { status: 'pending' };
   } catch (err) {
+    // Lookup failed on both primary and fallback endpoints; report 'unknown' so
+    // callers don't treat an undetermined tx as confirmed-absent (see doc above).
     console.warn('[mina-client] fetchZkappTxStatus failed', txHash, err);
-    return { status: 'pending' };
+    return { status: 'unknown' };
   }
 }
 

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -408,6 +408,23 @@ export async function fetchZkappTxStatus(
   }
 }
 
+/** Fetches all zkApp tx hashes currently in the daemon's mempool. Returns null
+ *  on network failure so callers can fall back conservatively. */
+export async function fetchMempoolHashes(
+  config: BackendConfig,
+): Promise<Set<string> | null> {
+  const query = `{ pooledZkappCommands { hash } }`;
+  try {
+    const data = await graphqlRequest<{
+      pooledZkappCommands?: Array<{ hash: string }>;
+    }>(query, config.minaEndpoint, config.minaFallbackEndpoint);
+    return new Set((data.pooledZkappCommands ?? []).map((c) => c.hash));
+  } catch (err) {
+    console.warn('[mina-client] fetchMempoolHashes failed', err);
+    return null;
+  }
+}
+
 /** Fetches decoded MinaGuard events for a contract within a block range. */
 export async function fetchDecodedContractEvents(
   address: string,

--- a/backend/src/tests/indexer-dropped-tx.test.ts
+++ b/backend/src/tests/indexer-dropped-tx.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PrivateKey } from 'o1js';
+import type { BackendConfig } from '../config.js';
+import { prisma } from '../db.js';
+import { MinaGuardIndexer } from '../indexer.js';
+import * as minaClient from '../mina-client.js';
+
+const config = {
+  minaEndpoint: 'http://stub',
+  minaFallbackEndpoint: null,
+  archiveEndpoint: 'http://stub',
+  archiveFallbackEndpoint: null,
+  indexPollIntervalMs: 1000,
+  indexStartHeight: 0,
+  minaguardVkHash: '0',
+  lightnetAccountManager: null,
+  indexerMode: 'full' as const,
+  discoveryBackend: 'archive' as const,
+} as unknown as BackendConfig;
+
+type TxStatus = Awaited<ReturnType<typeof minaClient.fetchZkappTxStatus>>;
+
+/** Stubs the two mina-client lookups that pollPendingSubmissions consults. */
+function stubLookups(opts: {
+  txStatus: TxStatus;
+  mempool: Set<string> | null;
+}) {
+  mock.module('../mina-client.js', () => ({
+    ...minaClient,
+    fetchZkappTxStatus: async (): Promise<TxStatus> => opts.txStatus,
+    fetchMempoolHashes: async (): Promise<Set<string> | null> => opts.mempool,
+  }));
+}
+
+async function clearAll() {
+  await prisma.proposalExecution.deleteMany();
+  await prisma.proposal.deleteMany();
+  await prisma.contract.deleteMany();
+}
+
+/** Creates a proposal carrying a pending approve/execute tx, backdated past the
+ *  20-minute grace window so pollPendingSubmissions treats it as drop-eligible. */
+async function seedPendingProposal(
+  kind: 'execute' | 'approve',
+  txHash: string,
+): Promise<number> {
+  const contract = await prisma.contract.create({
+    data: { address: PrivateKey.random().toPublicKey().toBase58(), ready: true },
+  });
+  const proposal = await prisma.proposal.create({
+    data: {
+      contractId: contract.id,
+      proposalHash: `hash-${txHash}`,
+      createdAtBlock: 1,
+      ...(kind === 'execute'
+        ? { lastExecuteTxHash: txHash }
+        : { lastApproveTxHash: txHash }),
+    },
+  });
+  // @updatedAt is auto-managed on write, so backdate it with raw SQL to make the
+  // submission look older than DROPPED_TX_GRACE_MS (20 min).
+  await prisma.$executeRawUnsafe(
+    `UPDATE "Proposal" SET "updatedAt" = NOW() - INTERVAL '30 minutes' WHERE id = $1`,
+    proposal.id,
+  );
+  return proposal.id;
+}
+
+async function pollOnce() {
+  const indexer = new MinaGuardIndexer(config);
+  // pollPendingSubmissions is private but self-contained (reads this.config +
+  // prisma only), so we drive it directly without the full start() tick.
+  await (indexer as unknown as { pollPendingSubmissions(): Promise<void> }).pollPendingSubmissions();
+}
+
+async function errorOf(id: number): Promise<{ execute: string | null; approve: string | null }> {
+  const p = await prisma.proposal.findUniqueOrThrow({
+    where: { id },
+    select: { lastExecuteError: true, lastApproveError: true },
+  });
+  return { execute: p.lastExecuteError, approve: p.lastApproveError };
+}
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+afterAll(async () => {
+  await clearAll();
+  await prisma.$disconnect();
+});
+
+describe('pollPendingSubmissions: dropped-tx detection', () => {
+  // Regression: a tx that was actually included leaves the mempool, but if the
+  // (heavy) bestChain lookup fails it returns 'unknown'. That must NOT be
+  // treated as confirmed-absent — otherwise a successful tx gets falsely marked
+  // dropped and the signer lock is released on a transient network blip.
+  test("does not mark dropped when the bestChain lookup fails ('unknown')", async () => {
+    const id = await seedPendingProposal('execute', 'tx-included');
+    // status 'unknown' = lookup failed; mempool succeeds but the tx already left
+    // it (because it was included on-chain).
+    stubLookups({ txStatus: { status: 'unknown' }, mempool: new Set<string>() });
+
+    await pollOnce();
+
+    expect((await errorOf(id)).execute).toBeNull();
+  });
+
+  test("does not mark dropped on the approve path when the lookup fails ('unknown')", async () => {
+    const id = await seedPendingProposal('approve', 'tx-approve-included');
+    stubLookups({ txStatus: { status: 'unknown' }, mempool: new Set<string>() });
+
+    await pollOnce();
+
+    expect((await errorOf(id)).approve).toBeNull();
+  });
+
+  // Positive control: a genuinely dropped tx — bestChain positively reports
+  // 'pending' (scanned, not there) and it's absent from the mempool — must still
+  // be detected so the signer isn't locked out forever.
+  test("marks dropped when bestChain is positively 'pending' and tx is absent from mempool", async () => {
+    const id = await seedPendingProposal('execute', 'tx-dropped');
+    stubLookups({ txStatus: { status: 'pending' }, mempool: new Set<string>() });
+
+    await pollOnce();
+
+    expect((await errorOf(id)).execute).toBe('Transaction was dropped from the mempool');
+  });
+
+  // Fail-safe on the mempool side: if the mempool fetch itself fails (null), we
+  // also abstain even when bestChain says 'pending'.
+  test('does not mark dropped when the mempool fetch fails (null)', async () => {
+    const id = await seedPendingProposal('execute', 'tx-mempool-down');
+    stubLookups({ txStatus: { status: 'pending' }, mempool: null });
+
+    await pollOnce();
+
+    expect((await errorOf(id)).execute).toBeNull();
+  });
+});

--- a/backend/src/tests/mina-client-tx-status.test.ts
+++ b/backend/src/tests/mina-client-tx-status.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import type { BackendConfig } from '../config.js';
+import { fetchZkappTxStatus } from '../mina-client.js';
+
+const config = {
+  minaEndpoint: 'http://stub',
+  minaFallbackEndpoint: null,
+} as unknown as BackendConfig;
+
+/** Minimal Response-shaped stub for the global fetch mock. */
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  spyOn(globalThis, 'fetch').mockRestore();
+});
+
+describe('fetchZkappTxStatus: distinguishes lookup failure from confirmed-absent', () => {
+  // Regression: a failed lookup must report 'unknown', NOT 'pending'. Masking it
+  // as 'pending' let the dropped-tx check treat an undetermined (possibly
+  // included) tx as confirmed-absent from the chain.
+  test("returns 'unknown' when the request rejects (network error)", async () => {
+    spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await fetchZkappTxStatus(config, 'tx-1');
+    expect(result.status).toBe('unknown');
+  });
+
+  test("returns 'unknown' on an upstream 5xx", async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(null, 502));
+    const result = await fetchZkappTxStatus(config, 'tx-1');
+    expect(result.status).toBe('unknown');
+  });
+
+  test("returns 'unknown' on a GraphQL error payload", async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ errors: [{ message: 'boom' }] }),
+    );
+    const result = await fetchZkappTxStatus(config, 'tx-1');
+    expect(result.status).toBe('unknown');
+  });
+
+  // Control: a successful scan that doesn't contain the tx is a *positive*
+  // 'pending' — this is what must stay distinct from 'unknown' above.
+  test("returns 'pending' when the scan succeeds but the tx is absent", async () => {
+    spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ data: { bestChain: [] } }),
+    );
+    const result = await fetchZkappTxStatus(config, 'tx-1');
+    expect(result.status).toBe('pending');
+  });
+});

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -118,14 +118,14 @@ export function extractTxHash(message: string | null): string | null {
  *  have no Proposal row to attach the failure to server-side. */
 export async function fetchTxStatus(
   txHash: string,
-): Promise<{ status: 'pending' | 'included' | 'failed'; reason?: string } | null> {
+): Promise<{ status: 'pending' | 'included' | 'failed' | 'unknown'; reason?: string } | null> {
   try {
     const response = await fetch(
       `${API_BASE}/api/tx-status?hash=${encodeURIComponent(txHash)}`,
       { cache: 'no-store' },
     );
     if (!response.ok) return null;
-    return (await response.json()) as { status: 'pending' | 'included' | 'failed'; reason?: string };
+    return (await response.json()) as { status: 'pending' | 'included' | 'failed' | 'unknown'; reason?: string };
   } catch (err) {
     console.warn('[api] fetchTxStatus failed', err);
     return null;


### PR DESCRIPTION
## Problem

When a signer broadcasts an approve/execute tx, the backend records the txHash and polls `bestChain` to detect failures. Other signers are locked out until it resolves. If the tx gets silently dropped from the mempool, `bestChain` never sees it, so the lock persists indefinitely.

## Fix

Adds a mempool check: if a tx has been pending >20 minutes and isn't in `pooledZkappCommands` either, mark it as dropped — clearing the lock so signers can retry. The mempool is fetched once per tick and only when needed.

## Fail-safe: don't mark dropped on a lookup failure

A dropped-tx decision must not fire on a transient network blip. Both lookups now have to *positively* succeed before a tx is marked dropped:

- `fetchMempoolHashes` returns `null` on failure → check skipped.
- `fetchZkappTxStatus` previously masked all lookup errors (network / GraphQL / upstream 5xx) as `'pending'`, making a failed `bestChain` scan indistinguishable from a genuine not-yet-on-chain result. Since the `bestChain` scan is the heavier query, it's the more likely to fail — and if the sibling mempool check happened to succeed, a tx that was actually **included** could be misclassified as dropped, releasing the lock and surfacing a spurious error. It now returns a distinct `'unknown'` status on failure, and the drop decision only proceeds on a positive `'pending'`.

## Tests

Regression coverage for both halves of the decision:

- **Producer** (`mina-client-tx-status.test.ts`): `fetchZkappTxStatus` returns `'unknown'` on reject / 5xx / GraphQL-error, and a positive `'pending'` when the scan succeeds but the tx is absent. (3 of 4 fail against the pre-fix code.)
- **Consumer** (`indexer-dropped-tx.test.ts`): `pollPendingSubmissions` does not mark dropped when the status is `'unknown'` (execute and approve paths) or when the mempool fetch is `null`, and still marks dropped when `bestChain` is positively `'pending'` and the tx is absent from the mempool.

## Behaviour notes

- On network failure the check is skipped (fail-safe).
- The `/api/tx-status` response can now be `'unknown'`; the UI treats it the same as `'pending'` (no-op), so behaviour there is unchanged.