### PR TITLE
Fix archive-discovery indexer crash loop and historical event gap

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -15,6 +15,7 @@ import {
   fetchOnChainState,
   fetchVerificationKeyHash,
   fetchZkappTxStatus,
+  type DiscoveryCandidate,
   type ChainEvent,
   type GenesisConstants,
 } from './mina-client.js';
@@ -120,6 +121,22 @@ export class MinaGuardIndexer {
         connectionTimeoutMillis: 5_000,
         statement_timeout: 30_000,
         query_timeout: 30_000,
+        // Cross-host postgres connections die silently when ufw/NAT timeouts
+        // close idle conns. TCP keepalives keep them warm + detect drops fast
+        // so the next query reopens cleanly instead of hanging.
+        keepAlive: true,
+        keepAliveInitialDelayMillis: 10_000,
+      });
+      // node-postgres pool errors on idle clients propagate as uncaught
+      // exceptions and crash the process unless this listener is attached
+      // (see node-postgres docs: "Pool errors"). Logging and swallowing here
+      // lets the pool transparently replace the dead client on the next
+      // checkout — what we want for transient cross-host drops.
+      this.archivePool.on('error', (err) => {
+        console.error(
+          '[indexer] archive pool idle error (will reconnect on next query):',
+          err instanceof Error ? err.message : err,
+        );
       });
     }
     return this.archivePool;
@@ -172,7 +189,7 @@ export class MinaGuardIndexer {
       // on fork — the next tick re-covers the reorged range.
       if (this.config.indexerMode === 'full') {
         const DISCOVERY_MARGIN = 5;
-        let candidates: string[];
+        let candidates: DiscoveryCandidate[];
         if (this.config.discoveryBackend === 'archive' && this.config.minaguardVkHash) {
           // Cold start (no archive_discovered_height cursor): scan from
           // indexStartHeight back to genesis-or-configured-floor so historical
@@ -194,9 +211,13 @@ export class MinaGuardIndexer {
             1,
             Math.min(290, latestHeight - indexedHeight + DISCOVERY_MARGIN),
           );
-          candidates = await discoverCandidateAddresses(this.config, discoveryWindow);
+          // TODO: daemon path approximates deployBlock as latestHeight, which
+          // sits above the actual deploy by up to ~290 blocks. Follow-up PR
+          // threads per-block height through the bestChain query.
+          const addrs = await discoverCandidateAddresses(this.config, discoveryWindow);
+          candidates = addrs.map((address) => ({ address, deployBlock: latestHeight }));
         }
-        const failureCount = await this.processCandidateAddresses(candidates, latestHeight);
+        const failureCount = await this.processCandidateAddresses(candidates);
         if (this.config.discoveryBackend === 'archive' && failureCount === 0) {
           // Only advance the cursor when every candidate was either inserted
           // or intentionally skipped (existing / VK mismatch). If any candidate
@@ -246,6 +267,12 @@ export class MinaGuardIndexer {
    * branches funnel through here so the dedup, VK re-verification, and backfill
    * logic stays in one place.
    *
+   * `deployBlock` is persisted as `discoveredAtBlock` so `rescanUnreadyContracts`
+   * scans a tight `[deploy_block, latestHeight]` window. For archive discovery
+   * this is the actual on-chain deploy block (from MIN(blocks.height) in the
+   * SQL); for daemon discovery it's the tick's chain tip — close enough since
+   * bestChain horizon caps the imprecision at ~290 blocks.
+   *
    * Returns the count of candidates that threw — the archive branch in tick()
    * uses this to decide whether to advance the archive_discovered_height
    * cursor (only advances when 0 failures, so transient failures get retried
@@ -256,9 +283,9 @@ export class MinaGuardIndexer {
    * sighting), and it catches the edge case where the archive shows a VK install
    * that has since been upgraded to a different VK on chain.
    */
-  private async processCandidateAddresses(addresses: string[], latestHeight: number): Promise<number> {
+  private async processCandidateAddresses(candidates: DiscoveryCandidate[]): Promise<number> {
     let failureCount = 0;
-    for (const address of addresses) {
+    for (const { address, deployBlock } of candidates) {
       try {
         const existing = await prisma.contract.findUnique({ where: { address } });
         if (existing) continue;
@@ -274,7 +301,7 @@ export class MinaGuardIndexer {
         }
 
         const created = await prisma.contract.create({
-          data: { address, discoveredAtBlock: latestHeight },
+          data: { address, discoveredAtBlock: deployBlock },
         });
 
         await this.backfillContract(created.id, address);

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -248,15 +248,27 @@ export async function discoverCandidateAddresses(
  * zkapp_verification_keys). If the archive schema shifts in a future Mina release,
  * this query needs revisiting.
  */
+export interface DiscoveryCandidate {
+  address: string;
+  /** Block height attributed to this address's discovery — used as the
+   *  contract's discoveredAtBlock so rescan windows are tight around the
+   *  deploy. The archive backend populates this with the actual on-chain
+   *  deploy block (MIN(blocks.height) from the SQL); the daemon backend
+   *  currently approximates it as the tick's chain tip (precise enough
+   *  for the rescan since bestChain's ~290-block horizon bounds the
+   *  imprecision). */
+  deployBlock: number;
+}
+
 export async function discoverCandidateAddressesFromArchive(
   pool: Pool,
   vkHash: string,
   fromHeight: number,
   toHeight: number,
-): Promise<string[]> {
-  const result = await pool.query<{ address: string }>(
+): Promise<DiscoveryCandidate[]> {
+  const result = await pool.query<{ address: string; deploy_block: string }>(
     `
-    SELECT DISTINCT pk.value AS address
+    SELECT pk.value AS address, MIN(b.height)::text AS deploy_block
     FROM zkapp_account_update_body zaub
     JOIN zkapp_updates zu ON zu.id = zaub.update_id
     JOIN zkapp_verification_keys vk ON vk.id = zu.verification_key_id
@@ -271,10 +283,11 @@ export async function discoverCandidateAddressesFromArchive(
     WHERE vkh.value = $1
       AND b.chain_status <> 'orphaned'
       AND b.height BETWEEN $2 AND $3
+    GROUP BY pk.value
     `,
     [vkHash, fromHeight, toHeight],
   );
-  return result.rows.map((r) => r.address);
+  return result.rows.map((r) => ({ address: r.address, deployBlock: Number(r.deploy_block) }));
 }
 
 /** Reads the current verification key hash for an account if present. */

--- a/backend/src/tests/indexer-archive-discovery.test.ts
+++ b/backend/src/tests/indexer-archive-discovery.test.ts
@@ -62,11 +62,11 @@ afterAll(async () => {
 });
 
 describe('archive discovery: happy path', () => {
-  test('discovers contracts returned by archive query and advances archive_discovered_height cursor', async () => {
-    const addrs = [
-      PrivateKey.random().toPublicKey().toBase58(),
-      PrivateKey.random().toPublicKey().toBase58(),
-      PrivateKey.random().toPublicKey().toBase58(),
+  test('discovers contracts returned by archive query, stores deploy block as discoveredAtBlock, and advances cursor', async () => {
+    const candidates = [
+      { address: PrivateKey.random().toPublicKey().toBase58(), deployBlock: 100 },
+      { address: PrivateKey.random().toPublicKey().toBase58(), deployBlock: 250 },
+      { address: PrivateKey.random().toPublicKey().toBase58(), deployBlock: 700 },
     ];
 
     let archiveQueryCalledWith: { from: number; to: number } | null = null;
@@ -82,7 +82,7 @@ describe('archive discovery: happy path', () => {
         to: number,
       ) => {
         archiveQueryCalledWith = { from, to };
-        return addrs;
+        return candidates;
       },
       // All 3 candidates verify with the matching MinaGuard VK on-chain.
       fetchVerificationKeyHash: async () => VK_HASH,
@@ -98,7 +98,17 @@ describe('archive discovery: happy path', () => {
     expect(archiveQueryCalledWith).toEqual({ from: 0, to: 1000 });
 
     const contracts = await prisma.contract.findMany({ orderBy: { address: 'asc' } });
-    expect(contracts.map((c) => c.address).sort()).toEqual([...addrs].sort());
+    expect(contracts.map((c) => c.address).sort()).toEqual(candidates.map((c) => c.address).sort());
+
+    // Critical: discoveredAtBlock must be the actual deploy block, not the
+    // tick's chain tip. This is what makes rescanUnreadyContracts's
+    // [discoveredAtBlock, latestHeight] window cover the deploy events
+    // (without it, archive-discovered contracts would have a permanent
+    // blind spot below the tick's chain tip).
+    const byAddr = new Map(contracts.map((c) => [c.address, c.discoveredAtBlock]));
+    for (const { address, deployBlock } of candidates) {
+      expect(byAddr.get(address)).toBe(deployBlock);
+    }
 
     const cursor = await prisma.indexerCursor.findUnique({
       where: { key: 'archive_discovered_height' },
@@ -115,7 +125,10 @@ describe('archive discovery: happy path', () => {
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 500,
       fetchBestChainHeaders: async () => [],
-      discoverCandidateAddressesFromArchive: async () => [matching, mismatched],
+      discoverCandidateAddressesFromArchive: async () => [
+        { address: matching, deployBlock: 200 },
+        { address: mismatched, deployBlock: 300 },
+      ],
       fetchVerificationKeyHash: async (addr: string) =>
         addr === matching ? VK_HASH : 'different-vk-hash',
       fetchDecodedContractEvents: async () => [],
@@ -146,7 +159,11 @@ describe('archive discovery: per-iteration failure isolation', () => {
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 1000,
       fetchBestChainHeaders: async () => [],
-      discoverCandidateAddressesFromArchive: async () => [ok1, bad, ok2],
+      discoverCandidateAddressesFromArchive: async () => [
+        { address: ok1, deployBlock: 100 },
+        { address: bad, deployBlock: 200 },
+        { address: ok2, deployBlock: 300 },
+      ],
       fetchVerificationKeyHash: async (addr: string) => {
         if (addr === bad) throw new Error('simulated daemon hiccup on VK fetch');
         return VK_HASH;
@@ -190,7 +207,10 @@ describe('archive discovery: per-iteration failure isolation', () => {
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 1000,
       fetchBestChainHeaders: async () => [],
-      discoverCandidateAddressesFromArchive: async () => [bad, ok],
+      discoverCandidateAddressesFromArchive: async () => [
+        { address: bad, deployBlock: 100 },
+        { address: ok, deployBlock: 200 },
+      ],
       fetchVerificationKeyHash: async () => VK_HASH,
       fetchDecodedContractEvents: async (addr: string) => {
         if (addr === bad) {
@@ -245,7 +265,7 @@ describe('archive discovery: backfill range', () => {
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 50_000,
       fetchBestChainHeaders: async () => [],
-      discoverCandidateAddressesFromArchive: async () => [addr],
+      discoverCandidateAddressesFromArchive: async () => [{ address: addr, deployBlock: 12_345 }],
       fetchVerificationKeyHash: async () => VK_HASH,
       fetchDecodedContractEvents: async (_addr: string, from: number, to: number) => {
         backfillCalls.push({ from, to });


### PR DESCRIPTION
## Summary

Two bugs in the archive-discovery path added in #78.

1. **pg.Pool error handler missing.** node-postgres surfaces idle-client failures via `pool.emit('error', ...)`. With no listener, Node converts the emit into an uncaught exception and kills the process. Cross-host postgres connections die silently when ufw/NAT times out the idle TCP. Fix: attach an `error` handler (pool self-heals — replaces the dead client on next checkout) plus `keepAlive: true` so silent drops are detected via TCP probe instead of exploding on the next query.

2. **`Contract.discoveredAtBlock` was the tick's chain tip, not the actual deploy block.** `processCandidateAddresses` set it to `latestHeight` (the indexer tick's current chain tip), which works for daemon discovery — its bestChain horizon caps imprecision at ~290 blocks — but breaks for archive discovery, where deploys can be arbitrarily far in the past. Symptom: `rescanUnreadyContracts` scans `[discoveredAtBlock, latestHeight]`, so events emitted *below* the discovery-tick chain tip are permanently missed and `ready=true` never fires. Fix: extend the archive SQL to return `MIN(blocks.height)` per address as `deployBlock`, plumb it through `discoverCandidateAddressesFromArchive` → `processCandidateAddresses` → `Contract.discoveredAtBlock`. Rescan logic stays unchanged because the field now genuinely means what it claims to.