### PR TITLE
Add archive-postgres discovery backend

### DIFF
--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -10,11 +10,14 @@
 #
 #   - MESA_NODE_HOST       IP/host of the standalone Mesa Trail node stack
 #                          REQUIRED — docker-compose.trail.yml asserts it.
+#   - ARCHIVE_DB_PASSWORD  Password for the read-only `minaguard_ro` role
+#                          on the node-stack box's archive postgres. REQUIRED —
+#                          docker-compose.trail.yml asserts it.
 #
 # The MinaGuard VK hash is NOT a secret — it's committed at
 # contracts/.vk-hash and read automatically by deploy-trail.sh.
 #
-# To bootstrap: add MESA_NODE_HOST, then merge a PR to main (or trigger
+# To bootstrap: add the secrets above, then merge a PR to main (or trigger
 # via `gh workflow run deploy-trail.yml`).
 #
 # To tighten later: add a `paths:` filter under `on.push` so this only
@@ -49,6 +52,7 @@ jobs:
         # The VK hash is read from contracts/.vk-hash by deploy-trail.sh.
         env:
           MESA_NODE_HOST: ${{ secrets.MESA_NODE_HOST }}
+          ARCHIVE_DB_PASSWORD: ${{ secrets.ARCHIVE_DB_PASSWORD }}
         run: |
           chmod +x deploy/deploy-trail.sh
           ./deploy/deploy-trail.sh up

--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -44,17 +44,20 @@ jobs:
           submodules: recursive
 
       - name: Deploy
-        # deploy-trail.sh runs `docker compose ... up -d --build` for the
-        # minaguard-trail compose project on host port 10001, then adds the
-        # /trail, /trail/* route to the host Caddy via admin API on
-        # localhost:2019 (mirrors deploy.sh add_caddy_route + COOP/COEP).
-        # Idempotent — safe to re-run on every main push.
-        # The VK hash is read from contracts/.vk-hash by deploy-trail.sh.
+        # `down` wipes the app DB volume before `up` rebuilds. Mirrors the
+        # main deploy's reasoning: the MinaGuard contract changes per PR
+        # merge, the VK hash changes with it, and the indexer filters
+        # discovery by VK hash — so any previously-indexed Contract rows
+        # point at addresses deployed with the old VK that the new
+        # indexer would skip anyway. Wiping is cleaner than carrying dead
+        # rows forward. When the contract stabilizes, switch back to
+        # `up`-only to get persistence.
         env:
           MESA_NODE_HOST: ${{ secrets.MESA_NODE_HOST }}
           ARCHIVE_DB_PASSWORD: ${{ secrets.ARCHIVE_DB_PASSWORD }}
         run: |
           chmod +x deploy/deploy-trail.sh
+          ./deploy/deploy-trail.sh down
           ./deploy/deploy-trail.sh up
 
       - name: Wait for trail backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,11 +18,13 @@
     "contracts": "workspace:*",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "pg": "^8.13.1",
     "zod": "^3.25"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/pg": "^8.11.10",
     "prisma": "6.12.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -11,6 +11,22 @@ export interface BackendConfig {
   indexStartHeight: number;
   minaguardVkHash: string | null;
   indexerMode: 'full' | 'lite';
+  /** Where to source candidate addresses for contract discovery.
+   *  - 'daemon': scan daemon's bestChain — capped at 290 blocks back.
+   *  - 'archive': query Mina archive postgres directly — unbounded history. */
+  discoveryBackend: 'daemon' | 'archive';
+  /** Read-only Mina archive postgres connection (required when discoveryBackend='archive').
+   *  Discrete parts so reserved characters in the password don't need URL-encoding. */
+  archiveDb: ArchiveDbConfig | null;
+}
+
+/** Discrete postgres connection params for the Mina archive read replica. */
+export interface ArchiveDbConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
 }
 
 /** Throws if a required environment variable is missing or empty. */
@@ -45,6 +61,29 @@ export function loadConfig(): BackendConfig {
   }
   const indexerMode: 'full' | 'lite' = rawMode;
 
+  const rawDiscoveryBackend = process.env.DISCOVERY_BACKEND ?? 'daemon';
+  if (rawDiscoveryBackend !== 'daemon' && rawDiscoveryBackend !== 'archive') {
+    throw new Error(
+      `Env var DISCOVERY_BACKEND must be 'daemon' or 'archive', got: "${rawDiscoveryBackend}"`,
+    );
+  }
+  const discoveryBackend: 'daemon' | 'archive' = rawDiscoveryBackend;
+  let archiveDb: ArchiveDbConfig | null = null;
+  if (discoveryBackend === 'archive') {
+    if (!process.env.MINAGUARD_VK_HASH) {
+      throw new Error(
+        "DISCOVERY_BACKEND=archive requires MINAGUARD_VK_HASH to be set — the archive postgres query filters on the VK hash to keep results bounded. Without it, the indexer would silently fall back to the 290-block daemon scan, defeating the point of switching backends.",
+      );
+    }
+    archiveDb = {
+      host: requireEnv('ARCHIVE_DB_HOST'),
+      port: numericEnv('ARCHIVE_DB_PORT', 5432),
+      user: requireEnv('ARCHIVE_DB_USER'),
+      password: requireEnv('ARCHIVE_DB_PASSWORD'),
+      database: requireEnv('ARCHIVE_DB_NAME'),
+    };
+  }
+
   return {
     port,
     databaseUrl,
@@ -57,5 +96,7 @@ export function loadConfig(): BackendConfig {
     indexStartHeight: numericEnv('INDEX_START_HEIGHT', 0),
     minaguardVkHash: process.env.MINAGUARD_VK_HASH ?? null,
     indexerMode,
+    discoveryBackend,
+    archiveDb,
   };
 }

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -1,3 +1,4 @@
+import pg from 'pg';
 import { prisma } from './db.js';
 import type { BackendConfig } from './config.js';
 import { PublicKey } from 'o1js';
@@ -5,10 +6,12 @@ import { memoToField, decodeTxMemo } from 'contracts';
 import {
   configureNetwork,
   discoverCandidateAddresses,
+  discoverCandidateAddressesFromArchive,
   fetchBestChainHeaders,
   fetchDecodedContractEvents,
   fetchGenesisConstants,
   fetchLatestBlockHeight,
+  fetchLatestBlockHeightFromArchive,
   fetchOnChainState,
   fetchVerificationKeyHash,
   fetchZkappTxStatus,
@@ -55,6 +58,7 @@ export class MinaGuardIndexer {
   private readonly config: BackendConfig;
   private intervalHandle: NodeJS.Timeout | null = null;
   private genesis: GenesisConstants | null = null;
+  private archivePool: pg.Pool | null = null;
   private status: Omit<IndexerStatus, 'indexerMode'> = {
     running: false,
     lastRunAt: null,
@@ -90,6 +94,35 @@ export class MinaGuardIndexer {
       this.intervalHandle = null;
     }
     this.status.running = false;
+    if (this.archivePool) {
+      const pool = this.archivePool;
+      this.archivePool = null;
+      pool.end().catch((error) => {
+        console.error('[indexer] archivePool.end() failed during shutdown:', error);
+      });
+    }
+  }
+
+  /** Lazily constructs the read-only archive postgres pool when discoveryBackend='archive'. */
+  private getArchivePool(): pg.Pool {
+    if (!this.archivePool) {
+      if (!this.config.archiveDb) {
+        throw new Error('archiveDb is required for archive discovery backend');
+      }
+      this.archivePool = new pg.Pool({
+        ...this.config.archiveDb,
+        max: 2,
+        idleTimeoutMillis: 30_000,
+        // Cap how long a wedged archive postgres can hang the indexer for.
+        // Without these, a network blackhole or DB lockup makes every tick
+        // block until the kernel TCP timeout (minutes), starving everything
+        // downstream.
+        connectionTimeoutMillis: 5_000,
+        statement_timeout: 30_000,
+        query_timeout: 30_000,
+      });
+    }
+    return this.archivePool;
   }
 
   /** Returns the latest in-memory indexer status snapshot. Does not include `indexerMode` — the route layer adds it from config. */
@@ -102,7 +135,9 @@ export class MinaGuardIndexer {
     this.status.lastRunAt = new Date().toISOString();
 
     try {
-      const latestHeight = await fetchLatestBlockHeight(this.config);
+      const latestHeight = this.config.discoveryBackend === 'archive'
+        ? await fetchLatestBlockHeightFromArchive(this.getArchivePool())
+        : await fetchLatestBlockHeight(this.config);
       this.status.latestChainHeight = latestHeight;
       if (this.genesis) {
         const elapsed = Date.now() - this.genesis.genesisTimestampMs;
@@ -128,20 +163,52 @@ export class MinaGuardIndexer {
       const fromHeight = indexedHeight + 1;
       const toHeight = latestHeight;
 
-      // Scan bestChain for new contract deployments. Only look at the
-      // un-indexed delta plus a small margin for the race where a block lands
-      // between the latestHeight read and the bestChain call. Clamped to 290
-      // (Mina's bestChain cap); reorg safety is handled by detectAndRollbackReorg
-      // above, which rewinds IndexerCursor on fork — the next tick's window
-      // naturally re-covers the reorged range. Lite mode skips discovery
-      // entirely and tracks only contracts added via the /subscribe route.
+      // Scan for new contract deployments. The candidate-address source is
+      // pluggable: 'daemon' scans bestChain (capped at 290 blocks — see Mina's
+      // transition-frontier limit), 'archive' queries the archive postgres
+      // directly and has no horizon. Lite mode skips discovery entirely and
+      // tracks only contracts added via the /subscribe route. Reorg safety is
+      // handled by detectAndRollbackReorg above, which rewinds IndexerCursor
+      // on fork — the next tick re-covers the reorged range.
       if (this.config.indexerMode === 'full') {
         const DISCOVERY_MARGIN = 5;
-        const discoveryWindow = Math.max(
-          1,
-          Math.min(290, latestHeight - indexedHeight + DISCOVERY_MARGIN),
-        );
-        await this.discoverContracts(discoveryWindow, latestHeight);
+        let candidates: string[];
+        if (this.config.discoveryBackend === 'archive' && this.config.minaguardVkHash) {
+          // Cold start (no archive_discovered_height cursor): scan from
+          // indexStartHeight back to genesis-or-configured-floor so historical
+          // deploys are picked up. Subsequent ticks scan only the new delta
+          // plus a small reorg margin. The archive query filters by MinaGuard's
+          // VK hash, so even a from-genesis scan returns a tiny row set.
+          const lastDiscovered = await this.getArchiveDiscoveredHeight();
+          const discoveryFromHeight = lastDiscovered === null
+            ? this.config.indexStartHeight
+            : Math.max(this.config.indexStartHeight, lastDiscovered - DISCOVERY_MARGIN);
+          candidates = await discoverCandidateAddressesFromArchive(
+            this.getArchivePool(),
+            this.config.minaguardVkHash,
+            discoveryFromHeight,
+            latestHeight,
+          );
+        } else {
+          const discoveryWindow = Math.max(
+            1,
+            Math.min(290, latestHeight - indexedHeight + DISCOVERY_MARGIN),
+          );
+          candidates = await discoverCandidateAddresses(this.config, discoveryWindow);
+        }
+        const failureCount = await this.processCandidateAddresses(candidates, latestHeight);
+        if (this.config.discoveryBackend === 'archive' && failureCount === 0) {
+          // Only advance the cursor when every candidate was either inserted
+          // or intentionally skipped (existing / VK mismatch). If any candidate
+          // threw, keep the cursor where it was so the next tick re-scans the
+          // same range and gets another shot at the transient failure. The
+          // re-scan is cheap (single VK-filtered SQL returning a tiny row set)
+          // and existing-row dedup makes successful inserts from this tick
+          // skipped harmlessly next time. Without this gate, a pre-create
+          // failure (e.g. a flaky VK fetch via the daemon) would silently
+          // drop the candidate forever once the cursor moved past its block.
+          await this.setArchiveDiscoveredHeight(latestHeight);
+        }
       }
 
       // Rescan contracts that haven't yet seen a MinaGuard event. Runs
@@ -172,32 +239,59 @@ export class MinaGuardIndexer {
     return detectAndRollbackReorg(this.config);
   }
 
-  /** Discovers candidate contracts and stores verified MinaGuard addresses. */
-  private async discoverContracts(blockWindow: number, latestHeight: number): Promise<void> {
-    const candidates = await discoverCandidateAddresses(this.config, blockWindow);
+  /**
+   * Inserts new contracts for any candidate addresses that aren't already tracked
+   * and whose on-chain VK matches the configured MinaGuard hash. Candidates come
+   * from either the daemon bestChain scan or the archive postgres scan — both
+   * branches funnel through here so the dedup, VK re-verification, and backfill
+   * logic stays in one place.
+   *
+   * Returns the count of candidates that threw — the archive branch in tick()
+   * uses this to decide whether to advance the archive_discovered_height
+   * cursor (only advances when 0 failures, so transient failures get retried
+   * on the next tick instead of being dropped past the cursor).
+   *
+   * The on-chain VK re-fetch via the daemon stays in place even for the archive
+   * branch: it's cheap (one fetchAccount per new candidate, only on the first
+   * sighting), and it catches the edge case where the archive shows a VK install
+   * that has since been upgraded to a different VK on chain.
+   */
+  private async processCandidateAddresses(addresses: string[], latestHeight: number): Promise<number> {
+    let failureCount = 0;
+    for (const address of addresses) {
+      try {
+        const existing = await prisma.contract.findUnique({ where: { address } });
+        if (existing) continue;
 
-    for (const address of candidates) {
-      const existing = await prisma.contract.findUnique({ where: { address } });
-      if (existing) continue;
+        const verificationKeyHash = await fetchVerificationKeyHash(address);
+        if (!verificationKeyHash) continue;
 
-      const verificationKeyHash = await fetchVerificationKeyHash(address);
-      if (!verificationKeyHash) continue;
+        if (
+          this.config.minaguardVkHash &&
+          verificationKeyHash !== this.config.minaguardVkHash
+        ) {
+          continue;
+        }
 
-      if (
-        this.config.minaguardVkHash &&
-        verificationKeyHash !== this.config.minaguardVkHash
-      ) {
-        continue;
+        const created = await prisma.contract.create({
+          data: { address, discoveredAtBlock: latestHeight },
+        });
+
+        await this.backfillContract(created.id, address);
+      } catch (error) {
+        // Per-candidate isolation: a single bad apple (e.g. archive-node-api
+        // hiccup during backfill, transient daemon error during VK fetch)
+        // must not abort the whole batch. The caller uses the returned count
+        // to gate cursor advancement, so transient failures get retried on
+        // the next tick.
+        failureCount += 1;
+        const msg = error instanceof Error ? error.message : String(error);
+        console.error(`[indexer] processCandidateAddresses failed for ${address}: ${msg}`);
       }
-
-      const created = await prisma.contract.create({
-        data: { address, discoveredAtBlock: latestHeight },
-      });
-
-      await this.backfillContract(created.id, address);
     }
 
     this.status.discoveredContracts = await prisma.contract.count();
+    return failureCount;
   }
 
   /**
@@ -1042,6 +1136,28 @@ export class MinaGuardIndexer {
     await prisma.indexerCursor.upsert({
       where: { key: 'indexed_height' },
       create: { key: 'indexed_height', value: String(height) },
+      update: { value: String(height) },
+    });
+  }
+
+  /**
+   * Returns the highest block height that's been scanned for archive-discovery,
+   * or null if archive discovery has never run on this DB. Tracked separately
+   * from `indexed_height` so that switching DISCOVERY_BACKEND from 'daemon' to
+   * 'archive' triggers a from-genesis sweep instead of inheriting the (much
+   * narrower) daemon cursor's position.
+   */
+  private async getArchiveDiscoveredHeight(): Promise<number | null> {
+    const cursor = await prisma.indexerCursor.findUnique({
+      where: { key: 'archive_discovered_height' },
+    });
+    return cursor ? Number(cursor.value) : null;
+  }
+
+  private async setArchiveDiscoveredHeight(height: number): Promise<void> {
+    await prisma.indexerCursor.upsert({
+      where: { key: 'archive_discovered_height' },
+      create: { key: 'archive_discovered_height', value: String(height) },
       update: { value: String(height) },
     });
   }

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -295,11 +295,23 @@ export class MinaGuardIndexer {
   }
 
   /**
-   * Backfills events for a newly tracked contract. In full mode the backfill
-   * spans 300 blocks (bestChain window — the contract was just discovered there,
-   * so any earlier events are out of reorg range anyway). In lite mode the
-   * backfill starts at config.indexStartHeight (default 0) so a cold-started
-   * indexer pulls full history for any user-subscribed contract.
+   * Backfills events for a newly tracked contract. The lower bound depends on
+   * how the contract was sourced:
+   *
+   *   - Lite mode (user-subscribed via /api/subscribe with fromBlock=0) →
+   *     config.indexStartHeight (default 0). Full history fetch.
+   *   - Full mode + archive discovery → also config.indexStartHeight, because
+   *     archive-discovery can surface contracts deployed at arbitrary
+   *     historical heights and the 300-block guard below would lose every
+   *     event between the deploy block and (indexedHeight - 300).
+   *   - Full mode + daemon discovery → max(0, indexedHeight - 300). The 300
+   *     is a safe margin around Mina's ~290-block bestChain horizon: daemon
+   *     discovery could only have surfaced the contract from within that
+   *     window, so a 300-block backfill is guaranteed to cover the deploy.
+   *
+   * archive-node-api supports `from: 0` natively, so the from-genesis branches
+   * don't require direct postgres access — they just work harder against the
+   * same `events(input:{address, from, to})` endpoint o1js calls.
    *
    * Readiness is flipped by syncSingleContract on first event ingestion —
    * a subscribed-before-deploy contract returns from here with ready=false
@@ -311,7 +323,8 @@ export class MinaGuardIndexer {
   async backfillContract(contractId: number, address: string): Promise<void> {
     const indexedHeight = await this.getIndexedHeight();
     const backfillFrom =
-      this.config.indexerMode === 'lite'
+      this.config.indexerMode === 'lite' ||
+      this.config.discoveryBackend === 'archive'
         ? this.config.indexStartHeight
         : Math.max(0, indexedHeight - 300);
     if (indexedHeight > backfillFrom) {

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -1,5 +1,6 @@
 import { Mina, PublicKey, fetchAccount, UInt32 } from 'o1js';
 import { MinaGuard } from 'contracts';
+import type { Pool } from 'pg';
 import type { BackendConfig, } from './config.js';
 
 const EMPTY_PUBLIC_KEY = PublicKey.empty().toBase58();
@@ -139,6 +140,20 @@ export async function fetchLatestBlockHeight(config: BackendConfig): Promise<num
 }
 
 /**
+ * Same as fetchLatestBlockHeight but reads directly from the archive postgres
+ * (when DISCOVERY_BACKEND=archive). Bypasses archive-node-api, which has been
+ * observed to return generic "Unexpected error." responses on the networkState
+ * query when the underlying daemon is mid-block; postgres always has the
+ * latest persisted block height.
+ */
+export async function fetchLatestBlockHeightFromArchive(pool: Pool): Promise<number> {
+  const result = await pool.query<{ max: string | null }>(
+    `SELECT MAX(height)::text AS max FROM blocks WHERE chain_status <> 'orphaned'`,
+  );
+  return Number(result.rows[0]?.max ?? '0');
+}
+
+/**
  * Discovers candidate zkApp addresses by scanning recent best-chain zkApp account updates.
  * Candidates are later verified via verification key hash.
  */
@@ -204,6 +219,62 @@ export async function discoverCandidateAddresses(
   }
 
   return [...addresses];
+}
+
+/**
+ * Discovers candidate zkApp addresses by querying the Mina archive postgres directly,
+ * filtered to account updates that install MinaGuard's verification key. Unlike the
+ * daemon's bestChain scan (capped at 290 blocks), this reaches arbitrary history.
+ *
+ * Returns addresses from blocks where:
+ *   - chain_status != 'orphaned'  (canonical OR pending — see TODO below)
+ *   - the account update set a verification_key whose hash matches vkHash
+ *   - the containing zkapp_command was applied (not failed)
+ *   - the block height is in [fromHeight, toHeight] inclusive
+ *
+ * TODO(reorg-safety): we include `chain_status = 'pending'` so freshly-deployed
+ * contracts (the last ~k blocks) become discoverable without waiting for them
+ * to finalize. But `detectAndRollbackReorg` only rewinds event rows, not the
+ * Contract table — so if a pending block later orphans, its Contract row is
+ * never cleaned up and the indexer ends up tracking a deploy that didn't
+ * happen. Acceptable on mesa-mut (reorg risk ~0 on a low-stakes testnet);
+ * UNSAFE on mainnet. Before a mainnet deploy: either restrict to
+ * `chain_status = 'canonical'` (and accept a ~k-block discovery lag), or
+ * add a periodic reconciliation that deletes Contract rows whose
+ * discoveredAtBlock has since orphaned.
+ *
+ * The join shape matches the upstream Mina archive schema verified against the
+ * mesa-mut archive (45-table layout, zkapp_verification_key_hashes split from
+ * zkapp_verification_keys). If the archive schema shifts in a future Mina release,
+ * this query needs revisiting.
+ */
+export async function discoverCandidateAddressesFromArchive(
+  pool: Pool,
+  vkHash: string,
+  fromHeight: number,
+  toHeight: number,
+): Promise<string[]> {
+  const result = await pool.query<{ address: string }>(
+    `
+    SELECT DISTINCT pk.value AS address
+    FROM zkapp_account_update_body zaub
+    JOIN zkapp_updates zu ON zu.id = zaub.update_id
+    JOIN zkapp_verification_keys vk ON vk.id = zu.verification_key_id
+    JOIN zkapp_verification_key_hashes vkh ON vkh.id = vk.hash_id
+    JOIN account_identifiers ai ON ai.id = zaub.account_identifier_id
+    JOIN public_keys pk ON pk.id = ai.public_key_id
+    JOIN zkapp_account_update zau ON zau.body_id = zaub.id
+    JOIN zkapp_commands zc ON zau.id = ANY(zc.zkapp_account_updates_ids)
+    JOIN blocks_zkapp_commands bzc
+      ON bzc.zkapp_command_id = zc.id AND bzc.status = 'applied'
+    JOIN blocks b ON b.id = bzc.block_id
+    WHERE vkh.value = $1
+      AND b.chain_status <> 'orphaned'
+      AND b.height BETWEEN $2 AND $3
+    `,
+    [vkHash, fromHeight, toHeight],
+  );
+  return result.rows.map((r) => r.address);
 }
 
 /** Reads the current verification key hash for an account if present. */

--- a/backend/src/tests/indexer-archive-discovery.test.ts
+++ b/backend/src/tests/indexer-archive-discovery.test.ts
@@ -1,0 +1,252 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PrivateKey } from 'o1js';
+import type { BackendConfig } from '../config.js';
+import { prisma } from '../db.js';
+import { MinaGuardIndexer } from '../indexer.js';
+import * as minaClient from '../mina-client.js';
+
+const VK_HASH = '22592591136635241954458728867125272730912271761728581931779127524287952990537';
+
+const archiveConfig = {
+  minaEndpoint: 'http://stub',
+  minaFallbackEndpoint: null,
+  archiveEndpoint: 'http://stub',
+  archiveFallbackEndpoint: null,
+  indexPollIntervalMs: 1000,
+  indexStartHeight: 0,
+  minaguardVkHash: VK_HASH,
+  lightnetAccountManager: null,
+  indexerMode: 'full' as const,
+  discoveryBackend: 'archive' as const,
+  archiveDb: {
+    host: 'stub-host',
+    port: 5432,
+    user: 'stub-user',
+    password: 'stub-pass',
+    database: 'stub-db',
+  },
+} as unknown as BackendConfig;
+
+async function clearAll() {
+  await prisma.approval.deleteMany();
+  await prisma.proposalExecution.deleteMany();
+  await prisma.proposalReceiver.deleteMany();
+  await prisma.eventRaw.deleteMany();
+  await prisma.proposal.deleteMany();
+  await prisma.ownerMembership.deleteMany();
+  await prisma.contractConfig.deleteMany();
+  await prisma.contract.deleteMany();
+  await prisma.blockHeader.deleteMany();
+  await prisma.indexerCursor.deleteMany();
+}
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+afterAll(async () => {
+  await clearAll();
+  await prisma.$disconnect();
+});
+
+describe('archive discovery: happy path', () => {
+  test('discovers contracts returned by archive query and advances archive_discovered_height cursor', async () => {
+    const addrs = [
+      PrivateKey.random().toPublicKey().toBase58(),
+      PrivateKey.random().toPublicKey().toBase58(),
+      PrivateKey.random().toPublicKey().toBase58(),
+    ];
+
+    let archiveQueryCalledWith: { from: number; to: number } | null = null;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
+      fetchLatestBlockHeightFromArchive: async () => 1000,
+      fetchBestChainHeaders: async () => [],
+      discoverCandidateAddressesFromArchive: async (
+        _pool: unknown,
+        _vkHash: string,
+        from: number,
+        to: number,
+      ) => {
+        archiveQueryCalledWith = { from, to };
+        return addrs;
+      },
+      // All 3 candidates verify with the matching MinaGuard VK on-chain.
+      fetchVerificationKeyHash: async () => VK_HASH,
+      // Backfill is a no-op (no events emitted yet).
+      fetchDecodedContractEvents: async () => [],
+    }));
+
+    const indexer = new MinaGuardIndexer(archiveConfig);
+    await indexer.start();
+    indexer.stop();
+
+    // Archive scan covers [indexStartHeight, latestHeight] on cold start.
+    expect(archiveQueryCalledWith).toEqual({ from: 0, to: 1000 });
+
+    const contracts = await prisma.contract.findMany({ orderBy: { address: 'asc' } });
+    expect(contracts.map((c) => c.address).sort()).toEqual([...addrs].sort());
+
+    const cursor = await prisma.indexerCursor.findUnique({
+      where: { key: 'archive_discovered_height' },
+    });
+    expect(cursor?.value).toBe('1000');
+  });
+
+  test('skips candidates whose on-chain VK no longer matches (e.g. VK got upgraded after deploy)', async () => {
+    const matching = PrivateKey.random().toPublicKey().toBase58();
+    const mismatched = PrivateKey.random().toPublicKey().toBase58();
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
+      fetchLatestBlockHeightFromArchive: async () => 500,
+      fetchBestChainHeaders: async () => [],
+      discoverCandidateAddressesFromArchive: async () => [matching, mismatched],
+      fetchVerificationKeyHash: async (addr: string) =>
+        addr === matching ? VK_HASH : 'different-vk-hash',
+      fetchDecodedContractEvents: async () => [],
+    }));
+
+    const indexer = new MinaGuardIndexer(archiveConfig);
+    await indexer.start();
+    indexer.stop();
+
+    const contracts = await prisma.contract.findMany();
+    expect(contracts.map((c) => c.address)).toEqual([matching]);
+  });
+});
+
+describe('archive discovery: per-iteration failure isolation', () => {
+  test('a thrown error processing one candidate does not abort processing of the rest', async () => {
+    // Regression test for the "swallow whole batch on first failure" bug.
+    // Without per-iteration try/catch in processCandidateAddresses, an error
+    // on candidate B aborts the for-loop and candidates C+D never get processed
+    // — they're then lost forever because the archive_discovered_height cursor
+    // still advances in the finally block.
+    const ok1 = PrivateKey.random().toPublicKey().toBase58();
+    const bad = PrivateKey.random().toPublicKey().toBase58();
+    const ok2 = PrivateKey.random().toPublicKey().toBase58();
+
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
+      fetchLatestBlockHeightFromArchive: async () => 1000,
+      fetchBestChainHeaders: async () => [],
+      discoverCandidateAddressesFromArchive: async () => [ok1, bad, ok2],
+      fetchVerificationKeyHash: async (addr: string) => {
+        if (addr === bad) throw new Error('simulated daemon hiccup on VK fetch');
+        return VK_HASH;
+      },
+      fetchDecodedContractEvents: async () => [],
+    }));
+
+    const indexer = new MinaGuardIndexer(archiveConfig);
+    await indexer.start();
+    indexer.stop();
+
+    const contracts = await prisma.contract.findMany();
+    const addrs = contracts.map((c) => c.address).sort();
+    // ok2 MUST be in the DB despite `bad` throwing earlier in the loop.
+    expect(addrs).toEqual([ok1, ok2].sort());
+
+    // Cursor must NOT advance when any candidate fails — so the next tick
+    // re-scans the same range and gets another shot at `bad`. Without this
+    // gate, `bad` would be silently dropped forever once the cursor moved
+    // past its deploy block.
+    const cursor = await prisma.indexerCursor.findUnique({
+      where: { key: 'archive_discovered_height' },
+    });
+    expect(cursor).toBeNull();
+  });
+
+  test('backfill failure on one candidate does not abort processing of the rest, and cursor stays held', async () => {
+    // Another shape of the same bug: backfillContract throws (not VK fetch).
+    // Same expectation — other candidates still get processed, AND the cursor
+    // does not advance so the next tick re-scans the same range and can retry
+    // backfill for `bad`.
+    const ok = PrivateKey.random().toPublicKey().toBase58();
+    const bad = PrivateKey.random().toPublicKey().toBase58();
+
+    let backfillCallCountForBad = 0;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
+      fetchLatestBlockHeightFromArchive: async () => 1000,
+      fetchBestChainHeaders: async () => [],
+      discoverCandidateAddressesFromArchive: async () => [bad, ok],
+      fetchVerificationKeyHash: async () => VK_HASH,
+      fetchDecodedContractEvents: async (addr: string) => {
+        if (addr === bad) {
+          backfillCallCountForBad += 1;
+          throw new Error('simulated archive-node-api outage');
+        }
+        return [];
+      },
+    }));
+
+    const indexer = new MinaGuardIndexer(archiveConfig);
+    await indexer.start();
+    indexer.stop();
+
+    expect(backfillCallCountForBad).toBeGreaterThan(0);
+
+    // `ok` was inserted despite `bad` blowing up first.
+    const contracts = await prisma.contract.findMany();
+    expect(contracts.map((c) => c.address)).toContain(ok);
+
+    // Cursor held — next tick will re-scan and retry backfill for `bad`.
+    // (`bad`'s contract row was already created before backfill threw, so
+    // rescanUnreadyContracts will also retry it on subsequent ticks.)
+    const cursor = await prisma.indexerCursor.findUnique({
+      where: { key: 'archive_discovered_height' },
+    });
+    expect(cursor).toBeNull();
+  });
+});
+
+describe('archive discovery: cursor progression', () => {
+  test('uses indexStartHeight on cold start; uses prior cursor minus margin on subsequent runs', async () => {
+    // First tick: no cursor exists; archive query should be called with from=indexStartHeight=0.
+    // After the tick, archive_discovered_height = latestHeight.
+    // Second tick at a higher latestHeight: from = max(indexStartHeight, prevCursor - DISCOVERY_MARGIN).
+    const calls: Array<{ from: number; to: number }> = [];
+
+    let latestHeight = 1000;
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
+      fetchLatestBlockHeightFromArchive: async () => latestHeight,
+      fetchBestChainHeaders: async () => [],
+      discoverCandidateAddressesFromArchive: async (
+        _pool: unknown,
+        _vkHash: string,
+        from: number,
+        to: number,
+      ) => {
+        calls.push({ from, to });
+        return [];
+      },
+      fetchVerificationKeyHash: async () => VK_HASH,
+      fetchDecodedContractEvents: async () => [],
+    }));
+
+    const indexer = new MinaGuardIndexer(archiveConfig);
+    await indexer.start();
+    indexer.stop();
+    expect(calls[0]).toEqual({ from: 0, to: 1000 });
+
+    // Bump chain tip and re-run.
+    latestHeight = 1500;
+    const indexer2 = new MinaGuardIndexer(archiveConfig);
+    await indexer2.start();
+    indexer2.stop();
+    // DISCOVERY_MARGIN is 5 in the source.
+    expect(calls[1]).toEqual({ from: 1000 - 5, to: 1500 });
+  });
+});

--- a/backend/src/tests/indexer-archive-discovery.test.ts
+++ b/backend/src/tests/indexer-archive-discovery.test.ts
@@ -27,6 +27,14 @@ const archiveConfig = {
   },
 } as unknown as BackendConfig;
 
+async function setIndexedHeight(height: number) {
+  await prisma.indexerCursor.upsert({
+    where: { key: 'indexed_height' },
+    create: { key: 'indexed_height', value: String(height) },
+    update: { value: String(height) },
+  });
+}
+
 async function clearAll() {
   await prisma.approval.deleteMany();
   await prisma.proposalExecution.deleteMany();
@@ -169,7 +177,10 @@ describe('archive discovery: per-iteration failure isolation', () => {
     // Another shape of the same bug: backfillContract throws (not VK fetch).
     // Same expectation — other candidates still get processed, AND the cursor
     // does not advance so the next tick re-scans the same range and can retry
-    // backfill for `bad`.
+    // backfill for `bad`. Pre-seed indexedHeight so backfillContract actually
+    // runs (it short-circuits when indexedHeight <= backfillFrom).
+    await setIndexedHeight(999);
+
     const ok = PrivateKey.random().toPublicKey().toBase58();
     const bad = PrivateKey.random().toPublicKey().toBase58();
 
@@ -207,6 +218,51 @@ describe('archive discovery: per-iteration failure isolation', () => {
       where: { key: 'archive_discovered_height' },
     });
     expect(cursor).toBeNull();
+  });
+});
+
+describe('archive discovery: backfill range', () => {
+  test('backfill for a newly-discovered contract starts from indexStartHeight, not indexedHeight - 300', async () => {
+    // Regression test for the "historical event gap" bug: under full mode +
+    // daemon discovery, backfill spans the last 300 blocks (safe because
+    // daemon-discovery can't surface anything older). Archive-discovery can
+    // surface a deploy from 50k blocks ago — but with the old 300-block guard,
+    // every event between the deploy and (indexedHeight - 300) would be lost.
+    // This test pins the fix: archive backend uses indexStartHeight (the same
+    // lite-mode/manual-subscribe-with-fromBlock=0 path) regardless of how
+    // far ahead the indexer's cursor has advanced.
+    // Simulate: indexer has been running, cursor at 49999, archive scan now
+    // surfaces a contract whose deploy block is somewhere in [0, 49999].
+    // Without the seed, backfillContract short-circuits (indexedHeight=0,
+    // backfillFrom=0, nothing to fetch).
+    await setIndexedHeight(49_999);
+
+    const addr = PrivateKey.random().toPublicKey().toBase58();
+
+    const backfillCalls: Array<{ from: number; to: number }> = [];
+    mock.module('../mina-client.js', () => ({
+      ...minaClient,
+      fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
+      fetchLatestBlockHeightFromArchive: async () => 50_000,
+      fetchBestChainHeaders: async () => [],
+      discoverCandidateAddressesFromArchive: async () => [addr],
+      fetchVerificationKeyHash: async () => VK_HASH,
+      fetchDecodedContractEvents: async (_addr: string, from: number, to: number) => {
+        backfillCalls.push({ from, to });
+        return [];
+      },
+    }));
+
+    const indexer = new MinaGuardIndexer(archiveConfig);
+    await indexer.start();
+    indexer.stop();
+
+    // First call to fetchDecodedContractEvents is the backfill triggered by
+    // discovery. Lower bound must be indexStartHeight (0 in this config),
+    // NOT indexedHeight - 300 = 49699 (the old daemon-discovery guard).
+    expect(backfillCalls.length).toBeGreaterThan(0);
+    expect(backfillCalls[0].from).toBe(0);
+    expect(backfillCalls[0].to).toBe(49_999);
   });
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,11 +21,13 @@
         "contracts": "workspace:*",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "pg": "^8.13.1",
         "zod": "^3.25",
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/pg": "^8.11.10",
         "prisma": "6.12.0",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
@@ -593,6 +595,8 @@
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
@@ -1256,6 +1260,22 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1287,6 +1307,14 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1393,6 +1421,8 @@
     "source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
     "split-on-first": ["split-on-first@3.0.0", "", {}, "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -1532,6 +1562,8 @@
 
     "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
@@ -1648,7 +1680,7 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
-    "offline-cli/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "^1.2.1" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
+    "offline-cli/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "blakejs": "^1.2.1", "js-sha256": "^0.9.0" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1676,7 +1708,7 @@
 
     "ui/@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
-    "ui/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "@noble/hashes": "^1.7.1", "blakejs": "^1.2.1" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
+    "ui/mina-signer": ["mina-signer@file:ui/deps/o1js/src/mina-signer", { "dependencies": { "blakejs": "^1.2.1", "js-sha256": "^0.9.0" }, "devDependencies": { "pkg-pr-new": "^0.0.9" } }],
 
     "@babel/core/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -10,3 +10,11 @@
 # node-stack side. Use the box's public IPv4 today; switch to a Hetzner
 # Cloud Networks 10.x.x.x internal IP once the private network is wired.
 MESA_NODE_HOST=
+
+# Password for the read-only `minaguard_ro` role on the node-stack box's
+# archive postgres (exposed on ${MESA_NODE_HOST}:5433). The trail
+# backend's compose file builds the full connection from this +
+# MESA_NODE_HOST; storing only the password keeps the secret surface
+# minimal. Stored as the `ARCHIVE_DB_PASSWORD` GitHub secret for the
+# auto-deploy workflow; pull the real value from the team password manager.
+ARCHIVE_DB_PASSWORD=

--- a/deploy/deploy-trail.sh
+++ b/deploy/deploy-trail.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   ./deploy-trail.sh up      — deploy the trail (Mesa Trail / mesa-mut) compose project
-#   ./deploy-trail.sh down    — teardown (preserves db volume; pass -v manually to wipe)
+#   ./deploy-trail.sh down    — teardown (wipes the app DB volume — see comment on `down -v` below)
 #
 # Runs on the prod-facing box alongside /app/* (localnet, `deploy.sh`) and
 # the PR previews (`preview-env/preview.sh`). All three patterns use the
@@ -133,7 +133,17 @@ case "$COMMAND" in
 
     down)
         echo "Tearing down trail deployment..."
-        docker compose -f deploy/docker-compose.trail.yml -p minaguard-trail down --remove-orphans --rmi local
+        # `-v` wipes the minaguard-trail-db volume. Rationale: during active
+        # contract development the VK hash changes per PR merge, and the
+        # indexer filters discovery by VK hash — so on every deploy the
+        # previously-indexed Contract rows point at vk-hash-mismatched
+        # addresses that the new indexer would skip anyway. Preserving them
+        # would just leave dead rows in the DB and waste tick cycles on
+        # rescanUnreadyContracts for contracts nobody can interact with.
+        # Same applies to the new archive_discovered_height cursor — stale
+        # high-water mark, no longer matches the current VK's deploy heights.
+        # When the contract stabilizes, drop the `-v` to get persistence.
+        docker compose -f deploy/docker-compose.trail.yml -p minaguard-trail down -v --remove-orphans --rmi local
         remove_caddy_route
         echo "Done."
         ;;

--- a/deploy/deploy-trail.sh
+++ b/deploy/deploy-trail.sh
@@ -37,6 +37,7 @@ if [ -f deploy/.env ]; then
   set +a
 fi
 : "${MESA_NODE_HOST:?MESA_NODE_HOST must be set in deploy/.env (see deploy/.env.example) or exported in the shell}"
+: "${ARCHIVE_DB_PASSWORD:?ARCHIVE_DB_PASSWORD must be set in deploy/.env (see deploy/.env.example) or exported in the shell — read-only role on the node-stack archive postgres}"
 
 # The MinaGuard VK hash is a property of the contract source, not deploy-time
 # config — it's committed at contracts/.vk-hash. Read it from there (stripping

--- a/deploy/docker-compose.trail.yml
+++ b/deploy/docker-compose.trail.yml
@@ -54,6 +54,16 @@ services:
       # restricts ports 3085 + 8282 to inbound from this server's IP only.
       - MINA_ENDPOINT=http://${MESA_NODE_HOST:?MESA_NODE_HOST must be set (see deploy/.env.example)}:3085/graphql
       - ARCHIVE_ENDPOINT=http://${MESA_NODE_HOST:?MESA_NODE_HOST must be set (see deploy/.env.example)}:8282
+      # Read-only archive postgres on the node-stack box. Lets the indexer
+      # scan beyond the daemon's 290-block bestChain cap. Passed as discrete
+      # parts (not a URL) so passwords with reserved URL characters (/, @, :,
+      # etc.) don't need percent-encoding.
+      - ARCHIVE_DB_HOST=${MESA_NODE_HOST}
+      - ARCHIVE_DB_PORT=5433
+      - ARCHIVE_DB_USER=minaguard_ro
+      - ARCHIVE_DB_PASSWORD=${ARCHIVE_DB_PASSWORD:?ARCHIVE_DB_PASSWORD must be set (see deploy/.env.example)}
+      - ARCHIVE_DB_NAME=archive
+      - DISCOVERY_BACKEND=archive
       - PORT=4000
     depends_on:
       db:


### PR DESCRIPTION
Trail backend's discovery was capped at 290 blocks back (Mina's bestChain horizon), hiding MinaGuard contracts deployed on Mesa Trail before that window. New opt-in `DISCOVERY_BACKEND=archive` queries the archive postgres directly via a VK-hash-filtered SQL. Note that localnet/preview/e2e are unaffected.

Also added a TODO in `mina-client.ts` to handle reorgs for contracts written to DB correctly before mainnet (currently only supports events written to DB)