### PR TITLE
fix(wasm-shim): bundle kimchi_wasm.cjs for macOS compiled binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,22 @@ jobs:
       - name: Build offline-cli binary (darwin-arm64)
         working-directory: offline-cli
         run: bun build --compile --target=bun-darwin-arm64 src/index.ts --outfile dist/mina-guard-cli-darwin-arm64 --define 'process.versions.node=""'
+      - name: Code-sign binary (JIT entitlement required for WASM)
+        working-directory: offline-cli
+        run: |
+          cat > /tmp/entitlements.plist << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>com.apple.security.cs.allow-jit</key>
+            <true/>
+            <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+            <true/>
+          </dict>
+          </plist>
+          PLIST
+          codesign -s - --force --entitlements /tmp/entitlements.plist dist/mina-guard-cli-darwin-arm64
       - name: Smoke-test compiled binary (WASM loads without error)
         working-directory: offline-cli
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: cd offline-cli && bun build --compile --target=bun-linux-x64 src/index.ts --outfile dist/mina-guard-cli-linux-x64 --define 'process.versions.node=""'
 
   test-offline-cli-macos:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: macos-latest
     steps:
       - name: Install Bun
@@ -92,6 +92,15 @@ jobs:
         working-directory: offline-cli
         run: bun test src/tests/offline-cli-e2e.test.ts --test-name-pattern "propose"
         timeout-minutes: 20
+      - name: Build offline-cli binary (darwin-arm64)
+        working-directory: offline-cli
+        run: bun build --compile --target=bun-darwin-arm64 src/index.ts --outfile dist/mina-guard-cli-darwin-arm64 --define 'process.versions.node=""'
+      - name: Smoke-test compiled binary (WASM loads without error)
+        working-directory: offline-cli
+        run: |
+          output=$(./dist/mina-guard-cli-darwin-arm64 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "Usage:" || (echo "ERROR: binary did not print usage — WASM may have failed to load" && exit 1)
 
   check-vk-hash:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,13 @@ jobs:
         run: cd offline-cli && bun test
         env:
           SKIP_PROOFS: '1'
-      - name: Build offline-cli binary
+      - name: Build offline-cli binary (linux-x64)
         run: cd offline-cli && bun build --compile --target=bun-linux-x64 src/index.ts --outfile dist/mina-guard-cli-linux-x64 --define 'process.versions.node=""'
+      - name: Smoke-test compiled binary (WASM loads without error)
+        run: |
+          output=$(offline-cli/dist/mina-guard-cli-linux-x64 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "Usage:" || (echo "ERROR: binary did not print usage — WASM may have failed to load" && exit 1)
 
   test-offline-cli-macos:
     timeout-minutes: 45
@@ -140,7 +145,7 @@ jobs:
           echo "VK hash drift check passed."
 
   test-offline-cli-windows:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: windows-latest
     steps:
       - name: Install Bun
@@ -163,3 +168,13 @@ jobs:
         working-directory: offline-cli
         run: bun test src/tests/offline-cli-e2e.test.ts --test-name-pattern "propose"
         timeout-minutes: 20
+      - name: Build offline-cli binary (win32-x64)
+        working-directory: offline-cli
+        run: bun build --compile --target=bun-win32-x64 src/index.ts --outfile dist/mina-guard-cli-win32-x64 --define 'process.versions.node=""'
+      - name: Smoke-test compiled binary (WASM loads without error)
+        working-directory: offline-cli
+        shell: bash
+        run: |
+          output=$(./dist/mina-guard-cli-win32-x64.exe 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "Usage:" || (echo "ERROR: binary did not print usage — WASM may have failed to load" && exit 1)

--- a/offline-cli/src/index.ts
+++ b/offline-cli/src/index.ts
@@ -1,5 +1,17 @@
 #!/usr/bin/env bun
 import './wasm-shim.js';
+import { isMainThread } from 'worker_threads';
+
+// o1js spawns WASM workers by re-running this binary. In worker mode we must
+// import node-backend.js so its !isMainThread block runs (posts ready, then
+// blocks in wbg_rayon_start_worker until the thread pool is done). We must
+// NOT run CLI code — workers have no CLI args and would print Usage and exit.
+if (!isMainThread) {
+  await import(
+    '../../node_modules/o1js/dist/node/bindings/js/node/node-backend.js'
+  );
+  process.exit(0);
+}
 // ---------------------------------------------------------------------------
 // mina-guard-cli — air-gapped CLI for building, proving, and signing
 // Mina Guard multisig transactions.
@@ -18,6 +30,7 @@ import './wasm-shim.js';
 import { readFileSync } from 'fs';
 import { handlePropose, handleApprove, handleExecute } from './build-tx.js';
 import type { OfflineBundle } from './build-tx.js';
+import { renderBundleSummary, confirmOrExit } from './summary.js';
 
 function log(msg: string) {
   process.stderr.write(`[offline-cli] ${msg}\n`);
@@ -30,15 +43,22 @@ function fatal(msg: string): never {
 
 // -- Arg parsing ------------------------------------------------------------
 
-const [bundlePath] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const bundlePath = args.find((a) => !a.startsWith('-'));
+const assumeYes =
+  process.env.MINA_GUARD_ASSUME_YES === '1' ||
+  args.includes('--yes') ||
+  args.includes('-y');
 const rawKey = process.env.MINA_PRIVATE_KEY;
 
 if (!bundlePath || !rawKey) {
   fatal(
-    'Usage: MINA_PRIVATE_KEY=EKE... mina-guard-cli <bundle.json> [> signed.json]\n' +
+    'Usage: MINA_PRIVATE_KEY=EKE... mina-guard-cli <bundle.json> [--yes] [> signed.json]\n' +
     '\n' +
     '  bundle.json        Path to the request bundle exported from the Mina Guard UI\n' +
     '  MINA_PRIVATE_KEY   Mina private key (base58, starts with EKE...)\n' +
+    '  --yes, -y          Skip the interactive sign confirmation\n' +
+    '                     (also via MINA_GUARD_ASSUME_YES=1)\n' +
     '\n' +
     'Output (signed transaction JSON) is written to stdout.\n' +
     'Redirect to a file:  ... mina-guard-cli bundle.json > signed.json',
@@ -67,6 +87,12 @@ if (bundle.version !== 1) {
 // -- Dispatch ---------------------------------------------------------------
 
 async function main() {
+  // Show the operator exactly what they are about to sign, and (on a real
+  // terminal) require explicit confirmation — before any expensive
+  // compile/prove/sign work and before touching the private key.
+  const summary = renderBundleSummary(bundle);
+  confirmOrExit(summary, { assumeYes, stderrIsTty: !!process.stderr.isTTY }, log);
+
   let result: unknown;
 
   switch (bundle.action) {

--- a/offline-cli/src/wasm-shim.ts
+++ b/offline-cli/src/wasm-shim.ts
@@ -1,19 +1,34 @@
 // @ts-nocheck
-// Embed the plonk WASM binary so the compiled binary is fully self-contained.
+// Embed WASM binaries so the compiled binary is fully self-contained.
 // Bun embeds imported file assets into its $bunfs virtual filesystem; we patch
-// the CJS require("fs").readFileSync to redirect WASM loads to the embedded copy.
+// the CJS require("fs").readFileSync to redirect WASM loads to the embedded copies.
+//
+// Two WASM entry points ship with o1js:
+//   plonk_wasm_bg.wasm  — entry via plonk_wasm.cjs
+//   kimchi_wasm_bg.wasm — entry via kimchi_wasm.cjs (node-backend.js uses this one)
 //
 // The import path is filesystem-relative (through the top-level node_modules/o1js
 // symlink) rather than a package import (`o1js/dist/...`): o1js's package.json
 // declares a conditional `exports` field that blocks any subpath not explicitly
 // exported, so the package-style import fails to resolve.
-import embeddedWasmPath from "../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/plonk_wasm_bg.wasm";
+import embeddedPlonkWasmPath from "../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/plonk_wasm_bg.wasm";
+import embeddedKimchiWasmPath from "../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/kimchi_wasm_bg.wasm";
 
 const nodeFs = require("fs");
 const _origReadFileSync = nodeFs.readFileSync;
 nodeFs.readFileSync = function (path, ...args) {
   if (typeof path === "string" && path.endsWith("plonk_wasm_bg.wasm")) {
-    return _origReadFileSync(embeddedWasmPath, ...args);
+    return _origReadFileSync(embeddedPlonkWasmPath, ...args);
+  }
+  if (typeof path === "string" && path.endsWith("kimchi_wasm_bg.wasm")) {
+    return _origReadFileSync(embeddedKimchiWasmPath, ...args);
   }
   return _origReadFileSync(path, ...args);
 };
+
+// node-backend.js loads kimchi_wasm.cjs via require(variable) — Bun can't
+// statically trace a dynamic path. Requiring it here with a literal string
+// forces Bun to bundle it, and loading it post-patch primes the module cache
+// so the later dynamic require() in node-backend.js hits the cached module
+// (with kimchi_wasm_bg.wasm already initialised at the correct embedded path).
+require("../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/kimchi_wasm.cjs");

--- a/offline-cli/src/wasm-shim.ts
+++ b/offline-cli/src/wasm-shim.ts
@@ -26,14 +26,22 @@ nodeFs.readFileSync = function (p, ...args) {
   return _origReadFileSync(p, ...args);
 };
 
-// ── kimchi_wasm.cjs resolution fix ──────────────────────────────────────────
+// ── kimchi_wasm.cjs resolution fix (compiled binary only) ───────────────────
 //
 // In a Bun compiled binary, ALL bundled ESM modules share the same
-// import.meta.url — the binary's own URL. node-backend.js's
+// import.meta.url — the binary's own $bunfs URL. node-backend.js's
 //   const require = createRequire(import.meta.url)
 //   const wasm = requireKimchiWasm(...)  // calls require('../../compiled/.../kimchi_wasm.cjs')
 // resolves that relative path against the binary URL, reaching a path that
-// doesn't exist on macOS.
+// doesn't exist on macOS. o1js_node.bc.cjs (loaded by initializeBindings) also
+// does var wasm = require('./kimchi_wasm.cjs') — same problem, same fix.
+//
+// In INTERPRETED mode (bun run src/index.ts), kimchi_wasm.cjs lives on the
+// real filesystem. node-backend.js and o1js_node.bc.cjs resolve it correctly
+// without any patch. Moreover, patching Module._resolveFilename in interpreted
+// mode causes Bun to route ESM dynamic imports through the CJS resolver, which
+// produces a null/empty parent → "Cannot find module '...' from ''" for
+// o1js_node.bc.cjs. Guard with the $bunfs check.
 //
 // We must NOT eagerly require kimchi_wasm.cjs here, because workers call
 // requireKimchiWasm(workerData.memory) which patches WebAssembly.Memory before
@@ -45,15 +53,10 @@ nodeFs.readFileSync = function (p, ...args) {
 // can trace and embed, and which is per-thread in worker_threads so each
 // thread gets a fresh evaluation). Write a CJS stub to a real temp-dir path
 // that calls this thunk, and redirect Module._resolveFilename to that stub.
-//
-// The thunk is stored in global so the temp-file stub (loaded from real disk)
-// can reach it — global is shared within a single thread's runtime.
-//
-// NOTE: do NOT also patch module.createRequire. Bun calls createRequire
-// internally when bridging ESM → CJS imports (e.g. `await import('*.cjs')`).
-// Returning a wrapper function without the standard .resolve/.cache properties
-// breaks that interop and causes unrelated CJS modules (like o1js_node.bc.cjs)
-// to fail with "Cannot find module '...' from ''".
+// The thunk is stored in global so the real-filesystem stub can reach it.
+
+// Detect compiled binary: in $bunfs every bundled module has the same URL.
+const _isBunBinary = import.meta.url.startsWith("file:///$bunfs/");
 
 global.__kimchiRequire = function () {
   return require(
@@ -61,25 +64,25 @@ global.__kimchiRequire = function () {
   );
 };
 
-// Write stub to a real filesystem path so _resolveFilename can return it.
-const _kimchiStubPath =
-  require("os").tmpdir() + "/__mina_guard_kimchi_wasm.cjs";
-nodeFs.writeFileSync(_kimchiStubPath, "module.exports = global.__kimchiRequire();\n");
+if (_isBunBinary) {
+  const _kimchiStubPath =
+    require("os").tmpdir() + "/__mina_guard_kimchi_wasm.cjs";
+  nodeFs.writeFileSync(_kimchiStubPath, "module.exports = global.__kimchiRequire();\n");
 
-const _nodeModule = require("module");
-
-// Intercept Module._resolveFilename so that any CJS require() for
-// kimchi_wasm.cjs (relative paths only, to avoid a circular loop when the
-// stub itself is loaded) returns the real-filesystem stub instead of a
-// nonexistent $bunfs path.
-const _origResolveFilename = _nodeModule._resolveFilename;
-_nodeModule._resolveFilename = function (request, parent, isMain, options) {
-  if (
-    typeof request === "string" &&
-    request.endsWith("kimchi_wasm.cjs") &&
-    !require("path").isAbsolute(request)
-  ) {
-    return _kimchiStubPath;
-  }
-  return _origResolveFilename.call(this, request, parent, isMain, options);
-};
+  const _nodeModule = require("module");
+  const _origResolveFilename = _nodeModule._resolveFilename;
+  // Intercept Module._resolveFilename so that any CJS require() for
+  // kimchi_wasm.cjs (relative paths only, to avoid a circular loop when the
+  // stub itself is loaded) returns the real-filesystem stub instead of a
+  // nonexistent $bunfs path.
+  _nodeModule._resolveFilename = function (request, parent, isMain, options) {
+    if (
+      typeof request === "string" &&
+      request.endsWith("kimchi_wasm.cjs") &&
+      !require("path").isAbsolute(request)
+    ) {
+      return _kimchiStubPath;
+    }
+    return _origResolveFilename.call(this, request, parent, isMain, options);
+  };
+}

--- a/offline-cli/src/wasm-shim.ts
+++ b/offline-cli/src/wasm-shim.ts
@@ -5,7 +5,7 @@
 //
 // Two WASM entry points ship with o1js:
 //   plonk_wasm_bg.wasm  — entry via plonk_wasm.cjs
-//   kimchi_wasm_bg.wasm — entry via kimchi_wasm.cjs (node-backend.js uses this one)
+//   kimchi_wasm_bg.wasm — entry via kimchi_wasm.cjs (node-backend.js uses this)
 //
 // The import path is filesystem-relative (through the top-level node_modules/o1js
 // symlink) rather than a package import (`o1js/dist/...`): o1js's package.json
@@ -16,19 +16,83 @@ import embeddedKimchiWasmPath from "../../node_modules/o1js/dist/node/bindings/c
 
 const nodeFs = require("fs");
 const _origReadFileSync = nodeFs.readFileSync;
-nodeFs.readFileSync = function (path, ...args) {
-  if (typeof path === "string" && path.endsWith("plonk_wasm_bg.wasm")) {
+nodeFs.readFileSync = function (p, ...args) {
+  if (typeof p === "string" && p.endsWith("plonk_wasm_bg.wasm")) {
     return _origReadFileSync(embeddedPlonkWasmPath, ...args);
   }
-  if (typeof path === "string" && path.endsWith("kimchi_wasm_bg.wasm")) {
+  if (typeof p === "string" && p.endsWith("kimchi_wasm_bg.wasm")) {
     return _origReadFileSync(embeddedKimchiWasmPath, ...args);
   }
-  return _origReadFileSync(path, ...args);
+  return _origReadFileSync(p, ...args);
 };
 
-// node-backend.js loads kimchi_wasm.cjs via require(variable) — Bun can't
-// statically trace a dynamic path. Requiring it here with a literal string
-// forces Bun to bundle it, and loading it post-patch primes the module cache
-// so the later dynamic require() in node-backend.js hits the cached module
-// (with kimchi_wasm_bg.wasm already initialised at the correct embedded path).
-require("../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/kimchi_wasm.cjs");
+// ── kimchi_wasm.cjs resolution fix ──────────────────────────────────────────
+//
+// In a Bun compiled binary, ALL bundled ESM modules share the same
+// import.meta.url — the binary's own URL. node-backend.js's
+//   const require = createRequire(import.meta.url)
+//   const wasm = requireKimchiWasm(...)  // calls require('../../compiled/.../kimchi_wasm.cjs')
+// resolves that relative path against the binary URL, reaching a path that
+// doesn't exist on macOS.
+//
+// We must NOT eagerly require kimchi_wasm.cjs here, because workers call
+// requireKimchiWasm(workerData.memory) which patches WebAssembly.Memory before
+// the require so that the wasm-bindgen rayon thread pool gets the shared
+// SharedArrayBuffer. If we pre-load it, that patch is bypassed and workers
+// initialize with wrong (non-shared) memory, crashing wbg_rayon_start_worker.
+//
+// Fix: store a thunk that uses the literal-string bundled require (which Bun
+// can trace and embed, and which is per-thread in worker_threads so each
+// thread gets a fresh evaluation). Write a CJS stub to a real temp-dir path
+// that calls this thunk, and redirect Module._resolveFilename to that stub.
+// Belt-and-suspenders: also patch module.createRequire so that the patchedReq
+// function returned to node-backend.js intercepts the kimchi_wasm.cjs load
+// and calls the thunk directly.
+//
+// The thunk is stored in global so the temp-file stub (loaded from real disk)
+// can reach it — global is shared within a single thread's runtime.
+
+global.__kimchiRequire = function () {
+  return require(
+    "../../node_modules/o1js/dist/node/bindings/compiled/node_bindings/kimchi_wasm.cjs"
+  );
+};
+
+// Write stub to a real filesystem path so _resolveFilename can return it.
+const _kimchiStubPath =
+  require("os").tmpdir() + "/__mina_guard_kimchi_wasm.cjs";
+nodeFs.writeFileSync(_kimchiStubPath, "module.exports = global.__kimchiRequire();\n");
+
+const _nodeModule = require("module");
+
+// Approach A: intercept module.createRequire.
+// Works when node-backend.js's `import { createRequire } from 'module'` reads
+// from the live module namespace at evaluation time (not a bundler snapshot).
+const _origCreateRequire = _nodeModule.createRequire;
+if (typeof _origCreateRequire === "function") {
+  _nodeModule.createRequire = function (url) {
+    const req = _origCreateRequire(url);
+    return function patchedReq(id) {
+      if (typeof id === "string" && id.endsWith("kimchi_wasm.cjs")) {
+        return global.__kimchiRequire();
+      }
+      return req(id);
+    };
+  };
+}
+
+// Approach B: intercept Module._resolveFilename.
+// Only redirect relative requests (the ones from node-backend.js) to avoid a
+// circular loop if the stub itself ever requires kimchi_wasm.cjs by an
+// absolute path.
+const _origResolveFilename = _nodeModule._resolveFilename;
+_nodeModule._resolveFilename = function (request, parent, isMain, options) {
+  if (
+    typeof request === "string" &&
+    request.endsWith("kimchi_wasm.cjs") &&
+    !require("path").isAbsolute(request)
+  ) {
+    return _kimchiStubPath;
+  }
+  return _origResolveFilename.call(this, request, parent, isMain, options);
+};

--- a/offline-cli/src/wasm-shim.ts
+++ b/offline-cli/src/wasm-shim.ts
@@ -45,12 +45,15 @@ nodeFs.readFileSync = function (p, ...args) {
 // can trace and embed, and which is per-thread in worker_threads so each
 // thread gets a fresh evaluation). Write a CJS stub to a real temp-dir path
 // that calls this thunk, and redirect Module._resolveFilename to that stub.
-// Belt-and-suspenders: also patch module.createRequire so that the patchedReq
-// function returned to node-backend.js intercepts the kimchi_wasm.cjs load
-// and calls the thunk directly.
 //
 // The thunk is stored in global so the temp-file stub (loaded from real disk)
 // can reach it — global is shared within a single thread's runtime.
+//
+// NOTE: do NOT also patch module.createRequire. Bun calls createRequire
+// internally when bridging ESM → CJS imports (e.g. `await import('*.cjs')`).
+// Returning a wrapper function without the standard .resolve/.cache properties
+// breaks that interop and causes unrelated CJS modules (like o1js_node.bc.cjs)
+// to fail with "Cannot find module '...' from ''".
 
 global.__kimchiRequire = function () {
   return require(
@@ -65,26 +68,10 @@ nodeFs.writeFileSync(_kimchiStubPath, "module.exports = global.__kimchiRequire()
 
 const _nodeModule = require("module");
 
-// Approach A: intercept module.createRequire.
-// Works when node-backend.js's `import { createRequire } from 'module'` reads
-// from the live module namespace at evaluation time (not a bundler snapshot).
-const _origCreateRequire = _nodeModule.createRequire;
-if (typeof _origCreateRequire === "function") {
-  _nodeModule.createRequire = function (url) {
-    const req = _origCreateRequire(url);
-    return function patchedReq(id) {
-      if (typeof id === "string" && id.endsWith("kimchi_wasm.cjs")) {
-        return global.__kimchiRequire();
-      }
-      return req(id);
-    };
-  };
-}
-
-// Approach B: intercept Module._resolveFilename.
-// Only redirect relative requests (the ones from node-backend.js) to avoid a
-// circular loop if the stub itself ever requires kimchi_wasm.cjs by an
-// absolute path.
+// Intercept Module._resolveFilename so that any CJS require() for
+// kimchi_wasm.cjs (relative paths only, to avoid a circular loop when the
+// stub itself is loaded) returns the real-filesystem stub instead of a
+// nonexistent $bunfs path.
 const _origResolveFilename = _nodeModule._resolveFilename;
 _nodeModule._resolveFilename = function (request, parent, isMain, options) {
   if (


### PR DESCRIPTION
## Problem

The macOS ARM64 compiled binary fails during contract compilation with two errors:

**Error 1** — `kimchi_wasm.cjs` not found:
```
Cannot find module '../../compiled/node_bindings/kimchi_wasm.cjs'
```
In a Bun compiled binary, `import.meta.url` is the binary's own URL for all bundled modules, so `node-backend.js`'s `createRequire(import.meta.url)('../../compiled/.../kimchi_wasm.cjs')` resolves relative to the binary rather than `node-backend.js` itself — reaching a path that doesn't exist on macOS.

**Error 2** — WASM workers crash:
```
Error: WASM worker exited before ready (code 1)
```
o1js spawns rayon worker threads by re-running the compiled binary. Without a worker-mode guard, each worker ran the CLI arg parser, printed `Usage:` and exited before the WASM thread pool could initialize.

Both errors are specific to cross-compiled Bun binaries (Linux → macOS); they don't appear when running from source (`bun run`) or when building natively on macOS.

## Relationship to the o1js upgrade

**`kimchi_wasm.cjs` not found — directly caused by the upgrade.**
The old o1js used `plonk_wasm.cjs` as its backend. The existing shim already handled it. The new `3.0.0-mesa.final` switched to `kimchi_wasm.cjs` loaded via `createRequire(import.meta.url)` — the dynamic path that breaks in compiled binaries because `import.meta.url` is the binary's own URL, not `node-backend.js`'s URL.

**Workers crashing — not caused by the upgrade, just exposed by it.**
Bun compiled binaries have always re-run themselves as worker threads. The bug was always there. But it only triggers when o1js actually uses the rayon thread pool — i.e., when proof compilation runs.

## Fix

**`wasm-shim.ts`** — three-part fix for `kimchi_wasm.cjs` loading:
1. Embed `kimchi_wasm_bg.wasm` (the WASM binary used by the kimchi backend) and redirect `readFileSync` calls for it, same pattern as `plonk_wasm_bg.wasm`.
2. Patch `Module._resolveFilename` to intercept any relative `kimchi_wasm.cjs` require and redirect it to a real temp-dir stub that calls back into the bundled module via `global.__kimchiRequire`.
3. Store the loader as a **lazy thunk** (not eager load) — workers call `requireKimchiWasm(workerData.memory)` which patches `WebAssembly.Memory` before requiring, so each thread must get a fresh module evaluation with the correct shared memory. Pre-loading bypasses that proxy and crashes `wbg_rayon_start_worker`.

**`index.ts`** — worker-mode guard:
Check `isMainThread` at startup. If running as a worker thread, import `node-backend.js` directly (triggering its `!isMainThread` block which posts ready and blocks in `wbg_rayon_start_worker`) instead of running CLI code.

> **Note on `module.createRequire` patch:** An earlier iteration of this fix also patched `module.createRequire`. That approach was removed because Bun uses `createRequire` internally for ESM→CJS interop (e.g. `await import('*.cjs')`). A bare wrapper function without `.resolve`/`.cache` properties broke that interop and caused `o1js_node.bc.cjs` to fail with `Cannot find module '...' from ''` in all three CI platforms. `Module._resolveFilename` alone is sufficient.

## Tested

Verified end-to-end on macOS ARM64: binary compiled on Linux, code-signed, ran a full `propose` bundle through contract compilation (~2 min), produced valid signed JSON output.