### PR TITLE
ci: split runner labels for the three-box migration

### DIFF
--- a/.github/workflows/deploy-lightnet.yml
+++ b/.github/workflows/deploy-lightnet.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, deploy]
+    runs-on: [self-hosted, deploy-lightnet]
     steps:
       - name: Verify branch is main
         run: |

--- a/.github/workflows/deploy-trail.yml
+++ b/.github/workflows/deploy-trail.yml
@@ -27,8 +27,11 @@
 name: Deploy Mesa Trail
 
 on:
-  push:
-    branches: [main]
+  # Auto-deploy on merge is disabled during the three-box migration: the
+  # trail box intentionally runs no self-hosted `deploy` runner, so a
+  # push-triggered job would queue forever with no matching runner. Deploy
+  # manually over SSH for now; restore a trigger when the pull-based deploy
+  # (Option B) lands. See mina-guard-ops architecture.md 10.5.
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -31,7 +31,7 @@ jobs:
   deploy:
     # Only run on PRs from the same repo (not forks) to prevent arbitrary code execution on the server
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, deploy]
+    runs-on: [self-hosted, deploy-lightnet]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -143,7 +143,7 @@ jobs:
 
   teardown:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, deploy]
+    runs-on: [self-hosted, deploy-lightnet]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   reset:
-    runs-on: [self-hosted, deploy]
+    runs-on: [self-hosted, deploy-lightnet]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Part of the three-box migration (mina-guard-ops architecture.md §10.5 / §3). Splits CI runner labels so the deploy-lightnet box's runner can only pick up untrusted workloads, never a trail production deploy.

**Relabels the deploy-lightnet-box workflows** off the shared `deploy` label onto `deploy-lightnet`:
- `deploy-lightnet.yml`
- `preview-deploy.yml` (both jobs)
- `reset.yml`

`e2e.yml` already uses `e2e` — unchanged.

**Why:** `deploy-trail.yml` also uses `[self-hosted, deploy]`. If the deploy-lightnet box's runner carried the `deploy` label, trail production deploys would execute on that box — the opposite of the isolation being built. After this, the deploy-lightnet runner carries `{e2e, deploy-lightnet}` and matches previews/app/reset/e2e but **not** trail.

**Also disables `deploy-trail.yml`'s push-on-merge trigger** (keeps `workflow_dispatch`). During the migration the trail box has no self-hosted `deploy` runner by design, so a push-triggered deploy would queue forever with no matching runner. Deploy trail manually over SSH until the pull-based deploy (Option B) lands, then restore a trigger.

> Note: overlaps with #97 (adds `environment: Production` to the `deploy` job in the same file). Different regions — `on:` block here vs the job's `environment:` there — so they merge cleanly; just be aware both touch `deploy-trail.yml`.

Runner side (not in this PR): set the deploy-lightnet box's runner labels to `e2e` + `deploy-lightnet`, and remove the `e2e` runner from the node box.
