### PR TITLE
Fix: offline-cli change to signZkappCommand & memo

### DIFF
--- a/offline-cli/src/build-tx.ts
+++ b/offline-cli/src/build-tx.ts
@@ -123,6 +123,7 @@ export interface OfflineProposeBundle extends BundleBase {
     childMultiSigEnable?: boolean;
     createChildConfigHash?: string;
     expirySlot?: number;
+    memo?: string;
     childPrivateKey?: string;
     childOwners?: string[];
     childThreshold?: number;
@@ -544,47 +545,64 @@ function injectAccounts(bundle: BundleBase) {
 // Fee payer signing with mina-signer
 // ---------------------------------------------------------------------------
 
-function signFeePayer(txJson: string, privateKey: string, network: 'testnet' | 'mainnet'): string {
-  const client = new Client({ network });
-  const parsed = typeof txJson === 'string' ? JSON.parse(txJson) : txJson;
-  const { fullCommitment } = client.getZkappCommandCommitmentsFromJSON(parsed);
-  const signed = client.signFields([BigInt(fullCommitment)], privateKey);
-  parsed.feePayer.authorization = signed.signature;
-
-  // Also sign any account updates owned by the fee payer that require a signature
-  const feePayerPk = parsed.feePayer.body.publicKey;
-  for (const update of parsed.accountUpdates ?? []) {
-    if (
-      update.body?.publicKey === feePayerPk &&
-      update.body?.authorizationKind?.isSigned === true &&
-      update.body?.useFullCommitment === true
-    ) {
-      update.authorization = { signature: signed.signature };
-    }
-  }
-
-  return JSON.stringify(parsed);
+// Builds the flattened { feePayer, zkappCommand } wrapper that the public
+// Client.signZkappCommand expects, from a tx.toJSON() Json.ZkappCommand.
+// The wrapper re-derives the memo from PLAINTEXT (Memo.toBase58(Memo.fromString(memo))),
+// so we decode parsed.memo back to plaintext to avoid double-encoding — the round-trip is
+// byte-identical, so the resulting commitment matches what o1js built.
+function toSignWrapper(parsed: any) {
+  return {
+    feePayer: {
+      feePayer: parsed.feePayer.body.publicKey,
+      fee: parsed.feePayer.body.fee,
+      nonce: parsed.feePayer.body.nonce,
+      validUntil: parsed.feePayer.body.validUntil,
+      memo: decodeTxMemo(parsed.memo),
+    },
+    zkappCommand: parsed,
+  };
 }
 
-/** Signs a child zkApp's deploy account update using its private key. */
-function signChildAccount(txJson: string, childKey: InstanceType<typeof PrivateKey>, network: 'testnet' | 'mainnet'): string {
+// Signs the fee payer (and any signed account updates owned by the fee payer) using the
+// network-aware public signZkappCommand. Unlike the old signFields path — which is hardcoded
+// to the 'devnet' domain — this signs with the Client's configured network, so signatures
+// verify on the Mina node for both testnet and mainnet.
+export function signFeePayer(txJson: string, privateKey: string, network: 'testnet' | 'mainnet'): string {
+  const client = new Client({ network });
+  const parsed = typeof txJson === 'string' ? JSON.parse(txJson) : txJson;
+  const signed = client.signZkappCommand(toSignWrapper(parsed), privateKey);
+  return JSON.stringify(signed.data.zkappCommand);
+}
+
+/**
+ * Signs a child zkApp's deploy account update using its private key, chained after
+ * signFeePayer.
+ *
+ * The public signZkappCommand rebuilds feePayer.authorization to '' and only re-signs it when
+ * the signing key matches the fee payer (mina-signer.ts). Signing with the child key would
+ * therefore WIPE the fee-payer authorization that signFeePayer just produced. To avoid that,
+ * we run signZkappCommand to compute the child's signature(s), then graft only the child
+ * account updates' authorizations back onto the original `parsed` (which still carries the
+ * fee-payer authorization). signZkappCommand signs every isSigned update owned by the child
+ * key, so all child-owned updates are covered.
+ */
+export function signChildAccount(txJson: string, childKey: InstanceType<typeof PrivateKey>, network: 'testnet' | 'mainnet'): string {
+  const client = new Client({ network });
   const parsed = JSON.parse(txJson);
   const childPk = childKey.toPublicKey().toBase58();
-  const client = new Client({ network });
-  const { commitment, fullCommitment } = client.getZkappCommandCommitmentsFromJSON(parsed);
+  const signed = client.signZkappCommand(toSignWrapper(parsed), childKey.toBase58());
+  const signedUpdates: any[] = signed.data.zkappCommand.accountUpdates ?? [];
+
   let applied = false;
-  for (const update of parsed.accountUpdates ?? []) {
-    if (
-      update.body?.publicKey === childPk &&
-      update.body?.authorizationKind?.isSigned === true
-    ) {
-      const usedCommitment = update.body.useFullCommitment ? fullCommitment : commitment;
-      const signed = client.signFields([BigInt(usedCommitment)], childKey.toBase58());
-      update.authorization = { signature: signed.signature };
+  for (let i = 0; i < (parsed.accountUpdates?.length ?? 0); i++) {
+    const update = parsed.accountUpdates[i];
+    if (update.body?.publicKey === childPk && update.body?.authorizationKind?.isSigned === true) {
+      update.authorization = signedUpdates[i]?.authorization;
       applied = true;
     }
   }
   if (!applied) throw new Error('signChildAccount: no matching deploy account update found');
+
   return JSON.stringify(parsed);
 }
 
@@ -592,14 +610,63 @@ function signChildAccount(txJson: string, childKey: InstanceType<typeof PrivateK
 // Transaction sender helper
 // ---------------------------------------------------------------------------
 
-function txSender(pub: InstanceType<typeof PublicKey>) {
-  return { sender: pub, fee: ZKAPP_TX_FEE };
+function txSender(pub: InstanceType<typeof PublicKey>, memo?: string) {
+  return memo !== undefined
+    ? { sender: pub, fee: ZKAPP_TX_FEE, memo }
+    : { sender: pub, fee: ZKAPP_TX_FEE };
 }
 
 /** Safely serializes tx.toJSON() regardless of whether it returns a string or object. */
 function serializeTx(tx: Awaited<ReturnType<typeof Mina.transaction>>): string {
   const json = tx.toJSON();
   return typeof json === 'string' ? json : JSON.stringify(json);
+}
+
+// ---------------------------------------------------------------------------
+// Memo decoding — copied verbatim from contracts/src/memo.ts to keep offline-cli
+// self-contained (mirrors the duplicated NewProposalInput convention above).
+// ---------------------------------------------------------------------------
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58Decode(input: string): Uint8Array {
+  const base = BASE58_ALPHABET.length;
+  const bytes: number[] = [0];
+  for (const char of input) {
+    const idx = BASE58_ALPHABET.indexOf(char);
+    if (idx < 0) throw new Error(`Invalid base58 character: ${char}`);
+    let carry = idx;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * base;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  for (const char of input) {
+    if (char !== '1') break;
+    bytes.push(0);
+  }
+  return new Uint8Array(bytes.reverse());
+}
+
+// Mina memo base58check layout: version (1B) + tag (1B) + length (1B) + content (32B) + checksum (4B)
+// Tag 0x01 = user memo. See MinaProtocol/mina signed_command_memo.ml L49-61.
+export function decodeTxMemo(base58Memo: string): string {
+  const raw = base58Decode(base58Memo);
+  const payload = raw.slice(1, raw.length - 4); // strip version byte + 4-byte base58check checksum
+  if (payload.length !== 34) {
+    throw new Error(`decodeTxMemo: expected 34-byte payload, got ${payload.length}`);
+  }
+  const contentLength = payload[1];
+  if (contentLength > 32) {
+    throw new Error(`decodeTxMemo: invalid content length ${contentLength}`);
+  }
+  const contentBytes = payload.slice(2, 2 + contentLength);
+  return new TextDecoder().decode(contentBytes);
 }
 
 // ---------------------------------------------------------------------------
@@ -689,7 +756,11 @@ export async function handlePropose(
   const hashStr = proposalHash.toString();
   log(`Proposal hash: ${hashStr}`);
 
-  // Sign the proposal hash with mina-signer
+  // Sign the proposal hash with mina-signer.
+  // NOTE: signFields' hardcoded 'devnet' domain is CORRECT here and must stay. This signature
+  // is verified in-circuit via Signature.verify, which always uses the 'devnet' prefix
+  // regardless of network (o1js lib/provable/crypto/signature.ts). Do not make it
+  // network-aware — that would break on-chain proposal verification.
   log('Signing proposal hash...');
   const client = new Client({ network: bundle.minaNetwork });
   const signedFields = client.signFields([BigInt(hashStr)], privateKey);
@@ -718,7 +789,7 @@ export async function handlePropose(
   const contractAddress = PublicKey.fromBase58(bundle.contractAddress);
   const contract = new MinaGuard(contractAddress);
 
-  const tx = await Mina.transaction(txSender(proposer), async () => {
+  const tx = await Mina.transaction(txSender(proposer, input.memo), async () => {
     if (isCreateChild && childKey && childOwnerStore && childPaddedOwners) {
       const childAddress = childKey.toPublicKey();
       const childZkApp = new MinaGuard(childAddress);
@@ -798,7 +869,11 @@ export async function handleApprove(
   const hashStr = proposalHash.toString();
   log(`Proposal hash: ${hashStr}`);
 
-  // Sign the proposal hash
+  // Sign the proposal hash.
+  // NOTE: signFields' hardcoded 'devnet' domain is CORRECT here and must stay. This signature
+  // is verified in-circuit via Signature.verify, which always uses the 'devnet' prefix
+  // regardless of network (o1js lib/provable/crypto/signature.ts). Do not make it
+  // network-aware — that would break on-chain proposal verification.
   log('Signing proposal hash...');
   const client = new Client({ network: bundle.minaNetwork });
   const signedFields = client.signFields([BigInt(hashStr)], privateKey);

--- a/offline-cli/src/build-tx.ts
+++ b/offline-cli/src/build-tx.ts
@@ -164,6 +164,8 @@ interface BundleProposal {
   destination: string | null;
   childAccount: string | null;
   memoHash: string | null;
+  /** Plaintext tx memo (cosmetic, shown on the explorer); rides along from the backend Proposal record. */
+  memo?: string | null;
   receivers: BundleReceiver[];
   [key: string]: unknown;
 }
@@ -1048,7 +1050,8 @@ export async function handleExecute(
     const childZkApp = new MinaGuard(PublicKey.fromBase58(childAddr));
 
     log('Building transaction...');
-    const tx = await Mina.transaction(txSender(executor), async () => {
+    const childMemo = bundle.proposal.memo ?? undefined;
+    const tx = await Mina.transaction(txSender(executor, childMemo), async () => {
       if (txType === 'reclaimChild') {
         const amount = UInt64.from(bundle.proposal.data ?? '0');
         await childZkApp.executeReclaimToParent(
@@ -1107,7 +1110,8 @@ export async function handleExecute(
   log('Building transaction...');
   const contract = new MinaGuard(PublicKey.fromBase58(bundle.contractAddress));
 
-  const tx = await Mina.transaction(txSender(executor), async () => {
+  const proposalMemo = bundle.proposal.memo ?? undefined;
+  const tx = await Mina.transaction(txSender(executor, proposalMemo), async () => {
     if (newAccountCount > 0) {
       AccountUpdate.fundNewAccount(executor, newAccountCount);
     }

--- a/offline-cli/src/tests/offline-cli-e2e.test.ts
+++ b/offline-cli/src/tests/offline-cli-e2e.test.ts
@@ -29,6 +29,7 @@ import {
   MAX_RECEIVERS,
   TxType,
 } from 'contracts';
+import { decodeTxMemo } from '../build-tx.ts';
 
 const CLI_PATH = join(import.meta.dirname, '..', 'index.ts');
 const BINARY_PATH = join(import.meta.dirname, '..', '..', 'dist',
@@ -891,6 +892,11 @@ describe('offline-cli e2e', () => {
       );
       expect(childUpdate).toBeTruthy();
 
+      // Chained signing: signChildAccount must sign the child update WITHOUT clobbering the
+      // fee-payer authorization produced by signFeePayer.
+      expect(output.transaction.feePayer.authorization).toBeTruthy();
+      expect(childUpdate.authorization?.signature).toBeTruthy();
+
       // Execute propose on-chain to advance state for approve/execute
       const childOwnersCommitment = (() => {
         const cs = new OwnerStore();
@@ -933,6 +939,48 @@ describe('offline-cli e2e', () => {
       approvalStore.setCount(ccHash, PROPOSED_MARKER.add(1));
 
       console.log('[e2e] createChild propose OK, hash:', createChildProposalHash);
+    }, 120_000);
+
+    it('propose carries the on-chain tx memo', async () => {
+      // Isolated from the createChild flow above: own child key, own bundle, not fed
+      // downstream — so a non-empty memo (which changes the proposal hash) is harmless here.
+      const proposer = owners[0];
+      const memo = 'pay rent for june';
+      const localChildKey = PrivateKey.random();
+      const bundle = {
+        version: 1,
+        action: 'propose',
+        minaNetwork: 'testnet',
+        contractAddress: zkAppAddress.toBase58(),
+        feePayerAddress: proposer.pub.toBase58(),
+        accounts: accountsSnapshotForCreate(),
+        events: await parentEvents(),
+        input: {
+          txType: 'createChild',
+          nonce: 0,
+          memo,
+          childAccount: localChildKey.toPublicKey().toBase58(),
+          createChildConfigHash: configHash(),
+          childPrivateKey: localChildKey.toBase58(),
+          childOwners: childOwnerAddrs(),
+          childThreshold: 2,
+        },
+        configNonce: 0,
+        networkId: '1',
+      };
+
+      const bundlePath = join(tmpDir, 'propose-memo.json');
+      writeFileSync(bundlePath, JSON.stringify(bundle, null, 2));
+
+      console.log('[e2e] Running CLI: propose with memo (SKIP_PROOFS)...');
+      const result = await runCLI(bundlePath, proposer.key.toBase58(), 600_000, skipEnv);
+      if (result.code !== 0) console.log('[e2e] CLI stderr:', result.stderr, '\nstdout:', result.stdout);
+      expect(result.code).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      // The on-chain tx memo must round-trip back to the user's plaintext memo.
+      expect(output.transaction.memo).toBeTruthy();
+      expect(decodeTxMemo(output.transaction.memo)).toBe(memo);
     }, 120_000);
 
     it('approve createChild', async () => {

--- a/offline-cli/src/tests/offline-cli.test.ts
+++ b/offline-cli/src/tests/offline-cli.test.ts
@@ -26,6 +26,7 @@ import {
   MAX_OWNERS,
   MAX_RECEIVERS,
 } from 'contracts';
+import { signFeePayer, decodeTxMemo } from '../build-tx.ts';
 
 const CLI_PATH = join(import.meta.dirname, '..', 'index.ts');
 
@@ -225,4 +226,73 @@ describe('offline-cli', () => {
     const verified = client.verifyFields(signed);
     expect(verified).toBe(true);
   }, 10_000);
+
+  // -- Network-aware fee-payer signing (signZkappCommand path) --
+
+  describe('signFeePayer network domain', () => {
+    // Builds a realistic tx.toJSON() with a fee payer + one signed account update and a memo,
+    // without compiling any contract — a plain signed send on a LocalBlockchain.
+    async function buildSignedSendTxJson(memo: string): Promise<{ txJson: string; feePayerKey: InstanceType<typeof PrivateKey> }> {
+      const Local = await Mina.LocalBlockchain({ proofsEnabled: false });
+      Mina.setActiveInstance(Local);
+      const sender = Local.testAccounts[0];
+      const receiver = Local.testAccounts[1];
+      const tx = await Mina.transaction({ sender, fee: 1e8, memo }, async () => {
+        const au = AccountUpdate.createSigned(sender);
+        au.send({ to: receiver, amount: UInt64.from(1_000_000) });
+      });
+      const json = tx.toJSON();
+      return { txJson: typeof json === 'string' ? json : JSON.stringify(json), feePayerKey: sender.key };
+    }
+
+    function verifyWrapper(network: 'testnet' | 'mainnet', signedTxJson: string, key: InstanceType<typeof PrivateKey>): boolean {
+      const client = new ClientCtor({ network });
+      const parsed = JSON.parse(signedTxJson);
+      const wrapper = {
+        feePayer: {
+          feePayer: parsed.feePayer.body.publicKey,
+          fee: parsed.feePayer.body.fee,
+          nonce: parsed.feePayer.body.nonce,
+          validUntil: parsed.feePayer.body.validUntil,
+          memo: decodeTxMemo(parsed.memo),
+        },
+        zkappCommand: parsed,
+      };
+      const signature = parsed.feePayer.authorization;
+      return client.verifyZkappCommand({
+        data: { zkappCommand: parsed, feePayer: wrapper.feePayer },
+        publicKey: key.toPublicKey().toBase58(),
+        signature,
+      });
+    }
+
+    let ClientCtor: any;
+    beforeAll(async () => {
+      // @ts-ignore — ESM bundle built by ui/package.json postinstall
+      ClientCtor = (await import('../../../ui/deps/o1js/src/mina-signer/dist/web/index.js')).default;
+    });
+
+    it('mainnet signature verifies under mainnet and FAILS under testnet', async () => {
+      const { txJson, feePayerKey } = await buildSignedSendTxJson('');
+      const signed = signFeePayer(txJson, feePayerKey.toBase58(), 'mainnet');
+      expect(verifyWrapper('mainnet', signed, feePayerKey)).toBe(true);
+      expect(verifyWrapper('testnet', signed, feePayerKey)).toBe(false);
+    }, 20_000);
+
+    it('testnet signature verifies under testnet and FAILS under mainnet', async () => {
+      const { txJson, feePayerKey } = await buildSignedSendTxJson('');
+      const signed = signFeePayer(txJson, feePayerKey.toBase58(), 'testnet');
+      expect(verifyWrapper('testnet', signed, feePayerKey)).toBe(true);
+      expect(verifyWrapper('mainnet', signed, feePayerKey)).toBe(false);
+    }, 20_000);
+
+    it('preserves the memo without double-encoding (empty and non-empty)', async () => {
+      for (const memo of ['', 'hello multisig']) {
+        const { txJson, feePayerKey } = await buildSignedSendTxJson(memo);
+        const signed = signFeePayer(txJson, feePayerKey.toBase58(), 'testnet');
+        expect(JSON.parse(signed).memo).toBe(JSON.parse(txJson).memo);
+        expect(decodeTxMemo(JSON.parse(signed).memo)).toBe(memo);
+      }
+    }, 20_000);
+  });
 });

--- a/offline-cli/src/tests/offline-cli.test.ts
+++ b/offline-cli/src/tests/offline-cli.test.ts
@@ -294,5 +294,16 @@ describe('offline-cli', () => {
         expect(decodeTxMemo(JSON.parse(signed).memo)).toBe(memo);
       }
     }, 20_000);
+
+    // Guards the execute-path memo propagation (build-tx handleExecute passes
+    // bundle.proposal.memo into txSender). buildSignedSendTxJson mirrors the
+    // shape of a local-execute tx (fee payer + a signed update); we assert the
+    // proposal memo survives all the way through signFeePayer onto the tx.
+    it('carries the proposal memo through to the signed execute tx', async () => {
+      const proposalMemo = 'pay rent #42';
+      const { txJson, feePayerKey } = await buildSignedSendTxJson(proposalMemo);
+      const signed = signFeePayer(txJson, feePayerKey.toBase58(), 'testnet');
+      expect(decodeTxMemo(JSON.parse(signed).memo)).toBe(proposalMemo);
+    }, 20_000);
   });
 });


### PR DESCRIPTION
- Client.signFields would fail for mainnet (hardcoded devnet)
- memo now passes through for proposal (TODO: add in execute bundle too)