### PR TITLE
chore(ci): rename deploy.yml to deploy-lightnet.yml (pair with deploy-trail.yml)

### DIFF
--- a/.github/workflows/deploy-lightnet.yml
+++ b/.github/workflows/deploy-lightnet.yml
@@ -1,4 +1,4 @@
-name: Deploy main
+name: Deploy lightnet (/app)
 
 on:
   push:

--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -1,5 +1,5 @@
 # Auto-deploys the Mesa Trail webapp stack to prod when main is pushed
-# (e.g., when a PR merges). Mirrors deploy.yml's pattern for the localnet
+# (e.g., when a PR merges). Mirrors deploy-lightnet.yml's pattern for the localnet
 # /app/* deploy but targets the trail compose project + /trail/* routes.
 #
 # Self-hosted runner is on the prod-facing box; the actual deploy happens
@@ -22,7 +22,7 @@
 #
 # To tighten later: add a `paths:` filter under `on.push` so this only
 # fires when trail-relevant files change. Today it fires on every main
-# push for consistency with deploy.yml.
+# push for consistency with deploy-lightnet.yml.
 
 name: Deploy Mesa Trail
 

--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Reset
         # Safety net for quiet periods on main: same `down && up` sequence
-        # as deploy.yml, so the stack self-heals from bloat/drift every 3
+        # as deploy-lightnet.yml, so the stack self-heals from bloat/drift every 3
         # days even if nothing has been pushed.
         run: |
           chmod +x deploy/deploy.sh


### PR DESCRIPTION
Small naming-cleanup PR.

## What
Rename the CI workflow `deploy.yml` to `deploy-lightnet.yml` and its display name `Deploy main` to `Deploy lightnet (/app)`. Update the three filename references in comments (`deploy-trail.yml` x2, `reset.yml` x1).

## Why
`deploy.yml` deploys the lightnet `/app` stack, but next to `deploy-trail.yml` it reads like "the" deploy. Naming both by network (`deploy-lightnet` / `deploy-trail`) removes the ambiguity. `deploy-trail.yml` already calls itself "Mirrors deploy.yml's pattern for the localnet", so this makes the pair self-consistent.

## Risk: low
- Filename-only. No `workflow_run` triggers or `gh workflow run` automation reference it by filename.
- Branch-protection required checks key off the check/job name, not the filename. The display name does change to "Deploy lightnet (/app)"; if a required check references the old "Deploy main", update it in Settings -> Branches.
- Old Actions run history stays under the old entry; the renamed file starts fresh.

## Out of scope
- `preview-deploy.yml` left as-is (no `preview-deploy-trail.yml` sibling to disambiguate from).
- `deploy/deploy.sh` has the same asymmetry vs `deploy-trail.sh`; renaming it would be a natural follow-up, left out to keep this focused.