### PR TITLE
Daemon discovery: return actual deploy block, not chain tip

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -211,11 +211,7 @@ export class MinaGuardIndexer {
             1,
             Math.min(290, latestHeight - indexedHeight + DISCOVERY_MARGIN),
           );
-          // TODO: daemon path approximates deployBlock as latestHeight, which
-          // sits above the actual deploy by up to ~290 blocks. Follow-up PR
-          // threads per-block height through the bestChain query.
-          const addrs = await discoverCandidateAddresses(this.config, discoveryWindow);
-          candidates = addrs.map((address) => ({ address, deployBlock: latestHeight }));
+          candidates = await discoverCandidateAddresses(this.config, discoveryWindow);
         }
         const failureCount = await this.processCandidateAddresses(candidates);
         if (this.config.discoveryBackend === 'archive' && failureCount === 0) {
@@ -268,10 +264,9 @@ export class MinaGuardIndexer {
    * logic stays in one place.
    *
    * `deployBlock` is persisted as `discoveredAtBlock` so `rescanUnreadyContracts`
-   * scans a tight `[deploy_block, latestHeight]` window. For archive discovery
-   * this is the actual on-chain deploy block (from MIN(blocks.height) in the
-   * SQL); for daemon discovery it's the tick's chain tip — close enough since
-   * bestChain horizon caps the imprecision at ~290 blocks.
+   * scans a tight `[deploy_block, latestHeight]` window. Both backends return
+   * the actual on-chain deploy block — archive via MIN(blocks.height) in the
+   * SQL, daemon via the per-block iteration over bestChain.
    *
    * Returns the count of candidates that threw — the archive branch in tick()
    * uses this to decide whether to advance the archive_discovered_height

--- a/backend/src/mina-client.ts
+++ b/backend/src/mina-client.ts
@@ -160,9 +160,14 @@ export async function fetchLatestBlockHeightFromArchive(pool: Pool): Promise<num
 export async function discoverCandidateAddresses(
   config: BackendConfig,
   blockWindow: number
-): Promise<string[]> {
+): Promise<DiscoveryCandidate[]> {
   const query = `{
     bestChain(maxLength: ${blockWindow}) {
+      protocolState {
+        consensusState {
+          blockHeight
+        }
+      }
       transactions {
         zkappCommands {
           zkappCommand {
@@ -184,6 +189,7 @@ export async function discoverCandidateAddresses(
 
   type CandidateResponse = {
     bestChain?: Array<{
+      protocolState?: { consensusState?: { blockHeight?: string | number | null } | null } | null;
       transactions?: {
         zkappCommands?: Array<{
           zkappCommand?: {
@@ -205,20 +211,33 @@ export async function discoverCandidateAddresses(
     config.minaFallbackEndpoint
   );
 
-  const addresses = new Set<string>();
+  // Track the earliest block height per address. A single deploy tx often
+  // has multiple account updates touching the same address (create-account
+  // AU + install-VK AU); the earliest block in the window is the actual
+  // deploy. bestChain iterates oldest→newest so a plain set-if-absent is
+  // enough — but use explicit Math.min to be robust to future ordering
+  // changes.
+  const firstSeenAt = new Map<string, number>();
   for (const block of data.bestChain ?? []) {
+    const heightRaw = block.protocolState?.consensusState?.blockHeight;
+    if (heightRaw == null) continue;
+    const height = Number(heightRaw);
+    if (!Number.isFinite(height)) continue;
     for (const cmd of block.transactions?.zkappCommands ?? []) {
       for (const update of cmd.zkappCommand?.accountUpdates ?? []) {
         const body = update.body;
         if (!body?.publicKey) continue;
         if (body.update?.verificationKey?.hash) {
-          addresses.add(body.publicKey);
+          const prev = firstSeenAt.get(body.publicKey);
+          if (prev === undefined || height < prev) {
+            firstSeenAt.set(body.publicKey, height);
+          }
         }
       }
     }
   }
 
-  return [...addresses];
+  return [...firstSeenAt.entries()].map(([address, deployBlock]) => ({ address, deployBlock }));
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #80, which made the archive backend populate `Contract.discoveredAtBlock` with the actual on-chain deploy block but left the daemon backend approximating it as the tick's `latestHeight`. This PR makes the daemon path precise too.

1. Extend `discoverCandidateAddresses`'s `bestChain` query to include `protocolState.consensusState.blockHeight` per block.
2. Track the earliest block where each candidate's VK install landed (handles the case where a single deploy tx has multiple account-updates touching the same address — e.g. create-account AU + install-VK AU).
3. Return `DiscoveryCandidate[]` instead of `string[]`, with `deployBlock` set to the actual deploy block.
4. Remove the `.map((address) => ({ address, deployBlock: latestHeight }))` wrap in `indexer.ts` that approximated this, plus the TODO comment marking it for follow-up.

## Also fixes a pre-existing latent bug

For daemon-discovered contracts whose first `backfillContract` call failed (transient archive-node-api blip, daemon timeout, etc.), the contract would get permanently stuck `ready=false`. `rescanUnreadyContracts`'s window `[discoveredAtBlock=latestHeight, latestHeight]` couldn't reach back to the actual deploy block, so the fallback never recovered.

With `deployBlock` now being the actual deploy block, the rescan window `[deploy_block, latestHeight]` always covers — eliminating the stuck-on-failure mode for daemon-discovered contracts the same way #80 did for archive-discovered ones.