### PR TITLE
Add Mesa Trail deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 .next
 .git
 *.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,43 @@ jobs:
         run: bun test src/tests/offline-cli-e2e.test.ts --test-name-pattern "propose"
         timeout-minutes: 20
 
+  check-vk-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fail if VK-affecting files changed without updating contracts/.vk-hash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+
+          # Skip on initial push (before SHA is all-zeros)
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "Initial push — skipping VK hash drift check."
+            exit 0
+          fi
+
+          SRC_CHANGED=$(git diff --name-only "$BASE"...HEAD -- contracts/src/ || true)
+          O1JS_CHANGED=$(git diff "$BASE"...HEAD -- bun.lock | grep '^[+-].*"o1js@' | grep -v '^---\|^+++' || true)
+          HASH_CHANGED=$(git diff --name-only "$BASE"...HEAD -- contracts/.vk-hash || true)
+
+          TRIGGER=""
+          [ -n "$SRC_CHANGED" ] && TRIGGER="contracts/src changed"
+          [ -n "$O1JS_CHANGED" ] && TRIGGER="${TRIGGER:+$TRIGGER; }o1js version changed in bun.lock"
+
+          if [ -n "$TRIGGER" ] && [ -z "$HASH_CHANGED" ]; then
+            echo "::error::$TRIGGER but contracts/.vk-hash was not updated."
+            echo "Regenerate: bun run --filter contracts build && bun run dev-helpers/cli.ts vk-hash compile"
+            exit 1
+          fi
+
+          echo "VK hash drift check passed."
+
   test-offline-cli-windows:
     timeout-minutes: 30
     runs-on: windows-latest

--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -9,22 +9,13 @@
 # Required repo secrets (Settings → Secrets and variables → Actions):
 #
 #   - MESA_NODE_HOST       IP/host of the standalone Mesa Trail node stack
-#                          REQUIRED — the
-#                          docker-compose.trail.yml has a ${MESA_NODE_HOST:?...}
-#                          assertion that fails the build if unset.
+#                          REQUIRED — docker-compose.trail.yml asserts it.
 #
-#   - MINAGUARD_VK_HASH    Verification key hash of the deployed MinaGuard
-#                          contract (currently the browser-compiled hash —
-#                          see MINA_GUARD_PRODUCTION.md §10 2026-06-23
-#                          entry for the Node↔browser VK divergence context).
-#                          Optional but recommended; leave blank to fall
-#                          through to "no VK filter" mode (the indexer then
-#                          records events from any zkApp at queried
-#                          addresses, fine for testnet trial but not for
-#                          mainnet).
+# The MinaGuard VK hash is NOT a secret — it's committed at
+# contracts/.vk-hash and read automatically by deploy-trail.sh.
 #
-# To bootstrap: add the two secrets above, then merge a PR to main (or
-# trigger via `gh workflow run deploy-trail.yml`).
+# To bootstrap: add MESA_NODE_HOST, then merge a PR to main (or trigger
+# via `gh workflow run deploy-trail.yml`).
 #
 # To tighten later: add a `paths:` filter under `on.push` so this only
 # fires when trail-relevant files change. Today it fires on every main
@@ -45,36 +36,9 @@ jobs:
   deploy:
     runs-on: [self-hosted, deploy]
     steps:
-      - name: Verify branch is main
-        run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "::error::Refusing to deploy from ${{ github.ref }}. This workflow only runs on main."
-            exit 1
-          fi
-
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Write deploy/.env from secrets
-        # deploy-trail.sh sources deploy/.env at startup. MESA_NODE_HOST is
-        # required (compose's ${MESA_NODE_HOST:?...} fails the build if
-        # unset); MINAGUARD_VK_HASH is used as a build arg for the backend
-        # image (the Dockerfile writes it to /app/.vk-hash, the indexer
-        # reads it at runtime).
-        env:
-          MESA_NODE_HOST: ${{ secrets.MESA_NODE_HOST }}
-          MINAGUARD_VK_HASH: ${{ secrets.MINAGUARD_VK_HASH }}
-        run: |
-          if [ -z "$MESA_NODE_HOST" ]; then
-            echo "::error::secrets.MESA_NODE_HOST is not set — add it in repo Settings → Secrets"
-            exit 1
-          fi
-          cat > deploy/.env <<EOF
-          MESA_NODE_HOST=$MESA_NODE_HOST
-          MINAGUARD_VK_HASH=$MINAGUARD_VK_HASH
-          EOF
-          chmod 600 deploy/.env
 
       - name: Deploy
         # deploy-trail.sh runs `docker compose ... up -d --build` for the
@@ -82,6 +46,9 @@ jobs:
         # /trail, /trail/* route to the host Caddy via admin API on
         # localhost:2019 (mirrors deploy.sh add_caddy_route + COOP/COEP).
         # Idempotent — safe to re-run on every main push.
+        # The VK hash is read from contracts/.vk-hash by deploy-trail.sh.
+        env:
+          MESA_NODE_HOST: ${{ secrets.MESA_NODE_HOST }}
         run: |
           chmod +x deploy/deploy-trail.sh
           ./deploy/deploy-trail.sh up

--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -1,0 +1,101 @@
+# Auto-deploys the Mesa Trail webapp stack to prod when main is pushed
+# (e.g., when a PR merges). Mirrors deploy.yml's pattern for the localnet
+# /app/* deploy but targets the trail compose project + /trail/* routes.
+#
+# Self-hosted runner is on the prod-facing box; the actual deploy happens
+# there. No SSH credentials needed in GHA secrets — the workflow runs on
+# the box.
+#
+# Required repo secrets (Settings → Secrets and variables → Actions):
+#
+#   - MESA_NODE_HOST       IP/host of the standalone Mesa Trail node stack
+#                          REQUIRED — the
+#                          docker-compose.trail.yml has a ${MESA_NODE_HOST:?...}
+#                          assertion that fails the build if unset.
+#
+#   - MINAGUARD_VK_HASH    Verification key hash of the deployed MinaGuard
+#                          contract (currently the browser-compiled hash —
+#                          see MINA_GUARD_PRODUCTION.md §10 2026-06-23
+#                          entry for the Node↔browser VK divergence context).
+#                          Optional but recommended; leave blank to fall
+#                          through to "no VK filter" mode (the indexer then
+#                          records events from any zkApp at queried
+#                          addresses, fine for testnet trial but not for
+#                          mainnet).
+#
+# To bootstrap: add the two secrets above, then merge a PR to main (or
+# trigger via `gh workflow run deploy-trail.yml`).
+#
+# To tighten later: add a `paths:` filter under `on.push` so this only
+# fires when trail-relevant files change. Today it fires on every main
+# push for consistency with deploy.yml.
+
+name: Deploy Mesa Trail
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-trail
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, deploy]
+    steps:
+      - name: Verify branch is main
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error::Refusing to deploy from ${{ github.ref }}. This workflow only runs on main."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Write deploy/.env from secrets
+        # deploy-trail.sh sources deploy/.env at startup. MESA_NODE_HOST is
+        # required (compose's ${MESA_NODE_HOST:?...} fails the build if
+        # unset); MINAGUARD_VK_HASH is used as a build arg for the backend
+        # image (the Dockerfile writes it to /app/.vk-hash, the indexer
+        # reads it at runtime).
+        env:
+          MESA_NODE_HOST: ${{ secrets.MESA_NODE_HOST }}
+          MINAGUARD_VK_HASH: ${{ secrets.MINAGUARD_VK_HASH }}
+        run: |
+          if [ -z "$MESA_NODE_HOST" ]; then
+            echo "::error::secrets.MESA_NODE_HOST is not set — add it in repo Settings → Secrets"
+            exit 1
+          fi
+          cat > deploy/.env <<EOF
+          MESA_NODE_HOST=$MESA_NODE_HOST
+          MINAGUARD_VK_HASH=$MINAGUARD_VK_HASH
+          EOF
+          chmod 600 deploy/.env
+
+      - name: Deploy
+        # deploy-trail.sh runs `docker compose ... up -d --build` for the
+        # minaguard-trail compose project on host port 10001, then adds the
+        # /trail, /trail/* route to the host Caddy via admin API on
+        # localhost:2019 (mirrors deploy.sh add_caddy_route + COOP/COEP).
+        # Idempotent — safe to re-run on every main push.
+        run: |
+          chmod +x deploy/deploy-trail.sh
+          ./deploy/deploy-trail.sh up
+
+      - name: Wait for trail backend
+        run: |
+          echo "Waiting for trail backend to be ready..."
+          for i in $(seq 1 36); do
+            if curl -sf "http://localhost:10001/trail/health" > /dev/null 2>&1; then
+              echo "Trail backend is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/36: not ready yet..."
+            sleep 5
+          done
+          echo "::error::Trail backend failed to become ready within timeout"
+          exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Wait for services
         run: |
           echo "Waiting for backend..."
-          timeout 60 bash -c 'until curl -sf http://localhost:4000/health; do sleep 2; done'
+          timeout 60 bash -c 'until curl -sf http://localhost:14000/health; do sleep 2; done'
           echo "Waiting for frontend..."
-          timeout 120 bash -c 'until curl -sf http://localhost:3000; do sleep 2; done'
+          timeout 120 bash -c 'until curl -sf http://localhost:13000; do sleep 2; done'
           echo "Services ready"
 
       - name: Run e2e tests
@@ -64,6 +64,13 @@ jobs:
         env:
           CI: true
           TMPDIR: ${{ github.workspace }}/.tmp
+          # Point the harness at the isolated host ports published by
+          # docker-compose.e2e-ci.yml (1xxxx range avoids runner collisions).
+          E2E_MINA_ENDPOINT: http://127.0.0.1:18080/graphql
+          E2E_ARCHIVE_ENDPOINT: http://127.0.0.1:18282
+          E2E_ACCOUNT_MANAGER: http://127.0.0.1:18181
+          E2E_BACKEND_URL: http://localhost:14000
+          E2E_FRONTEND_URL: http://localhost:13000
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MinaGuard is a multisig wallet zkApp for Mina built with o1js, plus a Next.js UI
 
 ## o1js dependency
 
-The runtime o1js library comes from `o1js@3.0.0-mesa.final` on npm — the canonical Mesa-network release. Earlier versions of this monorepo depended on a [fork](https://github.com/mellowcroc/o1js/tree/mesa-srs-fix) carrying the SRS `getLagrangeBasis` try-catch fix; that patch (along with the graikos commitment-exposure patches as PR [#2869](https://github.com/o1-labs/o1js/pull/2869) and the SRS web-worker fix as PR [#2866](https://github.com/o1-labs/o1js/pull/2866)) has since been merged upstream and is baked into `3.0.0-mesa.final`.
+The runtime o1js library comes from `o1js@3.0.0-mesa.final` on npm — the canonical Mesa-network release.
 
 The `ui/deps/o1js/` submodule is still required, but only for `mina-signer` — the `ui` and `offline-cli` workspaces import it via `file:` workspace deps (mina-signer is a Mina-specific browser-side signing package shipped as a subpackage inside the o1js repo). The submodule points at [`graikos/o1js#develop-3.0`](https://github.com/graikos/o1js/tree/develop-3.0) (currently tip `a252f8bb`); its mina-signer source is byte-identical to what `o1js@3.0.0-mesa.final` ships in `node_modules/o1js/src/mina-signer/`, so there's no protocol-level divergence. A follow-up could drop the submodule entirely by switching to the standalone [`mina-signer`](https://www.npmjs.com/package/mina-signer) npm package.
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@ MinaGuard is a multisig wallet zkApp for Mina built with o1js, plus a Next.js UI
 
 ## o1js dependency
 
-The monorepo depends on a [fork of o1js](https://github.com/mellowcroc/o1js/tree/mesa-srs-fix) (`mesa-srs-fix` branch) rather than the upstream `3.0.0-mesa.0` release.
+The runtime o1js library comes from `o1js@3.0.0-mesa.final` on npm — the canonical Mesa-network release. Earlier versions of this monorepo depended on a [fork](https://github.com/mellowcroc/o1js/tree/mesa-srs-fix) carrying the SRS `getLagrangeBasis` try-catch fix; that patch (along with the graikos commitment-exposure patches as PR [#2869](https://github.com/o1-labs/o1js/pull/2869) and the SRS web-worker fix as PR [#2866](https://github.com/o1-labs/o1js/pull/2866)) has since been merged upstream and is baked into `3.0.0-mesa.final`.
 
-The upstream `srs.ts` calls `caml_{fp,fq}_srs_get_lagrange_basis` to compute and cache the lagrange basis during compilation. This WASM function is not properly implemented for the web target — it throws an uncaught error that crashes the browser tab. The upstream code has a TODO acknowledging this but no guard around it. The issue only surfaces when a writable `Cache` is provided (which we now do via IndexedDB).
-
-The fork wraps both `getLagrangeBasis` call sites in try-catch. On the first site (cache miss with writable cache), the catch falls back to `lagrangeCommitment()` which computes the basis point-by-point without the broken WASM path. On the second site (post-computation cache write), the catch silently skips the cache write. Compilation succeeds either way — the lagrange basis is still computed, just not via the batch WASM function.
-
-The fix is baked into the fork's dist files so no postinstall patching is needed. Revert to upstream once this is fixed in a future o1js release.
+The `ui/deps/o1js/` submodule is still required, but only for `mina-signer` — the `ui` and `offline-cli` workspaces import it via `file:` workspace deps (mina-signer is a Mina-specific browser-side signing package shipped as a subpackage inside the o1js repo). The submodule points at [`graikos/o1js#develop-3.0`](https://github.com/graikos/o1js/tree/develop-3.0) (currently tip `a252f8bb`); its mina-signer source is byte-identical to what `o1js@3.0.0-mesa.final` ships in `node_modules/o1js/src/mina-signer/`, so there's no protocol-level divergence. A follow-up could drop the submodule entirely by switching to the standalone [`mina-signer`](https://www.npmjs.com/package/mina-signer) npm package.
 
 ## Development
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "mina-guard",
       "dependencies": {
-        "o1js": "github:mellowcroc/o1js#mesa-srs-fix",
+        "o1js": "3.0.0-mesa.final",
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -54,7 +54,7 @@
       "dependencies": {
         "commander": "^13.1.0",
         "contracts": "workspace:*",
-        "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
+        "o1js": "3.0.0-mesa.final",
       },
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -493,6 +493,16 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@o1js/native": ["@o1js/native@3.0.0-mesa.final", "", { "optionalDependencies": { "@o1js/native-darwin-arm64": "3.0.0-mesa.final", "@o1js/native-darwin-x64": "3.0.0-mesa.final", "@o1js/native-linux-arm64": "3.0.0-mesa.final", "@o1js/native-linux-x64": "3.0.0-mesa.final" } }, "sha512-aKlr4yLer+psOELdxwp//gGc7OHH2TIRNkhvBgOga0CNhCFQtt0skeB2W16F143PoNzSKw/PLBEn/0v1Dhn6bg=="],
+
+    "@o1js/native-darwin-arm64": ["@o1js/native-darwin-arm64@3.0.0-mesa.final", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hRPzXCMKJoNpLN/WH9z7nZHY9LzRD9TPQ7cVKMch0M6t7VLZvbjLCVzu5JPnaiXWPbeK9f58DGktT84zcDT7Ug=="],
+
+    "@o1js/native-darwin-x64": ["@o1js/native-darwin-x64@3.0.0-mesa.final", "", { "os": "darwin", "cpu": "x64" }, "sha512-Lg17N6/xMnuOUXsgUjpuzLp3jhxn5VuwyqkqAV2Q/D6ATCCeppQ+YoDl7CEtig+zG61sncYJIJWGW0l0VhnymQ=="],
+
+    "@o1js/native-linux-arm64": ["@o1js/native-linux-arm64@3.0.0-mesa.final", "", { "os": "linux", "cpu": "arm64" }, "sha512-18vZGGgoXJR1Ox51LQTleiJmOAiUdtTONZabIfUcJN0WiiL9CV8N+q/1fqFs2LRFwGzLzNJnYB+THZx1YZVX4w=="],
+
+    "@o1js/native-linux-x64": ["@o1js/native-linux-x64@3.0.0-mesa.final", "", { "os": "linux", "cpu": "x64" }, "sha512-WNkIStNb1l1U2bmt0tCAb6rojhBaEMVDDi7qqlqG8D2I4aL1C420AfWJ7praN95XjZyKVOKEdUWrUyYmXVjEMg=="],
 
     "@octokit/action": ["@octokit/action@6.1.0", "", { "dependencies": { "@octokit/auth-action": "^4.0.0", "@octokit/core": "^5.0.0", "@octokit/plugin-paginate-rest": "^9.0.0", "@octokit/plugin-rest-endpoint-methods": "^10.0.0", "@octokit/types": "^12.0.0", "undici": "^6.0.0" } }, "sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw=="],
 
@@ -1198,7 +1208,7 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "o1js": ["o1js@github:mellowcroc/o1js#e0a1022", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "1.2.1", "cachedir": "^2.4.0", "libsodium-wrappers-sumo": "^0.7.15", "reflect-metadata": "^0.1.13", "stacktrace-js": "^2.0.2", "tslib": "^2.3.0" }, "bin": { "snarky-run": "src/build/run.js" } }, "mellowcroc-o1js-e0a1022"],
+    "o1js": ["o1js@3.0.0-mesa.final", "", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "1.2.1", "cachedir": "^2.4.0", "libsodium-wrappers-sumo": "^0.7.15", "reflect-metadata": "^0.1.13", "stacktrace-js": "^2.0.2", "tslib": "^2.3.0" }, "optionalDependencies": { "@o1js/native": "3.0.0-mesa.final" }, "bin": { "snarky-run": "src/build/run.js" } }, "sha512-o04zzGE+k2/vIy3Aq475PXQdtb04NRnRuXk622PyNYOFpxxiWur69mPP/bkQhVymJd0d0t2D3q+d4GADArWfoQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1608,8 +1618,6 @@
 
     "contracts/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
-    "dev-helpers/o1js": ["o1js@https://pkg.pr.new/o1-labs/o1js@2701", { "dependencies": { "blakejs": "1.2.1", "cachedir": "^2.4.0", "js-sha256": "^0.9.0", "libsodium-wrappers-sumo": "^0.7.15", "reflect-metadata": "^0.1.13", "stacktrace-js": "^2.0.2", "tslib": "^2.3.0" }, "bin": { "snarky-run": "src/build/run.js" } }],
-
     "e2e/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "eslint/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -1640,7 +1648,7 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
-    "offline-cli/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "blakejs": "^1.2.1", "js-sha256": "^0.9.0" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
+    "offline-cli/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "^1.2.1" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1668,7 +1676,7 @@
 
     "ui/@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
-    "ui/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "blakejs": "^1.2.1", "js-sha256": "^0.9.0" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
+    "ui/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "^1.2.1" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
 
     "@babel/core/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/contracts/.vk-hash
+++ b/contracts/.vk-hash
@@ -1,0 +1,14 @@
+# Canonical MinaGuard verification-key hash (decimal Field value).
+#
+# This is the hash MinaGuard.compile() produces from the CURRENT contracts/src.
+# The backend indexer filters on-chain zkApp events to this VK (via the
+# MINAGUARD_VK_HASH env var) so it only records genuine MinaGuard vaults.
+#
+# Node and the browser produce the SAME hash for the same source — there is no
+# environment divergence. A mismatch means contracts/build was stale when the
+# hash was computed. Regenerate after ANY change under contracts/src:
+#
+#     bun run --filter contracts build && bun run dev-helpers/cli.ts vk-hash compile
+#
+# Consumers strip these comment lines and read the bare number below.
+22592591136635241954458728867125272730912271761728581931779127524287952990537

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -10,11 +10,3 @@
 # node-stack side. Use the box's public IPv4 today; switch to a Hetzner
 # Cloud Networks 10.x.x.x internal IP once the private network is wired.
 MESA_NODE_HOST=
-
-# Optional. Verification-key hash for the MinaGuard zkApp contract, used by
-# the backend to filter recorded events to MinaGuard-owned contracts only.
-# Leave blank to skip filtering (records events from all zkApps that share
-# our contract addresses — fine for development, narrows correctness later).
-# Compute on the host via `bun run --filter contracts ...`; see how
-# preview-env/preview.sh derives it.
-MINAGUARD_VK_HASH=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,20 @@
+# deploy/.env — sourced by deploy/deploy-trail.sh.
+#
+# Copy to deploy/.env (gitignored) and fill in. `docker compose up` for the
+# trail stack fails fast if MESA_NODE_HOST is unset.
+
+# Address of the standalone Mesa Trail node-stack box (a separate Hetzner
+# server running mina-daemon + mina-archive + archive-node-api). The trail
+# app stack reaches that box on ports 3085 (daemon GraphQL) and 8282
+# (archive-node-api), gated by ufw allow-from-this-server's-IP on the
+# node-stack side. Use the box's public IPv4 today; switch to a Hetzner
+# Cloud Networks 10.x.x.x internal IP once the private network is wired.
+MESA_NODE_HOST=
+
+# Optional. Verification-key hash for the MinaGuard zkApp contract, used by
+# the backend to filter recorded events to MinaGuard-owned contracts only.
+# Leave blank to skip filtering (records events from all zkApps that share
+# our contract addresses — fine for development, narrows correctness later).
+# Compute on the host via `bun run --filter contracts ...`; see how
+# preview-env/preview.sh derives it.
+MINAGUARD_VK_HASH=

--- a/deploy/Caddyfile.trail
+++ b/deploy/Caddyfile.trail
@@ -68,6 +68,14 @@
         }
     }
 
+    # Block explorer
+    handle /trail/explorer/* {
+        reverse_proxy explorer:3000
+    }
+    handle /trail/explorer {
+        reverse_proxy explorer:3000
+    }
+
     # Static assets (content-hashed filenames, safe to cache long-term).
     # COOP/COEP set here too so cross-origin-isolated requirements (needed
     # by the o1js worker's SharedArrayBuffer) are consistent across assets.

--- a/deploy/Caddyfile.trail
+++ b/deploy/Caddyfile.trail
@@ -1,0 +1,103 @@
+# Caddyfile for the MinaGuard Mesa Trail (mesa-mut) inner Caddy.
+#
+# Mounted at /etc/caddy/Caddyfile inside the `caddy` service of the
+# `minaguard-trail` compose project. Listens on port 80 inside the container;
+# the host publishes port 10001 → container port 80.
+#
+# This compose project runs on the prod-facing box (the same box as the
+# existing /app/* localnet deploy and the PR previews). The outer host Caddy
+# on that box reverse-proxies /trail, /trail/* to localhost:10001
+# (see deploy-trail.sh add_caddy_route).
+#
+# Upstream targets:
+#   - backend:4000  / frontend:3000   → services in the same compose project
+#                                       (resolved on the compose network)
+#   - {$MESA_NODE_HOST}:3085          → daemon GraphQL (standalone Mesa Trail
+#                                       node stack on a separate box)
+#   - {$MESA_NODE_HOST}:8282          → archive-node-api (same node-stack box)
+#
+# MESA_NODE_HOST is read from the caddy container's environment, populated
+# by the compose file from MESA_NODE_HOST in the deploying shell. Required —
+# `docker compose up` fails if unset (see deploy/.env.example).
+#
+# Both cross-host hops use plaintext HTTP over the public internet, gated by
+# ufw on the node-stack box (allow inbound 3085/8282 only from prod IP).
+# Sibling file `deploy/Caddyfile` documents the equivalent `/app/*` routes.
+
+:80 {
+    # Backend health
+    handle /trail/health {
+        uri strip_prefix /trail
+        reverse_proxy backend:4000
+    }
+
+    # Backend API
+    handle /trail/api/* {
+        uri strip_prefix /trail
+        reverse_proxy backend:4000
+    }
+
+    # Daemon GraphQL — proxied across the network to the standalone Mesa Trail
+    # node stack at {$MESA_NODE_HOST}:3085.
+    handle /trail/graphql {
+        uri strip_prefix /trail
+        header Access-Control-Allow-Origin "*"
+        header Access-Control-Allow-Methods "GET, POST, OPTIONS"
+        header Access-Control-Allow-Headers "Content-Type"
+        @options method OPTIONS
+        respond @options 204
+        reverse_proxy {$MESA_NODE_HOST}:3085 {
+            header_down -Access-Control-Allow-Origin
+            header_down -Access-Control-Allow-Methods
+            header_down -Access-Control-Allow-Headers
+        }
+    }
+
+    # Archive-node-api — also proxied across the network to the node-stack box.
+    handle /trail/archive {
+        uri strip_prefix /trail
+        header Access-Control-Allow-Origin "*"
+        header Access-Control-Allow-Methods "GET, POST, OPTIONS"
+        header Access-Control-Allow-Headers "Content-Type"
+        @options method OPTIONS
+        respond @options 204
+        reverse_proxy {$MESA_NODE_HOST}:8282 {
+            header_down -Access-Control-Allow-Origin
+            header_down -Access-Control-Allow-Methods
+            header_down -Access-Control-Allow-Headers
+        }
+    }
+
+    # Static assets (content-hashed filenames, safe to cache long-term).
+    # COOP/COEP set here too so cross-origin-isolated requirements (needed
+    # by the o1js worker's SharedArrayBuffer) are consistent across assets.
+    handle /trail/_next/static/* {
+        reverse_proxy frontend:3000
+        header Cross-Origin-Opener-Policy "same-origin"
+        header Cross-Origin-Embedder-Policy "credentialless"
+    }
+
+    # Frontend (catch-all under /trail). The COOP/COEP headers cross-origin-
+    # isolate the document so o1js can use SharedArrayBuffer for proof
+    # generation in its web worker. In the prod deploy the outer host Caddy
+    # also sets these (see deploy-trail.sh add_caddy_route) and explicitly
+    # `delete`s them from the upstream response, so setting them here is a
+    # no-op there — but it's necessary for any deploy that hits the inner
+    # Caddy directly (e.g. local testing on the node-stack box).
+    handle /trail/* {
+        reverse_proxy frontend:3000 {
+            header_down -Cache-Control
+        }
+        header Cache-Control "no-cache"
+        header Cross-Origin-Opener-Policy "same-origin"
+        header Cross-Origin-Embedder-Policy "credentialless"
+    }
+    handle /trail {
+        reverse_proxy frontend:3000 {
+            header_down -Cache-Control
+        }
+        header Cache-Control "no-cache"
+        header Cross-Origin-Opener-Policy "same-origin"
+        header Cross-Origin-Embedder-Policy "credentialless"
+    }
+}

--- a/deploy/deploy-trail.sh
+++ b/deploy/deploy-trail.sh
@@ -38,6 +38,16 @@ if [ -f deploy/.env ]; then
 fi
 : "${MESA_NODE_HOST:?MESA_NODE_HOST must be set in deploy/.env (see deploy/.env.example) or exported in the shell}"
 
+# The MinaGuard VK hash is a property of the contract source, not deploy-time
+# config — it's committed at contracts/.vk-hash. Read it from there (stripping
+# the comment header) unless explicitly overridden in the environment. The
+# backend image takes it as a build arg; the indexer filters events by it.
+if [ -z "${MINAGUARD_VK_HASH:-}" ] && [ -f contracts/.vk-hash ]; then
+  MINAGUARD_VK_HASH=$(grep -vE '^[[:space:]]*#' contracts/.vk-hash | tr -d '[:space:]')
+  export MINAGUARD_VK_HASH
+fi
+: "${MINAGUARD_VK_HASH:?contracts/.vk-hash parsed to empty — regenerate with: bun run --filter contracts build && bun run dev-helpers/cli.ts vk-hash compile}"
+
 COMMAND="${1:-}"
 PORT=10001
 CADDY_API="http://localhost:2019"
@@ -122,7 +132,7 @@ case "$COMMAND" in
 
     down)
         echo "Tearing down trail deployment..."
-        docker compose -p minaguard-trail down --remove-orphans --rmi local
+        docker compose -f deploy/docker-compose.trail.yml -p minaguard-trail down --remove-orphans --rmi local
         remove_caddy_route
         echo "Done."
         ;;

--- a/deploy/deploy-trail.sh
+++ b/deploy/deploy-trail.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# MinaGuard Mesa Trail Deployment
+#
+# Usage:
+#   ./deploy-trail.sh up      — deploy the trail (Mesa Trail / mesa-mut) compose project
+#   ./deploy-trail.sh down    — teardown (preserves db volume; pass -v manually to wipe)
+#
+# Runs on the prod-facing box alongside /app/* (localnet, `deploy.sh`) and
+# the PR previews (`preview-env/preview.sh`). All three patterns use the
+# same host Caddy admin API on localhost:2019 to dynamically add/remove
+# reverse-proxy routes, and each deploys to a separate per-project host
+# port (main=10000, previews=1000N, trail=10001).
+#
+# Cross-host dependency: the application stack here reaches the Mina node
+# stack on $MESA_NODE_HOST (ports 3085 + 8282). Before bringing this up,
+# confirm ufw on the node-stack box allows inbound 3085 + 8282 from this
+# server's public IP:
+#
+#   sudo ufw allow from <this-server's-public-IP> to any port 3085 proto tcp
+#   sudo ufw allow from <this-server's-public-IP> to any port 8282 proto tcp
+#
+# MESA_NODE_HOST is required — fill in deploy/.env (see deploy/.env.example)
+# or `export MESA_NODE_HOST=...` in the deploying shell before invoking this
+# script. There is no default — `docker compose up` fails fast if unset.
+#
+# Expects to be run from the repo root directory.
+
+set -euo pipefail
+
+# Pull deploy-time config from deploy/.env if present (gitignored). Then
+# enforce MESA_NODE_HOST is set so the failure is loud here, not buried
+# in docker compose's parser later.
+if [ -f deploy/.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . deploy/.env
+  set +a
+fi
+: "${MESA_NODE_HOST:?MESA_NODE_HOST must be set in deploy/.env (see deploy/.env.example) or exported in the shell}"
+
+COMMAND="${1:-}"
+PORT=10001
+CADDY_API="http://localhost:2019"
+ROUTES_PATH="apps/http/servers/srv0/routes/0/handle/0/routes"
+
+add_caddy_route() {
+    remove_caddy_route 2>/dev/null || true
+
+    local group
+    group=$(curl -s "${CADDY_API}/config/${ROUTES_PATH}/0" | python3 -c "import sys,json; print(json.load(sys.stdin).get('group','group0'))" 2>/dev/null || echo "group0")
+
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"@id\": \"trail-main\",
+          \"group\": \"${group}\",
+          \"match\": [{\"path\": [\"/trail\", \"/trail/*\"]}],
+          \"handle\": [{
+            \"handler\": \"subroute\",
+            \"routes\": [{
+              \"handle\": [
+                {
+                  \"handler\": \"headers\",
+                  \"response\": {
+                    \"set\": {
+                      \"Cross-Origin-Opener-Policy\": [\"same-origin\"],
+                      \"Cross-Origin-Embedder-Policy\": [\"credentialless\"]
+                    }
+                  }
+                },
+                {
+                  \"handler\": \"reverse_proxy\",
+                  \"headers\": {
+                    \"response\": {
+                      \"delete\": [\"Cross-Origin-Opener-Policy\", \"Cross-Origin-Embedder-Policy\"]
+                    }
+                  },
+                  \"upstreams\": [{\"dial\": \"localhost:${PORT}\"}]
+                }
+              ]
+            }]
+          }]
+        }" \
+        "${CADDY_API}/config/${ROUTES_PATH}")
+
+    if [ "$status" = "200" ]; then
+        echo "Caddy route added: /trail/ → localhost:${PORT}"
+    else
+        echo "ERROR: Failed to add Caddy route (HTTP ${status})"
+        exit 1
+    fi
+}
+
+remove_caddy_route() {
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+        "${CADDY_API}/id/trail-main")
+
+    if [ "$status" = "200" ]; then
+        echo "Caddy route removed for /trail"
+    elif [ "$status" = "404" ]; then
+        echo "No Caddy route found for /trail"
+    else
+        echo "ERROR: Failed to remove Caddy route (HTTP ${status})"
+        exit 1
+    fi
+}
+
+case "$COMMAND" in
+    up)
+        echo "Deploying trail (Mesa Trail) on port ${PORT}..."
+        docker compose -f deploy/docker-compose.trail.yml -p minaguard-trail up -d --build --remove-orphans
+        add_caddy_route
+
+        echo ""
+        echo "  App:       https://mina-nodes.duckdns.org/trail/"
+        echo "  Health:    https://mina-nodes.duckdns.org/trail/health"
+        echo "  GraphQL:   https://mina-nodes.duckdns.org/trail/graphql"
+        echo "  Archive:   https://mina-nodes.duckdns.org/trail/archive"
+        ;;
+
+    down)
+        echo "Tearing down trail deployment..."
+        docker compose -p minaguard-trail down --remove-orphans --rmi local
+        remove_caddy_route
+        echo "Done."
+        ;;
+
+    *)
+        echo "Usage: $0 {up|down}"
+        exit 1
+        ;;
+esac

--- a/deploy/docker-compose.trail.yml
+++ b/deploy/docker-compose.trail.yml
@@ -75,12 +75,21 @@ services:
         # Mesa Trail has no built-in faucet; point users at the public Mina
         # faucet (the o1js Mina.faucet() helper also targets this host with
         # `?network=mesa`).
-        - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mesa.minaexplorer.com
+        - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mina-nodes.duckdns.org/trail/explorer
         - NEXT_PUBLIC_POLL_INTERVAL_MS=1000
         - ENABLE_SOURCE_MAPS=false
     restart: unless-stopped
     depends_on:
       - backend
+
+  explorer:
+    build:
+      context: ../preview-env
+      dockerfile: Dockerfile.explorer
+      args:
+        - NEXT_PUBLIC_BASE_PATH=/trail/explorer
+        - TESTNET_GRAPHQL_URL=http://${MESA_NODE_HOST:?MESA_NODE_HOST must be set}:3085/graphql
+    restart: unless-stopped
 
   caddy:
     image: caddy:2
@@ -99,6 +108,7 @@ services:
     depends_on:
       - frontend
       - backend
+      - explorer
 
 volumes:
   minaguard-trail-db:

--- a/deploy/docker-compose.trail.yml
+++ b/deploy/docker-compose.trail.yml
@@ -76,6 +76,7 @@ services:
         # faucet (the o1js Mina.faucet() helper also targets this host with
         # `?network=mesa`).
         - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mesa.minaexplorer.com
+        - NEXT_PUBLIC_POLL_INTERVAL_MS=1000
         - ENABLE_SOURCE_MAPS=false
     restart: unless-stopped
     depends_on:

--- a/deploy/docker-compose.trail.yml
+++ b/deploy/docker-compose.trail.yml
@@ -1,0 +1,103 @@
+# MinaGuard Mesa Trail (mesa-mut) deployment.
+#
+# This compose project runs on the prod-facing box alongside the existing
+# /app/* (localnet) deploy and the PR previews. The application stack
+# (db + backend + frontend + inner Caddy) lives here; the Mina node stack
+# (daemon + archive + archive-node-api) lives on a separate box and is
+# reached over the network at:
+#   - daemon GraphQL    → ${MESA_NODE_HOST}:3085
+#   - archive-node-api  → ${MESA_NODE_HOST}:8282
+#
+# MESA_NODE_HOST is required — `docker compose up` fails if it's not set in
+# the deploying shell. See deploy/.env.example for the shape of the file
+# deploy-trail.sh sources; or just `export MESA_NODE_HOST=...` before running.
+# ufw on whichever box that resolves to must allow inbound 3085 + 8282 from
+# this server's IP — see MINA_GUARD_PRODUCTION.md §3.
+#
+# Usage:
+#   ./deploy/deploy-trail.sh up
+#   ./deploy/deploy-trail.sh down
+#
+# Coexists with `deploy/docker-compose.yml -p minaguard` (the localnet
+# deployment) and the per-PR preview projects from `preview-env/preview.sh`
+# — different project name, different volumes, different inner-Caddy port.
+
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=minaguard
+      - POSTGRES_PASSWORD=minaguard
+      - POSTGRES_DB=minaguard
+    volumes:
+      - minaguard-trail-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U minaguard"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  backend:
+    build:
+      context: ..
+      dockerfile: preview-env/Dockerfile.backend
+      args:
+        # Skip the (memory-heavy) in-image circuit compile — host computes the
+        # vk-hash once and threads it through. See preview-env/preview.sh for
+        # how the localnet/preview path does the same.
+        - MINAGUARD_VK_HASH=${MINAGUARD_VK_HASH:-}
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgresql://minaguard:minaguard@db:5432/minaguard
+      # The Mesa Trail node stack lives on a separate box. ufw on that box
+      # restricts ports 3085 + 8282 to inbound from this server's IP only.
+      - MINA_ENDPOINT=http://${MESA_NODE_HOST:?MESA_NODE_HOST must be set (see deploy/.env.example)}:3085/graphql
+      - ARCHIVE_ENDPOINT=http://${MESA_NODE_HOST:?MESA_NODE_HOST must be set (see deploy/.env.example)}:8282
+      - PORT=4000
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: preview-env/Dockerfile.frontend
+      args:
+        # Public-facing URLs that the browser hits. Mirrors the localnet deploy's
+        # /app/* convention but under /trail/*. Substitute the actual host
+        # if you're not using mina-nodes.duckdns.org.
+        - NEXT_PUBLIC_BASE_PATH=/trail
+        - NEXT_PUBLIC_API_BASE_URL=https://mina-nodes.duckdns.org/trail
+        - NEXT_PUBLIC_MINA_ENDPOINT=https://mina-nodes.duckdns.org/trail/graphql
+        - NEXT_PUBLIC_ARCHIVE_ENDPOINT=https://mina-nodes.duckdns.org/trail/archive
+        - NEXT_PUBLIC_MINA_NETWORK=testnet
+        # Mesa Trail has no built-in faucet; point users at the public Mina
+        # faucet (the o1js Mina.faucet() helper also targets this host with
+        # `?network=mesa`).
+        - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mesa.minaexplorer.com
+        - ENABLE_SOURCE_MAPS=false
+    restart: unless-stopped
+    depends_on:
+      - backend
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    # Inner Caddy for this compose project. Listens on container :80, host-
+    # published at :10001. The outer host Caddy on this same box reverse-proxies
+    # /trail, /trail/* to localhost:10001 (see deploy-trail.sh add_caddy_route).
+    ports:
+      - "10001:80"
+    volumes:
+      - ./Caddyfile.trail:/etc/caddy/Caddyfile:ro
+    # Pass MESA_NODE_HOST into the caddy container so the Caddyfile's
+    # {$MESA_NODE_HOST} substitution resolves to the node-stack address.
+    environment:
+      - MESA_NODE_HOST=${MESA_NODE_HOST:?MESA_NODE_HOST must be set (see deploy/.env.example)}
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  minaguard-trail-db:

--- a/dev-helpers/commands/vk-hash-compile.ts
+++ b/dev-helpers/commands/vk-hash-compile.ts
@@ -1,20 +1,29 @@
-import { MinaGuard } from "contracts"
 import { Cache } from "o1js";
+import { execSync } from "node:child_process";
 
 /** Reads MinaGuard verification key hash from local contract compilation output. */
 export async function runVkHashCompile(): Promise<void> {
-  console.log('Compiling MinaGuard to extract verification key hash...');
+  // The VK is derived from the COMPILED contract. contracts/build is gitignored
+  // and is easily stale on a dev machine — it won't reflect contracts/src edits
+  // until rebuilt, which would silently yield a VK hash for OLD contract logic.
+  // (This was the "Node vs browser VK divergence" red herring: really a stale
+  // host build vs a fresh Docker build.) Rebuild from source first so the hash
+  // always matches current contracts/src, in every environment.
+  console.log('Rebuilding contracts from source so the VK matches current contracts/src...');
+  execSync('bun run --filter contracts build', { stdio: 'inherit' });
 
+  // Dynamic import AFTER the rebuild so we load the freshly-built output.
+  const { MinaGuard } = await import("contracts");
   if (!MinaGuard || typeof MinaGuard.compile !== 'function') {
     throw new Error(
       'Could not load MinaGuard from contracts build output. Rebuild with `bun run --filter contracts build`.'
     );
   }
 
+  console.log('Compiling MinaGuard to extract verification key hash...');
   const cache = Cache.FileSystem('./cache');
   const { verificationKey } = await MinaGuard.compile({ cache });
-  const hashValue = verificationKey?.hash;
-  const hashText = hashValue?.toString?.();
+  const hashText = verificationKey?.hash?.toString?.();
 
   if (!hashText) {
     throw new Error('Failed to read verification key hash from compile output.');

--- a/dev-helpers/package.json
+++ b/dev-helpers/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "commander": "^13.1.0",
-    "o1js": "https://pkg.pr.new/o1-labs/o1js@2701",
+    "o1js": "3.0.0-mesa.final",
     "contracts": "workspace:*"
   },
   "devDependencies": {

--- a/offline-cli/src/wasm-shim.ts
+++ b/offline-cli/src/wasm-shim.ts
@@ -1,20 +1,12 @@
 // @ts-nocheck
 // Embed the plonk WASM binary so the compiled binary is fully self-contained.
-// Bun embeds imported file assets into its $bunfs virtual filesystem.
-// We patch the CJS require("fs").readFileSync to redirect WASM loads.
+// Bun embeds imported file assets into its $bunfs virtual filesystem; we patch
+// the CJS require("fs").readFileSync to redirect WASM loads to the embedded copy.
 //
-// Filesystem-relative import that goes through the top-level
-// node_modules/o1js/ symlink that bun creates on workspace install — stable
-// across npm-vs-github cache layouts (i.e., whether bun cached o1js as
-// .bun/o1js@<version>/ for npm or .bun/o1js@github+.../ for a github dep).
-// A package-name import (`o1js/dist/...`) would be cleaner but doesn't work:
-// o1js's package.json declares a conditional `exports` field, which blocks
-// any subpath that isn't explicitly exported.
-//
-// Previous versions of this file imported through `.bun/o1js@github+
-// mellowcroc+o1js+e0a1022/...` — that hardcoded a specific bun cache key
-// for the old mesa-srs-fix fork, and broke when we bumped to
-// o1js@3.0.0-mesa.final on npm (the cache key changed).
+// The import path is filesystem-relative (through the top-level node_modules/o1js
+// symlink) rather than a package import (`o1js/dist/...`): o1js's package.json
+// declares a conditional `exports` field that blocks any subpath not explicitly
+// exported, so the package-style import fails to resolve.
 import embeddedWasmPath from "../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/plonk_wasm_bg.wasm";
 
 const nodeFs = require("fs");

--- a/offline-cli/src/wasm-shim.ts
+++ b/offline-cli/src/wasm-shim.ts
@@ -2,8 +2,20 @@
 // Embed the plonk WASM binary so the compiled binary is fully self-contained.
 // Bun embeds imported file assets into its $bunfs virtual filesystem.
 // We patch the CJS require("fs").readFileSync to redirect WASM loads.
-
-import embeddedWasmPath from "../../node_modules/.bun/o1js@github+mellowcroc+o1js+e0a1022/node_modules/o1js/dist/node/bindings/compiled/node_bindings/plonk_wasm_bg.wasm";
+//
+// Filesystem-relative import that goes through the top-level
+// node_modules/o1js/ symlink that bun creates on workspace install — stable
+// across npm-vs-github cache layouts (i.e., whether bun cached o1js as
+// .bun/o1js@<version>/ for npm or .bun/o1js@github+.../ for a github dep).
+// A package-name import (`o1js/dist/...`) would be cleaner but doesn't work:
+// o1js's package.json declares a conditional `exports` field, which blocks
+// any subpath that isn't explicitly exported.
+//
+// Previous versions of this file imported through `.bun/o1js@github+
+// mellowcroc+o1js+e0a1022/...` — that hardcoded a specific bun cache key
+// for the old mesa-srs-fix fork, and broke when we bumped to
+// o1js@3.0.0-mesa.final on npm (the cache key changed).
+import embeddedWasmPath from "../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/plonk_wasm_bg.wasm";
 
 const nodeFs = require("fs");
 const _origReadFileSync = nodeFs.readFileSync;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck": "bun run --filter contracts typecheck && bun run --filter backend build"
   },
   "dependencies": {
-    "o1js": "github:mellowcroc/o1js#mesa-srs-fix"
+    "o1js": "3.0.0-mesa.final"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/preview-env/docker-compose.e2e-ci.yml
+++ b/preview-env/docker-compose.e2e-ci.yml
@@ -3,6 +3,12 @@
 # Playwright runs on the host; all infrastructure lives in containers.
 # Ports are published to 127.0.0.1 only (self-hosted runner has a public IP).
 #
+# Host ports are published in an isolated 1xxxx range (container ports unchanged)
+# so the stack never collides with other long-lived services on the shared
+# self-hosted runner (e.g. host postgres on 5432, other apps on 8080/8282).
+# The host-facing endpoints are passed to the test harness via E2E_* env vars
+# in .github/workflows/e2e.yml; internal service-to-service URLs are unchanged.
+#
 # Usage:
 #   MINAGUARD_VK_HASH=skip docker compose -f preview-env/docker-compose.e2e-ci.yml -p mina-guard-e2e up -d --build --wait
 #   docker compose -f preview-env/docker-compose.e2e-ci.yml -p mina-guard-e2e down -v
@@ -18,9 +24,9 @@ services:
       - NETWORK_TYPE=single-node
       - LOG_LEVEL=Info
     ports:
-      - "127.0.0.1:8080:8080"
-      - "127.0.0.1:8181:8181"
-      - "127.0.0.1:8282:8282"
+      - "127.0.0.1:18080:8080"
+      - "127.0.0.1:18181:8181"
+      - "127.0.0.1:18282:8282"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ syncStatus }\"}' http://localhost:8080/graphql"]
       interval: 10s
@@ -36,7 +42,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=minaguard
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:15432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -58,7 +64,7 @@ services:
       - PORT=4000
       - INDEX_POLL_INTERVAL_MS=5000
     ports:
-      - "127.0.0.1:4000:4000"
+      - "127.0.0.1:14000:4000"
     depends_on:
       lightnet:
         condition: service_healthy
@@ -70,14 +76,14 @@ services:
       context: ..
       dockerfile: preview-env/Dockerfile.frontend
       args:
-        - NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
-        - NEXT_PUBLIC_MINA_ENDPOINT=http://localhost:8080/graphql
-        - NEXT_PUBLIC_ARCHIVE_ENDPOINT=http://localhost:8282
+        - NEXT_PUBLIC_API_BASE_URL=http://localhost:14000
+        - NEXT_PUBLIC_MINA_ENDPOINT=http://localhost:18080/graphql
+        - NEXT_PUBLIC_ARCHIVE_ENDPOINT=http://localhost:18282
         - NEXT_PUBLIC_E2E_TEST=true
         - NEXT_PUBLIC_POLL_INTERVAL_MS=3000
         - NEXT_PUBLIC_MINA_NETWORK=testnet
     restart: "no"
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:13000:3000"
     depends_on:
       - backend


### PR DESCRIPTION
- deploys alongside the existing deployments (`/app` and `/preview/N` PR previews)
  - Mesa Trail archive node runs on a separate machine
  - backend reaches the node machine over the network on ports 3085 + 8282
- update o1js deps to `3.0.0-mesa.final`
- add `contracts/.vk-hash`, which is used as a single source-of-truth for the contract verifier key
- add `check-vk-hash` workflow, which checks whether `contracts/.vk-hash` needs to be updated or not by looking at if the contract changed or the o1js dependency changed
- bump o1js to 3.0.0-mesa.final, which contains the following fixes (https://github.com/o1-labs/o1js/pull/2866, https://github.com/o1-labs/o1js/pull/2869)
- fix e2e port conflict issue