### PR TITLE
fix(e2e): cap Chromium V8 heap via E2E_V8_HEAP_MB on shared runners

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,10 +7,16 @@ const config = getNetworkConfig();
 // Give Chromium's V8 up to 75% of system RAM (capped at 32 GB, floor at 8 GB).
 // On a beefy self-hosted runner this eliminates the need for page recycling;
 // on a GitHub-hosted runner (~7 GB) it stays at the 8 GB floor.
-export const V8_HEAP_MB = Math.max(
-  8192,
-  Math.min(Math.floor(os.totalmem() / 1024 / 1024 * 0.75), 32768)
-);
+//
+// E2E_V8_HEAP_MB overrides the auto-sizing. Set it when the runner shares the
+// box with other services (e.g. the Mesa Trail node) — there, 75% of RAM lets a
+// single test browser OOM the whole machine. Page recycling already bounds WASM
+// memory (see e2e/README.md), so a few GB is plenty.
+const heapOverride = Number(process.env.E2E_V8_HEAP_MB);
+export const V8_HEAP_MB =
+  Number.isFinite(heapOverride) && heapOverride > 0
+    ? heapOverride
+    : Math.max(8192, Math.min(Math.floor(os.totalmem() / 1024 / 1024 * 0.75), 32768));
 
 export default defineConfig({
   testDir: '.',


### PR DESCRIPTION
## Problem

`e2e/playwright.config.ts` sizes Chromium's V8 heap to **75% of total RAM** (floor 8 GB, cap 32 GB):

```js
export const V8_HEAP_MB = Math.max(8192,
  Math.min(Math.floor(os.totalmem()/1024/1024 * 0.75), 32768));
// → --js-flags=--max-old-space-size=${V8_HEAP_MB}
```

On our 30 GB self-hosted runner that's **23.5 GB**. That's fine on a *dedicated* CI box, but this runner **shares the box with the Mesa Trail node stack** — so a single e2e browser can consume nearly all RAM and OOM the whole machine (observed: a chrome renderer at 8.4 GB climbing toward its 23.5 GB ceiling while the box hit swap and rebooted).

## Fix

Add a non-breaking `E2E_V8_HEAP_MB` env override; auto-sizing stays the default for dedicated runners:

```js
const heapOverride = Number(process.env.E2E_V8_HEAP_MB);
export const V8_HEAP_MB =
  Number.isFinite(heapOverride) && heapOverride > 0
    ? heapOverride
    : Math.max(8192, Math.min(Math.floor(os.totalmem()/1024/1024 * 0.75), 32768));
```

The suite already recycles the page every ~15 tx to bound WASM memory (`e2e/README.md`), so a few GB is plenty on a shared host. Set e.g. `E2E_V8_HEAP_MB=6144` in the shared runner's environment.

## Pairs with

A systemd `MemoryMax=` on the self-hosted runner service (operator-side) as a hard backstop, so a runaway job OOM-kills the *test*, not the node.