### PR TITLE
Compute ownersCommitment on chain instead of arg

### DIFF
--- a/contracts/src/MinaGuard.ts
+++ b/contracts/src/MinaGuard.ts
@@ -28,7 +28,7 @@ import {
   Destination,
 } from './constants';
 
-import { addOwnerToCommitment, removeOwnerFromCommitment, assertOwnerMembership, OwnerWitness, PublicKeyOption } from './list-commitment';
+import { addOwnerToCommitment, removeOwnerFromCommitment, assertOwnerMembership, OwnerWitness, PublicKeyOption, computeSetupOwnersChain, assertCoherentSetupOwners } from './list-commitment';
 
 // -- Types -------------------------------------------------------------------
 
@@ -656,7 +656,6 @@ export class MinaGuard extends SmartContract {
 
   /** Shared initialization: validates config, sets all state, emits setup + owner events. */
   private initializeState(
-    ownersCommitment: Field,
     threshold: Field,
     numOwners: Field,
     networkId: Field,
@@ -668,7 +667,13 @@ export class MinaGuard extends SmartContract {
     // Use requireEquals instead of getAndRequireEquals so deploy+setup can
     // be combined in a single transaction (no account cache read needed).
     this.ownersCommitment.requireEquals(Field(0));
-    ownersCommitment.assertNotEquals(Field(0), 'Owners commitment must not be zero');
+
+    // Compute the commitment ON-CHAIN from the supplied owner list rather than
+    // trusting a caller-supplied value: this makes commitment == hash(ownerSet)
+    // true by construction, so the stored anchor and emitted setupOwner events
+    // can never describe a different set than the one committed to.
+    assertCoherentSetupOwners(initialOwners.owners, numOwners);
+    const ownersCommitment = computeSetupOwnersChain(initialOwners.owners, numOwners);
 
     threshold.assertGreaterThan(Field(0), 'Threshold must be > 0');
     numOwners.assertGreaterThanOrEqual(
@@ -705,11 +710,11 @@ export class MinaGuard extends SmartContract {
   /**
    * Initializes a root guard (no parent). Cannot call twice.
    *
-   * IMPORTANT: Assuming an untrusted deployer, a client must compute the expected commitment
-   * themselves and cross-check with the one on chain. numOwners as well, for sync.
+   * The owners commitment is computed on-chain from `initialOwners` (see
+   * initializeState), so the deployer cannot store a commitment that disagrees
+   * with the owner set — no client-side cross-check is required.
    */
   @method async setup(
-    ownersCommitment: Field,
     threshold: Field,
     numOwners: Field,
     networkId: Field,
@@ -717,7 +722,6 @@ export class MinaGuard extends SmartContract {
   ) {
     this.parent.requireEquals(PublicKey.empty());
     this.initializeState(
-      ownersCommitment,
       threshold,
       numOwners,
       networkId,
@@ -741,7 +745,6 @@ export class MinaGuard extends SmartContract {
   @method async reserveForParent(
     parentAddress: PublicKey,
     proposalHash: Field,
-    ownersCommitment: Field,
     threshold: Field,
     numOwners: Field,
     initialOwners: SetupOwnersInput,
@@ -750,6 +753,12 @@ export class MinaGuard extends SmartContract {
     this.parent.requireEquals(PublicKey.empty());
     parentAddress.equals(PublicKey.empty()).assertFalse('Parent address must not be empty');
     this.parent.set(parentAddress);
+
+    // Compute the commitment on-chain from the owner list so the emitted
+    // createChildConfig/createChildOwner events are provably coherent (the
+    // event commitment is the hash of the emitted owner set, not a free input).
+    assertCoherentSetupOwners(initialOwners.owners, numOwners);
+    const ownersCommitment = computeSetupOwnersChain(initialOwners.owners, numOwners);
 
     this.emitEvent('createChildConfig', {
       proposalHash,
@@ -782,7 +791,6 @@ export class MinaGuard extends SmartContract {
    * reserveForParent(), which sets this.parent and blocks setup().
    */
   @method async executeSetupChild(
-    ownersCommitment: Field,
     threshold: Field,
     numOwners: Field,
     initialOwners: SetupOwnersInput,
@@ -800,6 +808,13 @@ export class MinaGuard extends SmartContract {
     proposal.childAccount.equals(this.address).assertTrue('Proposal not for this child');
     proposal.nonce.assertEquals(Field(0), 'Create child proposal nonce must be 0');
 
+    // Compute the commitment on-chain from the owner list, then bind the
+    // parent-approved proposal.data to THAT computed value. This makes the
+    // approved data commit to the real owner set: the executor cannot
+    // substitute a different list that merely shares a caller-supplied
+    // commitment.
+    assertCoherentSetupOwners(initialOwners.owners, numOwners);
+    const ownersCommitment = computeSetupOwnersChain(initialOwners.owners, numOwners);
     const childConfigHash = Poseidon.hash([ownersCommitment, threshold, numOwners]);
     proposal.data.assertEquals(childConfigHash, 'Child config mismatch');
 
@@ -814,7 +829,6 @@ export class MinaGuard extends SmartContract {
     );
 
     this.initializeState(
-      ownersCommitment,
       threshold,
       numOwners,
       proposal.networkId,

--- a/contracts/src/list-commitment.ts
+++ b/contracts/src/list-commitment.ts
@@ -23,11 +23,11 @@ function computeOwnerChain(owners: PublicKey[]): Field {
  * Takes a raw PublicKey[] (caller passes SetupOwnersInput.owners) to avoid a
  * circular import with MinaGuard.ts where SetupOwnersInput is defined.
  *
- * TODO: while chaining, add coherence checks to harden the committed set:
- *   - reject duplicate owners (same pk appearing twice within the active range)
- *   - assert padding slots (index >= numOwners) are PublicKey.empty()
- *   - (optional) assert active owners are strictly ascending by base58 to
- *     enforce canonical ordering rather than only failing the equality check
+ * Duplicate-owner and padding-is-empty coherence checks live in the companion
+ * `assertCoherentSetupOwners`. Canonical ordering is intentionally NOT enforced
+ * in-circuit (the off-chain order is base58, infeasible to reproduce cheaply
+ * here); it is pinned for free by binding this result to the approved
+ * `ownersCommitment` — any reordering changes the chain hash.
  */
 function computeSetupOwnersChain(owners: PublicKey[], numOwners: Field): Field {
   let currentChain = INITIAL_OWNER_CHAIN;
@@ -37,6 +37,36 @@ function computeSetupOwnersChain(owners: PublicKey[], numOwners: Field): Field {
     currentChain = Provable.if(active, next, currentChain);
   });
   return currentChain;
+}
+
+/**
+ * Asserts the setup owner array is coherent w.r.t. `numOwners`:
+ *  1. Every inactive slot (index >= numOwners) is PublicKey.empty() — padding
+ *     must be empty (the dedup gate below intentionally ignores padding).
+ *  2. No two active owners are equal — rejects a committed duplicate set
+ *     (e.g. [A, A]), which the `commitment == ownersCommitment` bind cannot
+ *     catch on its own.
+ *
+ * Ordering is NOT checked here: the canonical order is base58, which is
+ * infeasible in-circuit, and ordering is already pinned by the separate
+ * commitment-equality assert.
+ */
+function assertCoherentSetupOwners(owners: PublicKey[], numOwners: Field): void {
+  const empty = PublicKey.empty();
+  // hoist: one lessThan per index instead of recomputing inside the O(N^2) loop
+  const active = owners.map((_, i) => Field(i).lessThan(numOwners));
+
+  for (let i = 0; i < owners.length; i++) {
+
+    // check if padding positions are indeed empty
+    active[i].or(owners[i].equals(empty)).assertTrue('Padding slot must be empty');
+
+    // pairwise dedup: slot i against all later active slots (O(N^2) overall)
+    for (let j = i + 1; j < owners.length; j++) {
+      owners[i].equals(owners[j]).and(active[i]).and(active[j])
+        .assertFalse('Duplicate owner in setup list');
+    }
+  }
 }
 
 /**
@@ -170,5 +200,5 @@ function removeOwnerFromCommitment(
 
 export {
   OwnerWitness, OwnerWitnessArray, PublicKeyOption, computeOwnerChain, computeSetupOwnersChain,
-  assertOwnerMembership, addOwnerToCommitment, removeOwnerFromCommitment
+  assertCoherentSetupOwners, assertOwnerMembership, addOwnerToCommitment, removeOwnerFromCommitment
 };

--- a/contracts/src/list-commitment.ts
+++ b/contracts/src/list-commitment.ts
@@ -14,6 +14,32 @@ function computeOwnerChain(owners: PublicKey[]): Field {
 }
 
 /**
+ * Computes the owner-chain commitment from a fixed-size setup owner array,
+ * folding in only the first `numOwners` slots (index < numOwners) and skipping
+ * the PublicKey.empty() padding. Mirrors `computeOwnerChain` (which hashes only
+ * real owners) so the result matches the commitment produced off-chain by
+ * OwnerStore.getCommitment().
+ *
+ * Takes a raw PublicKey[] (caller passes SetupOwnersInput.owners) to avoid a
+ * circular import with MinaGuard.ts where SetupOwnersInput is defined.
+ *
+ * TODO: while chaining, add coherence checks to harden the committed set:
+ *   - reject duplicate owners (same pk appearing twice within the active range)
+ *   - assert padding slots (index >= numOwners) are PublicKey.empty()
+ *   - (optional) assert active owners are strictly ascending by base58 to
+ *     enforce canonical ordering rather than only failing the equality check
+ */
+function computeSetupOwnersChain(owners: PublicKey[], numOwners: Field): Field {
+  let currentChain = INITIAL_OWNER_CHAIN;
+  owners.forEach((pk, i) => {
+    const active = Field(i).lessThan(numOwners);
+    const next = Poseidon.hash([currentChain, pk.x, pk.isOdd.toField()]);
+    currentChain = Provable.if(active, next, currentChain);
+  });
+  return currentChain;
+}
+
+/**
  * Circuit to check membership of a public key in the owner list.
  * 
  * @param ownerCommitment
@@ -143,6 +169,6 @@ function removeOwnerFromCommitment(
 }
 
 export {
-  OwnerWitness, OwnerWitnessArray, PublicKeyOption, computeOwnerChain, assertOwnerMembership,
-  addOwnerToCommitment, removeOwnerFromCommitment
+  OwnerWitness, OwnerWitnessArray, PublicKeyOption, computeOwnerChain, computeSetupOwnersChain,
+  assertOwnerMembership, addOwnerToCommitment, removeOwnerFromCommitment
 };

--- a/contracts/src/tests/child.test.ts
+++ b/contracts/src/tests/child.test.ts
@@ -130,7 +130,6 @@ describe('MinaGuard - Child Lifecycle', () => {
         await childZkApp.reserveForParent(
           parentCtx.zkAppAddress,
           proposal.hash(),
-          ownersCommitment,
           Field(2),
           Field(3),
           new SetupOwnersInput({ owners: setupOwners }),
@@ -142,7 +141,6 @@ describe('MinaGuard - Child Lifecycle', () => {
       await expect(async () => {
         const txn = await Mina.transaction(parentCtx.deployerAccount, async () => {
           await childZkApp.executeSetupChild(
-            ownersCommitment,
             Field(2),
             Field(3),
             new SetupOwnersInput({ owners: setupOwners }),
@@ -170,7 +168,6 @@ describe('MinaGuard - Child Lifecycle', () => {
       await expect(async () => {
         const txn = await Mina.transaction(parentCtx.deployerAccount, async () => {
           await childZkApp.executeSetupChild(
-            ownersCommitment,
             Field(2),
             Field(3),
             new SetupOwnersInput({ owners: setupOwners }),
@@ -226,7 +223,6 @@ describe('MinaGuard - Child Lifecycle', () => {
         await childZkApp.reserveForParent(
           parentCtx.zkAppAddress,
           badProposal.hash(),
-          ownersCommitment,
           Field(2),
           Field(3),
           new SetupOwnersInput({ owners: setupOwners }),
@@ -238,7 +234,6 @@ describe('MinaGuard - Child Lifecycle', () => {
       await expect(async () => {
         const txn = await Mina.transaction(parentCtx.deployerAccount, async () => {
           await childZkApp.executeSetupChild(
-            ownersCommitment,
             Field(2),
             Field(3),
             new SetupOwnersInput({ owners: setupOwners }),
@@ -302,7 +297,6 @@ describe('MinaGuard - Child Lifecycle', () => {
         await parentCtx.zkApp.reserveForParent(
           attackerAddress,
           Field(999),
-          ownersCommitment,
           Field(2),
           Field(3),
           new SetupOwnersInput({ owners: setupOwners }),

--- a/contracts/src/tests/list-commitment.test.ts
+++ b/contracts/src/tests/list-commitment.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { Bool, PrivateKey, Provable, PublicKey } from 'o1js';
+import { Bool, Field, PrivateKey, Provable, PublicKey } from 'o1js';
 import {
   PublicKeyOption,
   OwnerWitness,
   computeOwnerChain,
+  computeSetupOwnersChain,
+  assertCoherentSetupOwners,
   assertOwnerMembership,
   addOwnerToCommitment,
   removeOwnerFromCommitment,
@@ -26,10 +28,20 @@ function after(pk: PublicKey): PublicKeyOption {
   return new PublicKeyOption({ value: pk, isSome: Bool(true) });
 }
 
+/** Pad a compact owner list to MAX_OWNERS with PublicKey.empty() at the end. */
+function padToMax(real: PublicKey[]): PublicKey[] {
+  const padded = [...real];
+  while (padded.length < MAX_OWNERS) {
+    padded.push(PublicKey.empty());
+  }
+  return padded.slice(0, MAX_OWNERS);
+}
+
 // Pre-generate test keys
 const keyA = PrivateKey.random().toPublicKey();
 const keyB = PrivateKey.random().toPublicKey();
 const keyC = PrivateKey.random().toPublicKey();
+const keyD = PrivateKey.random().toPublicKey();
 
 describe('computeOwnerChain', () => {
   it('empty array returns INITIAL_OWNER_CHAIN', () => {
@@ -331,5 +343,76 @@ describe('round-trips', () => {
       remValid.assertTrue();
       removed.assertEquals(original);
     });
+  });
+});
+
+describe('computeSetupOwnersChain', () => {
+  it('matches computeOwnerChain for a padded list with numOwners = N', () => {
+    const real = [keyA, keyB, keyC];
+    const h = computeSetupOwnersChain(padToMax(real), Field(real.length));
+    expect(h.toBigInt()).toBe(computeOwnerChain(real).toBigInt());
+  });
+
+  it('numOwners = 0 returns INITIAL_OWNER_CHAIN', () => {
+    const h = computeSetupOwnersChain(padToMax([keyA, keyB]), Field(0));
+    expect(h.toBigInt()).toBe(INITIAL_OWNER_CHAIN.toBigInt());
+  });
+
+  it('full list (numOwners = 2) matches computeOwnerChain([A, B])', () => {
+    const h = computeSetupOwnersChain(padToMax([keyA, keyB]), Field(2));
+    expect(h.toBigInt()).toBe(computeOwnerChain([keyA, keyB]).toBigInt());
+  });
+
+  it('ignores padding: single real owner matches computeOwnerChain([A])', () => {
+    const h = computeSetupOwnersChain(padToMax([keyA]), Field(1));
+    expect(h.toBigInt()).toBe(computeOwnerChain([keyA]).toBigInt());
+  });
+
+  it('numOwners is sensitive: Field(2) != Field(3) for the same array', () => {
+    const padded = padToMax([keyA, keyB, keyC]);
+    const h2 = computeSetupOwnersChain(padded, Field(2));
+    const h3 = computeSetupOwnersChain(padded, Field(3));
+    expect(h2.toBigInt()).not.toBe(h3.toBigInt());
+  });
+});
+
+describe('assertCoherentSetupOwners', () => {
+  it('passes for distinct active owners with empty padding', async () => {
+    await Provable.runAndCheck(() => {
+      assertCoherentSetupOwners(padToMax([keyA, keyB, keyC]), Field(3));
+    });
+  });
+
+  it('passes for a single owner', async () => {
+    await Provable.runAndCheck(() => {
+      assertCoherentSetupOwners(padToMax([keyA]), Field(1));
+    });
+  });
+
+  it('passes despite many duplicate empty() padding slots', async () => {
+    // numOwners = 2, the remaining 18 slots are all PublicKey.empty() (equal to
+    // each other) — the active-gate must keep dedup from firing on them.
+    await Provable.runAndCheck(() => {
+      assertCoherentSetupOwners(padToMax([keyA, keyB]), Field(2));
+    });
+  });
+
+  it('fails on a duplicate active owner', async () => {
+    // keyA at slots 0 and 1, both active (numOwners = 3).
+    await expect(
+      Provable.runAndCheck(() => {
+        assertCoherentSetupOwners(padToMax([keyA, keyA, keyB]), Field(3));
+      })
+    ).rejects.toThrow();
+  });
+
+  it('fails on a non-empty padding slot', async () => {
+    // Real owner planted at index 2, but numOwners = 2 so index 2 is inactive
+    // and must be empty.
+    await expect(
+      Provable.runAndCheck(() => {
+        assertCoherentSetupOwners(padToMax([keyA, keyB, keyC]), Field(2));
+      })
+    ).rejects.toThrow();
   });
 });

--- a/contracts/src/tests/setup.test.ts
+++ b/contracts/src/tests/setup.test.ts
@@ -48,7 +48,6 @@ describe('MinaGuard - Setup', () => {
     await expect(async () => {
       const txn = await Mina.transaction(ctx.deployerAccount, async () => {
         await ctx.zkApp.setup(
-          getOwnersCommitment(ctx),
           Field(2),
           Field(3),
           Field(1),
@@ -64,7 +63,6 @@ describe('MinaGuard - Setup', () => {
 
   it('should reject threshold = 0', async () => {
     const { zkApp, zkAppKey, deployerKey, deployerAccount } = ctx;
-    const ownersCommitment = getOwnersCommitment(ctx);
 
     // Deploy only
     const deployTxn = await Mina.transaction(deployerAccount, async () => {
@@ -77,7 +75,6 @@ describe('MinaGuard - Setup', () => {
     await expect(async () => {
       const txn = await Mina.transaction(deployerAccount, async () => {
         await zkApp.setup(
-          ownersCommitment,
           Field(0),
           Field(3),
           Field(1),
@@ -93,7 +90,6 @@ describe('MinaGuard - Setup', () => {
 
   it('should reject numOwners < threshold', async () => {
     const { zkApp, zkAppKey, deployerKey, deployerAccount } = ctx;
-    const ownersCommitment = getOwnersCommitment(ctx);
 
     const deployTxn = await Mina.transaction(deployerAccount, async () => {
       AccountUpdate.fundNewAccount(deployerAccount);
@@ -105,7 +101,6 @@ describe('MinaGuard - Setup', () => {
     await expect(async () => {
       const txn = await Mina.transaction(deployerAccount, async () => {
         await zkApp.setup(
-          ownersCommitment,
           Field(5),
           Field(3),
           Field(1),

--- a/contracts/src/tests/test-helpers.ts
+++ b/contracts/src/tests/test-helpers.ts
@@ -149,12 +149,10 @@ export async function deployAndSetup(
   await fundTxn.prove();
   await fundTxn.sign([deployerKey]).send();
 
-  const ownersCommitment = computeOwnerChain(owners.map((o) => o.pub));
   const setupOwners = toFixedSetupOwners(owners.map((o) => o.pub));
 
   const setupTxn = await Mina.transaction(deployerAccount, async () => {
     await zkApp.setup(
-      ownersCommitment,
       Field(threshold),
       Field(owners.length),
       ctx.networkId,
@@ -687,7 +685,6 @@ export async function deployAndSetupChildGuard(
     await childZkApp.reserveForParent(
       parentAddress,
       proposalHash,
-      ownersCommitment,
       thresholdField,
       numOwnersField,
       new SetupOwnersInput({ owners: setupOwners }),
@@ -720,7 +717,6 @@ export async function deployAndSetupChildGuard(
     const funder = AccountUpdate.createSigned(deployerAccount);
     funder.send({ to: childAddress, amount: UInt64.from(10_000_000_000) });
     await childZkApp.executeSetupChild(
-      ownersCommitment,
       thresholdField,
       numOwnersField,
       new SetupOwnersInput({ owners: setupOwners }),

--- a/offline-cli/src/build-tx.ts
+++ b/offline-cli/src/build-tx.ts
@@ -727,7 +727,6 @@ export async function handlePropose(
       await childZkApp.reserveForParent(
         contractAddress,
         proposalHash,
-        childOwnerStore.getCommitment(),
         Field(input.childThreshold!),
         Field(input.childOwners!.length),
         new SetupOwnersInput({ owners: childPaddedOwners.slice(0, MAX_OWNERS) }),
@@ -934,7 +933,6 @@ export async function handleExecute(
     log('Building transaction...');
     const tx = await Mina.transaction(txSender(executor), async () => {
       await childZkApp.executeSetupChild(
-        childOwnerStore.getCommitment(),
         Field(bundle.childThreshold!),
         Field(bundle.childOwners!.length),
         new SetupOwnersInput({ owners: paddedOwners.slice(0, MAX_OWNERS) }),

--- a/offline-cli/src/tests/offline-cli-e2e.test.ts
+++ b/offline-cli/src/tests/offline-cli-e2e.test.ts
@@ -185,7 +185,6 @@ describe('offline-cli e2e', () => {
 
     const setupTx = await Mina.transaction(deployer.pub, async () => {
       await zkApp.setup(
-        computeOwnerChain(owners.map((o) => o.pub)),
         Field(2),
         Field(owners.length),
         Field(1),
@@ -588,7 +587,7 @@ describe('offline-cli e2e', () => {
         AccountUpdate.fundNewAccount(owners[0].pub);
         await childZkApp.deploy();
         await childZkApp.reserveForParent(
-          zkAppAddress, ccHash, ownersCommitment, thresholdField, numOwnersField,
+          zkAppAddress, ccHash, thresholdField, numOwnersField,
           new SetupOwnersInput({ owners: setupOwners }),
         );
         await zkApp.propose(
@@ -618,7 +617,7 @@ describe('offline-cli e2e', () => {
         const funder = AccountUpdate.createSigned(deployer.pub);
         funder.send({ to: childAddress, amount: UInt64.from(10_000_000_000) });
         await childZkApp.executeSetupChild(
-          ownersCommitment, thresholdField, numOwnersField,
+          thresholdField, numOwnersField,
           new SetupOwnersInput({ owners: setupOwners }),
           createChildProposal, approvalStore.getWitness(ccHash), approvalStore.getCount(ccHash),
         );
@@ -920,7 +919,7 @@ describe('offline-cli e2e', () => {
         AccountUpdate.fundNewAccount(proposer.pub);
         await childZkApp.deploy();
         await childZkApp.reserveForParent(
-          zkAppAddress, ccHash, childOwnersCommitment, Field(2), Field(owners.length),
+          zkAppAddress, ccHash, Field(2), Field(owners.length),
           new SetupOwnersInput({ owners: setupOwners }),
         );
         await zkApp.propose(

--- a/offline-cli/src/tests/offline-cli.test.ts
+++ b/offline-cli/src/tests/offline-cli.test.ts
@@ -135,7 +135,6 @@ describe('offline-cli', () => {
     const setupOwners = toFixedOwners(owners.map((o) => o.pub));
     const setupTx = await Mina.transaction(deployer.pub, async () => {
       await zkApp.setup(
-        ownersCommitment,
         Field(2),
         Field(owners.length),
         Field(1),

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -745,7 +745,6 @@ const workerApi = {
       AccountUpdate.fundNewAccount(feePayer);
       await zkApp.deploy();
       await zkApp.setup(
-        ownerStore.getCommitment(),
         Field(params.threshold),
         Field(ownerKeys.length),
         Field(params.networkId),
@@ -796,7 +795,6 @@ const workerApi = {
     clearStaleTransaction();
     const tx = await Mina.transaction(txSender(feePayer), async () => {
       await zkApp.setup(
-        ownerStore.getCommitment(),
         Field(params.threshold),
         Field(ownerStore.length),
         Field(params.networkId),
@@ -948,7 +946,6 @@ const workerApi = {
         await childZkApp.reserveForParent(
           contractAddress,
           proposalHash,
-          childOwnerStore.getCommitment(),
           Field(params.childThreshold!),
           Field(params.childOwners!.length),
           new SetupOwnersInput({ owners: childPaddedOwners.slice(0, MAX_OWNERS) }),
@@ -1238,7 +1235,6 @@ const workerApi = {
     clearStaleTransaction();
     const tx = await Mina.transaction(txSender(executor), async () => {
       await childZkApp.executeSetupChild(
-        ownersCommitment,
         threshold,
         numOwners,
         new SetupOwnersInput({ owners: paddedOwners.slice(0, MAX_OWNERS) }),


### PR DESCRIPTION
This PR hardens the `ownersCommitment` binding. Previously, we assumed the client would check that the supplied commitment argument during setup matched the claimed owner list.

Now, the commitment is computed on chain on setup from the owners list, removing the need for the commitment argument. 

Duplicate owners and empty slots are rejected on chain.