### PR TITLE
Changed o1js fork commitment names and types

### DIFF
--- a/offline-cli/src/build-tx.ts
+++ b/offline-cli/src/build-tx.ts
@@ -547,8 +547,7 @@ function injectAccounts(bundle: BundleBase) {
 function signFeePayer(txJson: string, privateKey: string, network: 'testnet' | 'mainnet'): string {
   const client = new Client({ network });
   const parsed = typeof txJson === 'string' ? JSON.parse(txJson) : txJson;
-  const wrapped = { feePayer: parsed.feePayer, zkappCommand: parsed };
-  const { fullCommitment } = client.getZkappCommandCommitmentsNoCheck(wrapped);
+  const { fullCommitment } = client.getZkappCommandCommitmentsFromJSON(parsed);
   const signed = client.signFields([BigInt(fullCommitment)], privateKey);
   parsed.feePayer.authorization = signed.signature;
 
@@ -572,8 +571,7 @@ function signChildAccount(txJson: string, childKey: InstanceType<typeof PrivateK
   const parsed = JSON.parse(txJson);
   const childPk = childKey.toPublicKey().toBase58();
   const client = new Client({ network });
-  const wrapped = { feePayer: parsed.feePayer, zkappCommand: parsed };
-  const { commitment, fullCommitment } = client.getZkappCommandCommitmentsNoCheck(wrapped);
+  const { commitment, fullCommitment } = client.getZkappCommandCommitmentsFromJSON(parsed);
   let applied = false;
   for (const update of parsed.accountUpdates ?? []) {
     if (

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -582,9 +582,7 @@ async function broadcastWithLedgerSig(
   signFeePayerFn: SignFeePayerFn
 ): Promise<string | null> {
   const parsed = JSON.parse(txJson);
-  // mina-signer expects { feePayer, zkappCommand } wrapper; parsed is the raw tx JSON
-  const wrapped = { feePayer: parsed.feePayer, zkappCommand: parsed };
-  const { fullCommitment } = signerClient.getZkappCommandCommitmentsNoCheck(wrapped);
+  const { fullCommitment } = signerClient.getZkappCommandCommitmentsFromJSON(parsed);
   const sig = await signFeePayerFn(fullCommitment.toString());
   if (!sig) return null;
 

--- a/ui/types/mina-signer.d.ts
+++ b/ui/types/mina-signer.d.ts
@@ -4,9 +4,6 @@ declare module 'mina-signer' {
   export default class Client {
     constructor(options: { network: 'mainnet' | 'testnet' | 'devnet' });
     genKeys(): { privateKey: string; publicKey: string };
-    getZkappCommandCommitmentsNoCheck(command: {
-      feePayer: unknown;
-      zkappCommand: unknown;
-    }): { fullCommitment: bigint };
+    getZkappCommandCommitmentsFromJSON(zkappCommand: unknown): { commitment: bigint; fullCommitment: bigint };
   }
 }


### PR DESCRIPTION
Changed the zkApp getter from `NoCheck` to `FromJSON`, to match the updated o1js fork about to be a PR