### PR TITLE
Record broadcast timestamps server-side for every UI-broadcast tx

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -187,3 +187,32 @@ model IndexerCursor {
   value     String
   updatedAt DateTime @updatedAt
 }
+
+/// Records the moment a client broadcast a signed tx to the network, so the
+/// server has a timeline from UI-click through chain inclusion. Written by the
+/// UI immediately after `savePendingTx` (fire-and-forget); nothing blocks on
+/// this succeeding — the pending-tx entry in localStorage is the source of
+/// truth for the tx's identity, this row is just the server-visible slice.
+///
+/// One row per tx (unique on txHash). For deploys, `proposalHash` mirrors
+/// `contractAddress` — the same sentinel the client-side PendingTx type uses,
+/// since a deploy has no on-chain proposal identity.
+model Submission {
+  id              Int      @id @default(autoincrement())
+  /// "create" | "approve" | "execute" | "deploy" — mirrors ui/lib/storage.ts's
+  /// PendingTxKind union. String rather than enum so a UI shipping a new kind
+  /// doesn't force a coordinated schema migration.
+  kind            String
+  txHash          String   @unique
+  contractAddress String
+  proposalHash    String
+  signerPubkey    String
+  /// Client's Date.now() at broadcast — what the user actually cares about
+  /// ("when did I click"), as opposed to `createdAt` which is server receive.
+  broadcastedAt   DateTime
+  createdAt       DateTime @default(now())
+
+  @@index([contractAddress, kind])
+  @@index([signerPubkey])
+  @@index([broadcastedAt])
+}

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -55,6 +55,19 @@ const submissionBodySchema = z.object({
   txHash: z.string().min(1).max(200),
 });
 
+/// Body of POST /api/submissions — mirrors ui/lib/storage.ts's PendingTx
+/// shape so the client can construct it from the same record it puts into
+/// localStorage. `broadcastedAt` is the client's Date at broadcast time,
+/// serialized as ISO-8601 (the UI's `new Date().toISOString()` output).
+const broadcastSubmissionBodySchema = z.object({
+  kind: z.enum(['create', 'approve', 'execute', 'deploy']),
+  txHash: z.string().min(1).max(200),
+  contractAddress: z.string().min(1).max(200),
+  proposalHash: z.string().min(1).max(200),
+  signerPubkey: z.string().min(1).max(200),
+  broadcastedAt: z.string().datetime(),
+});
+
 type OwnersQuery = z.infer<typeof ownersQuerySchema>;
 type ProposalsQuery = z.infer<typeof proposalsQuerySchema>;
 type EventsQuery = z.infer<typeof eventsQuerySchema>;
@@ -341,6 +354,48 @@ export function createApiRouter(indexer: MinaGuardIndexer, config?: BackendConfi
       res.json({ ok: true });
     })
   );
+
+  /** Records the moment a client broadcast a signed tx. Mirrors what the UI
+   *  writes into localStorage via `savePendingTx`, so the server has a
+   *  timeline from UI-click through inclusion. Called fire-and-forget from
+   *  the UI — failures here do not affect the client (the pending-tx entry
+   *  still lives in localStorage). Idempotent on `txHash`: re-posting the
+   *  same hash returns the existing row.
+   *
+   *  Not to be confused with the per-proposal submissions route above, which
+   *  updates `Proposal.lastApproveTxHash` / `lastExecuteTxHash` for the
+   *  cross-signer execute lock. That route stays as-is; this one is the
+   *  broadcast-timeline record. */
+  router.post('/api/submissions', safe(async (req, res) => {
+    const parsed = broadcastSubmissionBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid submission payload', details: parsed.error.flatten() });
+      return;
+    }
+    const data = { ...parsed.data, broadcastedAt: new Date(parsed.data.broadcastedAt) };
+
+    const existing = await prisma.submission.findUnique({ where: { txHash: data.txHash } });
+    if (existing) {
+      res.json(existing);
+      return;
+    }
+
+    try {
+      const created = await prisma.submission.create({ data });
+      res.status(201).json(created);
+    } catch (err: unknown) {
+      // Handle the race where two requests for the same txHash arrive
+      // simultaneously and both pass the findUnique check.
+      if (err instanceof Error && err.message.includes('Unique constraint')) {
+        const existing2 = await prisma.submission.findUnique({ where: { txHash: data.txHash } });
+        if (existing2) {
+          res.json(existing2);
+          return;
+        }
+      }
+      throw err;
+    }
+  }));
 
   /** Lists per-approver records for a given proposal hash. */
   router.get(

--- a/ui/lib/storage.ts
+++ b/ui/lib/storage.ts
@@ -164,12 +164,45 @@ export function getPendingTx(
   );
 }
 
-/** Inserts or replaces a pending tx record keyed by (contract, proposal, kind, signer). */
+/** Inserts or replaces a pending tx record keyed by (contract, proposal, kind, signer).
+ *  Also fires a fire-and-forget POST to the backend so the server has a
+ *  broadcast-timestamp record of every UI-broadcast tx (see
+ *  `POST /api/submissions` on the backend and the `Submission` model). Server
+ *  sync failures do not affect the client — localStorage is still the
+ *  in-flight source of truth for the UI. */
 export function savePendingTx(record: PendingTx): void {
   const next = readPendingTxsRaw().filter((r) => pendingTxKey(r) !== pendingTxKey(record));
   next.push(record);
   writePendingTxs(pruneStale(next));
   notifyPendingTxsChanged();
+  void syncSubmissionToServer(record);
+}
+
+/** Mirrors a broadcast record to the backend's `Submission` table. Runs after
+ *  localStorage is already updated, so failures here are safe to swallow —
+ *  the UI still shows the pending banner from the local record. Not exported;
+ *  the only invocation is from `savePendingTx` above. */
+async function syncSubmissionToServer(record: PendingTx): Promise<void> {
+  if (typeof window === 'undefined') return;
+  const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:3001';
+  try {
+    await fetch(`${API_BASE}/api/submissions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        kind: record.kind,
+        txHash: record.txHash,
+        contractAddress: record.contractAddress,
+        proposalHash: record.proposalHash,
+        signerPubkey: record.signerPubkey,
+        broadcastedAt: record.createdAt,
+      }),
+    });
+  } catch {
+    // best-effort: server may be temporarily unavailable, localStorage still
+    // has the record, and the pending-tx entry will get pruned by TTL on the
+    // client independent of whether the server sync succeeded.
+  }
 }
 
 /** Removes any record matching the (contract, proposal, kind[, signer]) key. */


### PR DESCRIPTION
## Summary

Adds a `Submission` table + `POST /api/submissions` endpoint that mirrors the client-side `PendingTx` shape (from `ui/lib/storage.ts`) server-side. `savePendingTx` now fires a fire-and-forget POST to it after writing to localStorage, so every UI-broadcast tx (create / approve / execute / deploy) leaves a server-visible row with `(kind, txHash, contractAddress, proposalHash, signerPubkey, broadcastedAt, createdAt)`.

## Motivation

Currently the only server-side record of a broadcast is the per-proposal `lastApproveTxHash` / `lastExecuteTxHash` fields on `Proposal`, and only for approve/execute. Deploys and proposal creates had zero server visibility, and even for approve/execute we didn't know when the click happened — only that it eventually did. Debugging "why isn't my tx landing?" required correlating localStorage in the deploying user's browser + on-chain block times, with no timeline in between.

This gives every submission a click-through-inclusion timeline server-side.

## Design

- **Fire-and-forget on the client** so server availability never blocks the UX. If `/api/submissions` is down or slow, the pending banner still fires from localStorage — the server sync just quietly drops.
- **Idempotent on `txHash`** (unique constraint) so a client retry or a race between two rapid clicks is safe. Handler does `findUnique` first and returns the existing row; on a race that gets past the check, catches the unique-violation and returns the just-inserted row.
- **`kind` stored as a plain `String`** (not a Prisma enum) so a UI shipping a new kind doesn't force a coordinated schema migration.
- **`String` field width** capped at 200 for all client-supplied fields — matches the existing `submissionBodySchema` pattern.

## What this does NOT change

The pre-existing per-proposal submissions route (`POST /api/contracts/:address/proposals/:proposalHash/submissions`) is untouched. That one exists for the cross-signer execute lock — it populates `lastExecuteTxHash` for the \"another signer broadcast\" banner. This new route is orthogonal: pure timeline record, no side effects beyond the row insert. Both routes fire from the same UI broadcast paths in parallel; they store overlapping information for different downstream uses.

The 7 `savePendingTx(...)` call sites in the UI are unchanged. The integration lives entirely inside `savePendingTx` itself, so any future broadcast path picks it up automatically.

## Test plan

- [x] Backend typecheck passes (\`docker compose build backend\`).
- [x] Prisma schema formats cleanly (\`bunx prisma format\`).
- [ ] Verify on the trail deployment after merge: broadcast a proposal from the UI, confirm a Submission row appears within \\~1s with the correct \`broadcastedAt\` (client-side click time) vs \`createdAt\` (server-side receive time).
- [ ] Confirm server outage during broadcast doesn't break the UI (kill the backend, click Deploy, confirm the pending banner still shows and localStorage still records).

## Follow-ups (out of scope for this PR)

- **Set `includedAt` / `includedAtBlock` on the Submission when events land.** Wire the indexer's event-ingestion path to update the matching Submission row by \`txHash\`. Would give a full click-to-inclusion delta on the server for every tx type.
- **GET endpoint** for reading submissions per contract / per signer, useful for debugging \"where is my tx?\" from server-side data alone.