### PR TITLE
ci(e2e): scope concurrency group to branch to stop cross-PR cancellations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: e2e-runner
+  group: e2e-runner-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

`e2e.yml` used a global concurrency group (`e2e-runner`) shared across all branches and PRs. With `cancel-in-progress: true`, any new e2e trigger cancelled every other in-flight e2e run — regardless of which PR it belonged to. With 4+ active PRs today, no run could complete before being cancelled by another PR's push.

## Fix

Scope the concurrency group to the branch:

```yaml
group: e2e-runner-${{ github.ref }}
```

Each PR now gets its own slot. A new push to PR A cancels PR A's previous run, not PR B's.