### PR TITLE
ci: gate trail deploy behind the Production environment

### DIFF
--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -38,6 +38,12 @@ concurrency:
 jobs:
   deploy:
     runs-on: [self-hosted, deploy]
+    # Gates the deploy behind a second account. The `Production` environment
+    # has required reviewers with `prevent_self_review`, so whoever merged
+    # cannot also approve the rollout. Without this key the environment's
+    # protection rules do not apply at all — they only bind jobs that
+    # reference the environment.
+    environment: Production
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `Production` environment already has required reviewers (`graikos`, `mitschabaude`) and `prevent_self_review` — but **no workflow referenced it**, so the protection rules were inert. Environment protection only binds jobs that declare `environment:`.

Adds `environment: Production` to the `deploy` job in `deploy-trail.yml`. The rollout now pauses on merge and waits for approval from a second account; whoever merged cannot approve their own deploy.

`deploy-lightnet.yml` is deliberately left ungated — it targets the throwaway lightnet stack, not production.