### PR TITLE
ci(trail): build, sign & publish /trail images (pull-based deploy, phase 1)

### DIFF
--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -37,13 +37,13 @@ env:
   IMAGE_PREFIX: ghcr.io/zksecurity/mina-guard/trail
   # Public build-time config baked into the frontend bundle. Mirrors the values
   # previously hardcoded in deploy/docker-compose.trail.yml. Change these if the
-  # trail domain moves off mina-nodes.duckdns.org/trail.
+  # trail domain moves off mina-trail.duckdns.org/trail.
   NEXT_PUBLIC_BASE_PATH: /trail
-  NEXT_PUBLIC_API_BASE_URL: https://mina-nodes.duckdns.org/trail
-  NEXT_PUBLIC_MINA_ENDPOINT: https://mina-nodes.duckdns.org/trail/graphql
-  NEXT_PUBLIC_ARCHIVE_ENDPOINT: https://mina-nodes.duckdns.org/trail/archive
+  NEXT_PUBLIC_API_BASE_URL: https://mina-trail.duckdns.org/trail
+  NEXT_PUBLIC_MINA_ENDPOINT: https://mina-trail.duckdns.org/trail/graphql
+  NEXT_PUBLIC_ARCHIVE_ENDPOINT: https://mina-trail.duckdns.org/trail/archive
   NEXT_PUBLIC_MINA_NETWORK: testnet
-  NEXT_PUBLIC_BLOCK_EXPLORER_URL: https://mina-nodes.duckdns.org/trail/explorer
+  NEXT_PUBLIC_BLOCK_EXPLORER_URL: https://mina-trail.duckdns.org/trail/explorer
   NEXT_PUBLIC_POLL_INTERVAL_MS: "1000"
 
 jobs:

--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -1,10 +1,12 @@
 name: Trail release (build · sign · publish)
 
 # Pull-based deploy, phase 1. Builds the /trail images, pushes them
-# to GHCR by digest, and signs each digest with cosign keyless (GitHub OIDC →
-# Fulcio, logged to Rekor — the PUBLIC Sigstore services, so signing here and
-# verification on the box are an external availability dependency on
-# fulcio/rekor.sigstore.dev). NOTHING here touches the trail box — the box pulls
+# to GHCR by digest, and attaches a GitHub build-provenance attestation to each
+# digest (actions/attest-build-provenance — keyless, Sigstore-backed: GitHub OIDC
+# → Fulcio → Rekor). The box verifies with `gh attestation verify` before running
+# (phase 2). Signing here and verification on the box are an external availability
+# dependency on the Sigstore/GitHub attestation services.
+# NOTHING here touches the trail box — the box pulls
 # and verifies these images itself (phase 2). This replaces the self-hosted
 # `deploy` runner path: nothing pushes to the box, so no party with repo
 # write access can execute on it via a pushed-branch workflow.
@@ -32,8 +34,9 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write   # push images to GHCR
-  id-token: write   # keyless cosign signing via OIDC
+  packages: write       # push images to GHCR
+  id-token: write       # keyless signing via OIDC (Sigstore)
+  attestations: write   # write the build-provenance attestations
 
 env:
   IMAGE_PREFIX: ghcr.io/zksecurity/mina-guard/trail
@@ -72,8 +75,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: sigstore/cosign-installer@v3
 
       - name: Build & push — backend
         id: backend
@@ -121,13 +122,28 @@ jobs:
           build-args: |
             NEXT_PUBLIC_BASE_PATH=/trail/explorer
 
-      - name: Sign images by digest (keyless)
-        env:
-          COSIGN_YES: "true"
-        run: |
-          cosign sign "${{ env.IMAGE_PREFIX }}-backend@${{ steps.backend.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}-frontend@${{ steps.frontend.outputs.digest }}"
-          cosign sign "${{ env.IMAGE_PREFIX }}-explorer@${{ steps.explorer.outputs.digest }}"
+      # Build-provenance attestations (SLSA), pushed to GHCR as OCI referrers
+      # alongside each image so the box can verify with `gh attestation verify`.
+      - name: Attest — backend
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}-backend
+          subject-digest: ${{ steps.backend.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest — frontend
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}-frontend
+          subject-digest: ${{ steps.frontend.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest — explorer
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}-explorer
+          subject-digest: ${{ steps.explorer.outputs.digest }}
+          push-to-registry: true
 
       - name: Publish digest manifest
         # The box's pull agent (phase 2) can pull :main and verify, or pin these

--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -1,0 +1,147 @@
+name: Trail release (build · sign · publish)
+
+# Option B, phase 1 (pull-based deploy). Builds the /trail images, pushes them
+# to GHCR by digest, and signs each digest with cosign keyless (GitHub OIDC →
+# Fulcio, logged to Rekor). NOTHING here touches the trail box — the box pulls
+# and verifies these images itself (phase 2). This replaces the self-hosted
+# `deploy` runner path, closing the box-root exposure in
+# mina-guard-ops/architecture.md §10.5 (issue 4).
+#
+# ── BEFORE GO-LIVE (required) ─────────────────────────────────────────────
+#  1. Pin every `uses:` below to a full commit SHA. This is a release pipeline
+#     that SIGNS artifacts users run; mutable tags are a supply-chain hole
+#     (same finding as desktop-release.yml). Dependabot (github-actions
+#     ecosystem, already configured) will then keep the SHAs current.
+#  2. Confirm the `Production` environment has required reviewers with
+#     prevent-self-review. That is the second-account gate — it now lives HERE
+#     (it makes PR #97's gate on the old deploy job redundant; close #97).
+#  3. Make the three GHCR packages readable by the box's pull token
+#     (phase 2 / runbook).
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: trail-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write   # push images to GHCR
+  id-token: write   # keyless cosign signing via OIDC
+
+env:
+  IMAGE_PREFIX: ghcr.io/zksecurity/mina-guard/trail
+  # Public build-time config baked into the frontend bundle. Mirrors the values
+  # previously hardcoded in deploy/docker-compose.trail.yml. Change these if the
+  # trail domain moves off mina-nodes.duckdns.org/trail.
+  NEXT_PUBLIC_BASE_PATH: /trail
+  NEXT_PUBLIC_API_BASE_URL: https://mina-nodes.duckdns.org/trail
+  NEXT_PUBLIC_MINA_ENDPOINT: https://mina-nodes.duckdns.org/trail/graphql
+  NEXT_PUBLIC_ARCHIVE_ENDPOINT: https://mina-nodes.duckdns.org/trail/archive
+  NEXT_PUBLIC_MINA_NETWORK: testnet
+  NEXT_PUBLIC_BLOCK_EXPLORER_URL: https://mina-nodes.duckdns.org/trail/explorer
+  NEXT_PUBLIC_POLL_INTERVAL_MS: "1000"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: Production   # second-account approval gate (supersedes #97)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive   # ui/deps/o1js submodule the frontend build needs
+
+      - name: Read MinaGuard VK hash
+        id: vk
+        # A property of the contract source, committed at contracts/.vk-hash;
+        # the backend takes it as a build arg and the indexer filters by it.
+        run: |
+          h=$(grep -vE '^[[:space:]]*#' contracts/.vk-hash | tr -d '[:space:]')
+          [ -n "$h" ] || { echo "::error::contracts/.vk-hash parsed empty"; exit 1; }
+          echo "hash=$h" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Build & push — backend
+        id: backend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: preview-env/Dockerfile.backend
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-backend:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}-backend:main
+          build-args: |
+            MINAGUARD_VK_HASH=${{ steps.vk.outputs.hash }}
+
+      - name: Build & push — frontend
+        id: frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: preview-env/Dockerfile.frontend
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-frontend:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}-frontend:main
+          build-args: |
+            NEXT_PUBLIC_BASE_PATH=${{ env.NEXT_PUBLIC_BASE_PATH }}
+            NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
+            NEXT_PUBLIC_MINA_ENDPOINT=${{ env.NEXT_PUBLIC_MINA_ENDPOINT }}
+            NEXT_PUBLIC_ARCHIVE_ENDPOINT=${{ env.NEXT_PUBLIC_ARCHIVE_ENDPOINT }}
+            NEXT_PUBLIC_MINA_NETWORK=${{ env.NEXT_PUBLIC_MINA_NETWORK }}
+            NEXT_PUBLIC_BLOCK_EXPLORER_URL=${{ env.NEXT_PUBLIC_BLOCK_EXPLORER_URL }}
+            NEXT_PUBLIC_POLL_INTERVAL_MS=${{ env.NEXT_PUBLIC_POLL_INTERVAL_MS }}
+            ENABLE_SOURCE_MAPS=false
+
+      - name: Build & push — explorer
+        id: explorer
+        uses: docker/build-push-action@v6
+        with:
+          context: preview-env
+          file: preview-env/Dockerfile.explorer
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-explorer:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}-explorer:main
+          build-args: |
+            NEXT_PUBLIC_BASE_PATH=/trail/explorer
+
+      - name: Sign images by digest (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign "${{ env.IMAGE_PREFIX }}-backend@${{ steps.backend.outputs.digest }}"
+          cosign sign "${{ env.IMAGE_PREFIX }}-frontend@${{ steps.frontend.outputs.digest }}"
+          cosign sign "${{ env.IMAGE_PREFIX }}-explorer@${{ steps.explorer.outputs.digest }}"
+
+      - name: Publish digest manifest
+        # The box's pull agent (phase 2) can pull :main and verify, or pin these
+        # exact digests. Emitted as a build artifact for traceability.
+        run: |
+          cat > trail-images.json <<EOF
+          {
+            "backend":  "${{ env.IMAGE_PREFIX }}-backend@${{ steps.backend.outputs.digest }}",
+            "frontend": "${{ env.IMAGE_PREFIX }}-frontend@${{ steps.frontend.outputs.digest }}",
+            "explorer": "${{ env.IMAGE_PREFIX }}-explorer@${{ steps.explorer.outputs.digest }}",
+            "sha": "${{ github.sha }}",
+            "vk_hash": "${{ steps.vk.outputs.hash }}"
+          }
+          EOF
+          cat trail-images.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trail-images
+          path: trail-images.json

--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -19,8 +19,9 @@ name: Trail release (build · sign · publish)
 #  2. Confirm the `Production` environment has required reviewers with
 #     prevent-self-review. That is the second-account gate — it now lives HERE
 #     (the required-reviewer gate on the old on-box deploy job is then redundant).
-#  3. Make the three GHCR packages readable by the box's pull token
-#     (phase 2 / runbook).
+#  3. Make the three GHCR packages PUBLIC (after the first run creates them) so
+#     the box pulls anonymously — no pull token to store/rotate. They're built
+#     from open-source code and bake in nothing secret. See the phase-2 runbook.
 # ──────────────────────────────────────────────────────────────────────────
 
 on:

--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -66,17 +66,10 @@ jobs:
         id: vk
         # A property of the contract source, committed at contracts/.vk-hash;
         # the backend takes it as a build arg and the indexer filters by it.
-        # .vk-hash is the keyed per-network format (testnet=… / mainnet=…);
-        # trail is a testnet deploy (compose: NEXT_PUBLIC_MINA_NETWORK=testnet),
-        # so select the testnet line. Validate it's a bare decimal — the old
-        # `tr -d` collapsed both lines into "testnet=…mainnet=…" and the [ -n ]
-        # check passed it straight into the image.
+        # trail is a testnet deploy (compose: NEXT_PUBLIC_MINA_NETWORK=testnet).
+        # read-vk-hash.sh is the single validated parser for the keyed file.
         run: |
-          net=testnet
-          h=$(grep -E "^[[:space:]]*${net}=" contracts/.vk-hash | head -1 | cut -d= -f2- | tr -d '[:space:]')
-          case "$h" in
-            ''|*[!0-9]*) echo "::error::contracts/.vk-hash: '${net}=' hash missing or non-numeric ('$h')"; exit 1 ;;
-          esac
+          h=$(contracts/scripts/read-vk-hash.sh testnet) || exit 1
           echo "hash=$h" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3

--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -66,9 +66,17 @@ jobs:
         id: vk
         # A property of the contract source, committed at contracts/.vk-hash;
         # the backend takes it as a build arg and the indexer filters by it.
+        # .vk-hash is the keyed per-network format (testnet=… / mainnet=…);
+        # trail is a testnet deploy (compose: NEXT_PUBLIC_MINA_NETWORK=testnet),
+        # so select the testnet line. Validate it's a bare decimal — the old
+        # `tr -d` collapsed both lines into "testnet=…mainnet=…" and the [ -n ]
+        # check passed it straight into the image.
         run: |
-          h=$(grep -vE '^[[:space:]]*#' contracts/.vk-hash | tr -d '[:space:]')
-          [ -n "$h" ] || { echo "::error::contracts/.vk-hash parsed empty"; exit 1; }
+          net=testnet
+          h=$(grep -E "^[[:space:]]*${net}=" contracts/.vk-hash | head -1 | cut -d= -f2- | tr -d '[:space:]')
+          case "$h" in
+            ''|*[!0-9]*) echo "::error::contracts/.vk-hash: '${net}=' hash missing or non-numeric ('$h')"; exit 1 ;;
+          esac
           echo "hash=$h" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3

--- a/.github/workflows/trail-release.yml
+++ b/.github/workflows/trail-release.yml
@@ -1,20 +1,22 @@
 name: Trail release (build · sign · publish)
 
-# Option B, phase 1 (pull-based deploy). Builds the /trail images, pushes them
+# Pull-based deploy, phase 1. Builds the /trail images, pushes them
 # to GHCR by digest, and signs each digest with cosign keyless (GitHub OIDC →
-# Fulcio, logged to Rekor). NOTHING here touches the trail box — the box pulls
+# Fulcio, logged to Rekor — the PUBLIC Sigstore services, so signing here and
+# verification on the box are an external availability dependency on
+# fulcio/rekor.sigstore.dev). NOTHING here touches the trail box — the box pulls
 # and verifies these images itself (phase 2). This replaces the self-hosted
-# `deploy` runner path, closing the box-root exposure in
-# mina-guard-ops/architecture.md §10.5 (issue 4).
+# `deploy` runner path: nothing pushes to the box, so no party with repo
+# write access can execute on it via a pushed-branch workflow.
 #
 # ── BEFORE GO-LIVE (required) ─────────────────────────────────────────────
 #  1. Pin every `uses:` below to a full commit SHA. This is a release pipeline
 #     that SIGNS artifacts users run; mutable tags are a supply-chain hole
-#     (same finding as desktop-release.yml). Dependabot (github-actions
-#     ecosystem, already configured) will then keep the SHAs current.
+#     (same finding as desktop-release.yml). Add the `github-actions` ecosystem
+#     to .github/dependabot.yml (NOT yet configured) to keep the SHAs current.
 #  2. Confirm the `Production` environment has required reviewers with
 #     prevent-self-review. That is the second-account gate — it now lives HERE
-#     (it makes PR #97's gate on the old deploy job redundant; close #97).
+#     (the required-reviewer gate on the old on-box deploy job is then redundant).
 #  3. Make the three GHCR packages readable by the box's pull token
 #     (phase 2 / runbook).
 # ──────────────────────────────────────────────────────────────────────────
@@ -35,9 +37,10 @@ permissions:
 
 env:
   IMAGE_PREFIX: ghcr.io/zksecurity/mina-guard/trail
-  # Public build-time config baked into the frontend bundle. Mirrors the values
-  # previously hardcoded in deploy/docker-compose.trail.yml. Change these if the
-  # trail domain moves off mina-trail.duckdns.org/trail.
+  # Public build-time config baked into the frontend bundle. KEEP IN SYNC with
+  # deploy/docker-compose.trail.yml's frontend build args until the on-box build
+  # is retired (then this workflow is the single source). Change if the trail
+  # domain moves off mina-trail.duckdns.org/trail.
   NEXT_PUBLIC_BASE_PATH: /trail
   NEXT_PUBLIC_API_BASE_URL: https://mina-trail.duckdns.org/trail
   NEXT_PUBLIC_MINA_ENDPOINT: https://mina-trail.duckdns.org/trail/graphql
@@ -49,7 +52,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: Production   # second-account approval gate (supersedes #97)
+    environment: Production   # second-account approval gate (required reviewer)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/contracts/scripts/read-vk-hash.sh
+++ b/contracts/scripts/read-vk-hash.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# read-vk-hash <network> — print the MinaGuard verification-key hash for
+# <network> from contracts/.vk-hash.
+#
+# Single source of truth for parsing .vk-hash. The file is the keyed
+# per-network format (testnet=… / mainnet=…); this selects one network's line
+# and validates it is a bare decimal. Hand-rolling this parse in each caller is
+# how a format change once collapsed both lines into a "testnet=…mainnet=…"
+# garbage hash and baked it into an image — route every reader through here.
+#
+# Usage: read-vk-hash.sh <testnet|mainnet>
+set -euo pipefail
+
+net="${1:-}"
+[ -n "$net" ] || { echo "usage: read-vk-hash.sh <testnet|mainnet>" >&2; exit 2; }
+
+# .vk-hash lives one directory up from this script (contracts/.vk-hash); resolve
+# relative to the script so callers can invoke it from any working directory.
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+vk_file="${here}/../.vk-hash"
+[ -f "$vk_file" ] || { echo "read-vk-hash.sh: not found: $vk_file" >&2; exit 1; }
+
+h="$(grep -E "^[[:space:]]*${net}=" "$vk_file" | head -1 | cut -d= -f2- | tr -d '[:space:]')"
+case "$h" in
+  ''|*[!0-9]*)
+    echo "read-vk-hash.sh: no valid '${net}=' hash in ${vk_file} (got '${h}')" >&2
+    exit 1 ;;
+esac
+printf '%s\n' "$h"

--- a/deploy/deploy-trail.sh
+++ b/deploy/deploy-trail.sh
@@ -44,18 +44,16 @@ fi
 # the comment header) unless explicitly overridden in the environment. The
 # backend image takes it as a build arg; the indexer filters events by it.
 if [ -z "${MINAGUARD_VK_HASH:-}" ] && [ -f contracts/.vk-hash ]; then
-  # .vk-hash is the keyed per-network format (testnet=… / mainnet=…); trail is a
-  # testnet deploy, so select the testnet line. (The old `tr -d` collapsed both
-  # lines into "testnet=…mainnet=…" and baked that garbage into the image.)
-  MINAGUARD_VK_HASH=$(grep -E '^[[:space:]]*testnet=' contracts/.vk-hash | head -1 | cut -d= -f2- | tr -d '[:space:]')
+  # trail is a testnet deploy; read-vk-hash.sh is the single validated parser
+  # for the keyed .vk-hash (testnet=… / mainnet=…).
+  MINAGUARD_VK_HASH=$(contracts/scripts/read-vk-hash.sh testnet) || exit 1
   export MINAGUARD_VK_HASH
 fi
-# Validate: a bare decimal, or the explicit "skip" opt-out (indexer accepts all).
-# Fails loud on the concatenated garbage the old parse produced, which the plain
-# `:?`-empty check waved through.
+# A pre-set MINAGUARD_VK_HASH bypasses the helper's validation; still reject
+# empty/garbage and allow the explicit "skip" opt-out (indexer accepts all).
 case "${MINAGUARD_VK_HASH:-}" in
   skip) ;;
-  ''|*[!0-9]*) echo "contracts/.vk-hash: testnet= hash missing or non-numeric ('${MINAGUARD_VK_HASH:-}') — regenerate with: bun run --filter contracts build && bun run dev-helpers/cli.ts vk-hash compile" >&2; exit 1 ;;
+  ''|*[!0-9]*) echo "MINAGUARD_VK_HASH must be a decimal hash or 'skip' (got '${MINAGUARD_VK_HASH:-}')" >&2; exit 1 ;;
 esac
 
 COMMAND="${1:-}"

--- a/deploy/deploy-trail.sh
+++ b/deploy/deploy-trail.sh
@@ -44,10 +44,19 @@ fi
 # the comment header) unless explicitly overridden in the environment. The
 # backend image takes it as a build arg; the indexer filters events by it.
 if [ -z "${MINAGUARD_VK_HASH:-}" ] && [ -f contracts/.vk-hash ]; then
-  MINAGUARD_VK_HASH=$(grep -vE '^[[:space:]]*#' contracts/.vk-hash | tr -d '[:space:]')
+  # .vk-hash is the keyed per-network format (testnet=… / mainnet=…); trail is a
+  # testnet deploy, so select the testnet line. (The old `tr -d` collapsed both
+  # lines into "testnet=…mainnet=…" and baked that garbage into the image.)
+  MINAGUARD_VK_HASH=$(grep -E '^[[:space:]]*testnet=' contracts/.vk-hash | head -1 | cut -d= -f2- | tr -d '[:space:]')
   export MINAGUARD_VK_HASH
 fi
-: "${MINAGUARD_VK_HASH:?contracts/.vk-hash parsed to empty — regenerate with: bun run --filter contracts build && bun run dev-helpers/cli.ts vk-hash compile}"
+# Validate: a bare decimal, or the explicit "skip" opt-out (indexer accepts all).
+# Fails loud on the concatenated garbage the old parse produced, which the plain
+# `:?`-empty check waved through.
+case "${MINAGUARD_VK_HASH:-}" in
+  skip) ;;
+  ''|*[!0-9]*) echo "contracts/.vk-hash: testnet= hash missing or non-numeric ('${MINAGUARD_VK_HASH:-}') — regenerate with: bun run --filter contracts build && bun run dev-helpers/cli.ts vk-hash compile" >&2; exit 1 ;;
+esac
 
 COMMAND="${1:-}"
 PORT=10001

--- a/deploy/docker-compose.trail.yml
+++ b/deploy/docker-compose.trail.yml
@@ -78,14 +78,14 @@ services:
         # /app/* convention but under /trail/*. Substitute the actual host
         # if you're not using mina-nodes.duckdns.org.
         - NEXT_PUBLIC_BASE_PATH=/trail
-        - NEXT_PUBLIC_API_BASE_URL=https://mina-nodes.duckdns.org/trail
-        - NEXT_PUBLIC_MINA_ENDPOINT=https://mina-nodes.duckdns.org/trail/graphql
-        - NEXT_PUBLIC_ARCHIVE_ENDPOINT=https://mina-nodes.duckdns.org/trail/archive
+        - NEXT_PUBLIC_API_BASE_URL=https://mina-trail.duckdns.org/trail
+        - NEXT_PUBLIC_MINA_ENDPOINT=https://mina-trail.duckdns.org/trail/graphql
+        - NEXT_PUBLIC_ARCHIVE_ENDPOINT=https://mina-trail.duckdns.org/trail/archive
         - NEXT_PUBLIC_MINA_NETWORK=testnet
         # Mesa Trail has no built-in faucet; point users at the public Mina
         # faucet (the o1js Mina.faucet() helper also targets this host with
         # `?network=mesa`).
-        - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mina-nodes.duckdns.org/trail/explorer
+        - NEXT_PUBLIC_BLOCK_EXPLORER_URL=https://mina-trail.duckdns.org/trail/explorer
         - NEXT_PUBLIC_POLL_INTERVAL_MS=1000
         - ENABLE_SOURCE_MAPS=false
     restart: unless-stopped


### PR DESCRIPTION
**Pull-based deploy, phase 1 of 2** — builds and **attests** the `/trail` images. Nothing here touches the deploy box.

On push to `main` (gated behind the `Production` environment), builds the three `/trail` images (backend, frontend, explorer) from `preview-env/Dockerfile.*`, pushes them to GHCR by digest, and attaches a **GitHub build-provenance attestation** to each digest (`actions/attest-build-provenance`, pushed to GHCR as an OCI referrer). Build args match `docker-compose.trail.yml` (VK hash from `contracts/.vk-hash`; the `NEXT_PUBLIC_*` frontend config).

**Why attestations (keyless):** no signing key to store or leak — the box verifies the *signing identity* (this repo + this workflow on `main`), not a shared secret. A build from any other branch/workflow has a different identity and fails verification. And it's **SLSA build provenance** (source repo, commit, workflow, run), not just a bare signature — auditable and the supply-chain best-practice artifact. Same Sigstore-backed keyless model as raw cosign, less workflow plumbing.

**Removes the self-hosted deploy-runner path:** the box pulls and verifies these images itself (phase 2, via `gh attestation verify`), so nothing pushes to it and no repo-write party can execute on it via a pushed-branch workflow.

**External dependency:** verification is Sigstore/GitHub-attestation-backed, so the box must reach those services at verify time — an availability dependency to decide on before mainnet (offline verification via a bundled trust root is the mitigation).

**Before go-live (in-file checklist):** SHA-pin every `uses:` (this signs artifacts — same risk as `desktop-release.yml`); add the `github-actions` ecosystem to dependabot (not yet configured); set `Production` reviewers with prevent-self-review; make the three GHCR packages **public** after the first run (no pull token needed — they're built from open-source code and hold nothing secret).

Phase 2 (box-side pull + verify + deploy) is a separate PR. Nothing the box consumes runs yet — safe to land and iterate.
