### PR TITLE
Bind all service ports to localhost only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,9 +21,8 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: minaguard
-          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
-          - 5433:5432
+          - 127.0.0.1:5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -43,9 +42,9 @@ jobs:
           # up with settlementWaitMs/expirySlotOffset in network-config.ts.
           SLOT_TIME: '3000'
         ports:
-          - 8080:8080
-          - 8181:8181
-          - 8282:8282
+          - 127.0.0.1:8080:8080
+          - 127.0.0.1:8181:8181
+          - 127.0.0.1:8282:8282
         volumes:
           - /tmp:/root/logs
 
@@ -92,13 +91,13 @@ jobs:
         run: bunx prisma db push
         working-directory: backend
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/minaguard
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
 
       - name: Start backend
         run: bun run --filter backend dev &
         env:
           PORT: '4000'
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/minaguard
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/minaguard
           MINA_ENDPOINT: http://localhost:8080/graphql
           ARCHIVE_ENDPOINT: http://localhost:8282
           LIGHTNET_ACCOUNT_MANAGER: http://localhost:8181


### PR DESCRIPTION
Service container ports in the e2e workflow were bound to all interfaces (0.0.0.0) on the self-hosted runner. This caused intermittent Prisma connection/auth failures (500 errors) due to external interference on the exposed postgres port.

- Bind all service ports to 127.0.0.1 only (postgres, mina graphql, account manager, archive)
- Remove POSTGRES_HOST_AUTH_METHOD: trust (no longer needed with localhost-only binding)
- Revert to standard port 5432