### PR TITLE
fix(caddy): /trail/archive & /preview/*/archive return 404 instead of GraphQL

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -40,7 +40,10 @@
 
     # Lightnet archive node
     handle /app/archive {
-        uri strip_prefix /app
+        # The archive-node-api serves GraphQL only at its root "/", not
+        # "/archive" — stripping just "/app" would forward "/archive" and 404.
+        # Rewrite the upstream path to "/" instead.
+        rewrite * /
         header Access-Control-Allow-Origin "*"
         header Access-Control-Allow-Methods "GET, POST, OPTIONS"
         header Access-Control-Allow-Headers "Content-Type"

--- a/deploy/Caddyfile.trail
+++ b/deploy/Caddyfile.trail
@@ -55,7 +55,11 @@
 
     # Archive-node-api — also proxied across the network to the node-stack box.
     handle /trail/archive {
-        uri strip_prefix /trail
+        # The archive-node-api serves GraphQL only at its root "/", unlike the
+        # daemon (/graphql) and backend (/api). Stripping just "/trail" would
+        # forward "/archive" and the archive-node-api 404s on it. Rewrite the
+        # upstream path to "/" so o1js's archive queries reach the GraphQL root.
+        rewrite * /
         header Access-Control-Allow-Origin "*"
         header Access-Control-Allow-Methods "GET, POST, OPTIONS"
         header Access-Control-Allow-Headers "Content-Type"

--- a/preview-env/Caddyfile.preview
+++ b/preview-env/Caddyfile.preview
@@ -40,7 +40,10 @@
 
     # Lightnet archive node
     handle /preview/{$PR_NUMBER}/archive {
-        uri strip_prefix /preview/{$PR_NUMBER}
+        # The archive-node-api serves GraphQL only at its root "/", not
+        # "/archive" — stripping just the PR prefix would forward "/archive"
+        # and 404. Rewrite the upstream path to "/" instead.
+        rewrite * /
         header Access-Control-Allow-Origin "*"
         header Access-Control-Allow-Methods "GET, POST, OPTIONS"
         header Access-Control-Allow-Headers "Content-Type"


### PR DESCRIPTION
## Problem

`https://mina-nodes.duckdns.org/trail/archive` returns **HTTP 404**, not GraphQL:

```
POST .../trail/archive   -> 404
POST .../trail/graphql   -> 200   (daemon, for comparison)
```

The o1-labs `archive-node-api` serves GraphQL only at its **root** `/`:

```
POST http://<node>:8282/          -> 200  {"data":{"__typename":"Query"}}
POST http://<node>:8282/archive   -> 404
```

Unlike the daemon (`/graphql`) and backend (`/api`), the archive-node-api has no
`/archive` route. But both archive handles did `uri strip_prefix /trail` (resp.
the PR prefix), which forwards **`/archive`** to `:8282` → 404. The `/preview/<PR>/archive`
handle in `Caddyfile.preview` has the identical bug.

The **backend** is unaffected — it uses the bare `ARCHIVE_ENDPOINT=http://<MESA_NODE_HOST>:8282`
(root) directly, which returns 200. Only the browser-facing Caddy paths are misrouted.

## Fix

Rewrite the upstream path to `/` in both archive handles (instead of leaving `/archive`):

```diff
  handle /trail/archive {
-     uri strip_prefix /trail
+     rewrite * /
      ...
      reverse_proxy {$MESA_NODE_HOST}:8282 { ... }
  }
```

## Severity: latent (not an active outage)

The frontend worker (`ui/lib/multisigClient.worker.ts:153`) *configures*
`archive: ARCHIVE_ENDPOINT` in `Mina.Network`, but never calls
`fetchEvents`/`fetchActions` — its only o1js fetches are `fetchAccount` (which
hit the daemon). The contracts use events, not an Actions/Reducer, so no current
client flow reads the archive. This fixes the endpoint before anything depends
on it (and stops `/trail/archive` from being a confusing 404).

## Verify after deploy

```bash
curl -X POST -H 'content-type: application/json' \
  --data '{"query":"{ __typename }"}' https://mina-nodes.duckdns.org/trail/archive
# expect: {"data":{"__typename":"Query"}}
```