### PR TITLE
ci(e2e): fix host port collisions on self-hosted runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: e2e-runner
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- Serialize all e2e runs under a single concurrency group (`e2e-runner`) so two PRs can't race on the same runner and collide on fixed host ports