### PR TITLE
feat(trail): box-side pull, verify & deploy (pull-based deploy, phase 2)

### DIFF
--- a/deploy/docker-compose.trail.pull.yml
+++ b/deploy/docker-compose.trail.pull.yml
@@ -1,4 +1,4 @@
-# MinaGuard Mesa Trail — PULL-based deploy (Option B, phase 2).
+# MinaGuard Mesa Trail — PULL-based deploy (phase 2).
 #
 # Same services as docker-compose.trail.yml, but the app images are PULLED from
 # GHCR (signed, verified by trail-pull-deploy.sh) instead of built on-box. The

--- a/deploy/docker-compose.trail.pull.yml
+++ b/deploy/docker-compose.trail.pull.yml
@@ -52,6 +52,14 @@ services:
   explorer:
     image: ${TRAIL_EXPLORER_IMAGE:?set by trail-pull-deploy.sh (verified digest)}
     restart: unless-stopped
+    environment:
+      # Supplied at RUNTIME (unlike the frontend's build-time NEXT_PUBLIC_*): the
+      # explorer reads TESTNET_GRAPHQL_URL server-side in its /api/graphql route,
+      # so a runtime override works. The CI image (trail-release.yml) bakes it
+      # empty because CI can't know the box's MESA_NODE_HOST; the interim on-box
+      # compose passed it as a build arg. Without this the explorer runs with an
+      # empty GraphQL URL and can't query the chain.
+      - TESTNET_GRAPHQL_URL=http://${MESA_NODE_HOST:?MESA_NODE_HOST must be set}:3085/graphql
 
   caddy:
     image: caddy:2

--- a/deploy/docker-compose.trail.pull.yml
+++ b/deploy/docker-compose.trail.pull.yml
@@ -2,7 +2,7 @@
 #
 # Same services as docker-compose.trail.yml, but the app images are PULLED from
 # GHCR (signed, verified by trail-pull-deploy.sh) instead of built on-box. The
-# ${TRAIL_*_IMAGE} vars are set by that script to the cosign-verified digest
+# ${TRAIL_*_IMAGE} vars are set by that script to the attestation-verified digest
 # refs, so what runs is exactly what was verified.
 #
 # DRAFT — untested on the trail box. Keep the service shape in sync with

--- a/deploy/docker-compose.trail.pull.yml
+++ b/deploy/docker-compose.trail.pull.yml
@@ -1,0 +1,70 @@
+# MinaGuard Mesa Trail — PULL-based deploy (Option B, phase 2).
+#
+# Same services as docker-compose.trail.yml, but the app images are PULLED from
+# GHCR (signed, verified by trail-pull-deploy.sh) instead of built on-box. The
+# ${TRAIL_*_IMAGE} vars are set by that script to the cosign-verified digest
+# refs, so what runs is exactly what was verified.
+#
+# DRAFT — untested on the trail box. Keep the service shape in sync with
+# docker-compose.trail.yml (env/ports/volumes); only the image source differs.
+
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=minaguard
+      - POSTGRES_PASSWORD=minaguard
+      - POSTGRES_DB=minaguard
+    volumes:
+      - minaguard-trail-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U minaguard"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  backend:
+    image: ${TRAIL_BACKEND_IMAGE:?set by trail-pull-deploy.sh (verified digest)}
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgresql://minaguard:minaguard@db:5432/minaguard
+      - MINA_ENDPOINT=http://${MESA_NODE_HOST:?}:3085/graphql
+      - ARCHIVE_ENDPOINT=http://${MESA_NODE_HOST:?}:8282
+      - ARCHIVE_DB_HOST=${MESA_NODE_HOST}
+      - ARCHIVE_DB_PORT=5433
+      - ARCHIVE_DB_USER=minaguard_ro
+      - ARCHIVE_DB_PASSWORD=${ARCHIVE_DB_PASSWORD:?}
+      - ARCHIVE_DB_NAME=archive
+      - DISCOVERY_BACKEND=archive
+      - PORT=4000
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    # NEXT_PUBLIC_* are baked at BUILD time (trail-release.yml), not here.
+    image: ${TRAIL_FRONTEND_IMAGE:?set by trail-pull-deploy.sh (verified digest)}
+    restart: unless-stopped
+    depends_on:
+      - backend
+
+  explorer:
+    image: ${TRAIL_EXPLORER_IMAGE:?set by trail-pull-deploy.sh (verified digest)}
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports:
+      - "10001:80"
+    volumes:
+      - ./Caddyfile.trail:/etc/caddy/Caddyfile:ro
+    environment:
+      - MESA_NODE_HOST=${MESA_NODE_HOST:?}
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  minaguard-trail-db:

--- a/deploy/systemd/trail-pull-deploy.service
+++ b/deploy/systemd/trail-pull-deploy.service
@@ -1,13 +1,25 @@
 # Trail pull-based deploy (phase 2) — DRAFT, not yet enabled.
 #
-# Root system service on the ROOTFUL Docker daemon. Run the WHOLE trail
-# deployment rootful (inner stack + outer Caddy + this) so everything is on one
-# daemon — the outer Caddy already must be rootful to bind :443, so consolidating
-# there avoids a rootless/rootful split where the pull would land on a different
-# daemon than the running stack.
+# systemd USER unit — runs as the user that owns the ROOTLESS Docker daemon the
+# trail stack runs on (this box's default). Install + enable:
+#   mkdir -p ~/.config/systemd/user
+#   cp trail-pull-deploy.{service,timer} ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now trail-pull-deploy.timer
+#   sudo loginctl enable-linger "$USER"   # ESSENTIAL: keep it running when logged out
 #
-# Install (see setup runbook): copy trail-pull-deploy.sh to /usr/local/bin/ so
-# this path is stable and root-owned — do NOT point ExecStart at a home dir.
+# Why a user unit (not a root system unit): `docker compose -p minaguard-trail`
+# must target the SAME daemon the stack runs on — the rootless one. A root unit
+# hits the rootful daemon: wrong daemon, a second stack, a :10001 collision,
+# $HOME=/root, and no access to the user's cosign/ghcr config. A user unit runs
+# as the right user with the rootless socket + XDG_RUNTIME_DIR already set, and
+# `After=docker.service` correctly means the user's (rootless) docker.
+#
+# Prereqs the user unit needs: cosign on PATH (install to /usr/local/bin, not
+# ~/.local/bin, so the user manager's PATH finds it); `docker login ghcr.io` as
+# this user (or public packages → no login); ExecStart script at /usr/local/bin.
+# (If a box instead runs the stack ROOTFUL, use a root system unit with
+# WantedBy=multi-user.target + EnvironmentFile in /etc — the inverse of this.)
 [Unit]
 Description=MinaGuard trail: pull, verify (cosign), and deploy signed images
 Wants=network-online.target
@@ -15,12 +27,9 @@ After=network-online.target docker.service
 
 [Service]
 Type=oneshot
-# MESA_NODE_HOST + ARCHIVE_DB_PASSWORD live here, root-owned 0600. This is the
-# box-local secret home in the pull model — the secret never transits GitHub.
-EnvironmentFile=/etc/minaguard/trail.env
+# %h = this user's home. Owner-only 0600, readable by the unit's user.
+EnvironmentFile=%h/.config/minaguard/trail.env
 ExecStart=/usr/local/bin/trail-pull-deploy.sh
 # Don't thrash on a transient GHCR/cosign hiccup; the timer will retry.
 TimeoutStartSec=600
-
-[Install]
-WantedBy=multi-user.target
+# (No [Install] — this oneshot is triggered by trail-pull-deploy.timer, not enabled directly.)

--- a/deploy/systemd/trail-pull-deploy.service
+++ b/deploy/systemd/trail-pull-deploy.service
@@ -21,7 +21,7 @@
 # (If a box instead runs the stack ROOTFUL, use a root system unit with
 # WantedBy=multi-user.target + EnvironmentFile in /etc — the inverse of this.)
 [Unit]
-Description=MinaGuard trail: pull, verify (cosign), and deploy signed images
+Description=MinaGuard trail: pull, verify (attestation), and deploy signed images
 Wants=network-online.target
 After=network-online.target docker.service
 

--- a/deploy/systemd/trail-pull-deploy.service
+++ b/deploy/systemd/trail-pull-deploy.service
@@ -1,6 +1,13 @@
 # Trail pull-based deploy (phase 2) — DRAFT, not yet enabled.
-# Install to /etc/systemd/system/ (or ~/.config/systemd/user/ for a user unit).
-# Runs on the trail box only. Pairs with trail-pull-deploy.timer.
+#
+# Root system service on the ROOTFUL Docker daemon. Run the WHOLE trail
+# deployment rootful (inner stack + outer Caddy + this) so everything is on one
+# daemon — the outer Caddy already must be rootful to bind :443, so consolidating
+# there avoids a rootless/rootful split where the pull would land on a different
+# daemon than the running stack.
+#
+# Install (see setup runbook): copy trail-pull-deploy.sh to /usr/local/bin/ so
+# this path is stable and root-owned — do NOT point ExecStart at a home dir.
 [Unit]
 Description=MinaGuard trail: pull, verify (cosign), and deploy signed images
 Wants=network-online.target
@@ -11,7 +18,7 @@ Type=oneshot
 # MESA_NODE_HOST + ARCHIVE_DB_PASSWORD live here, root-owned 0600. This is the
 # box-local secret home in the pull model — the secret never transits GitHub.
 EnvironmentFile=/etc/minaguard/trail.env
-ExecStart=/home/jason/mina-guard/deploy/trail-pull-deploy.sh
+ExecStart=/usr/local/bin/trail-pull-deploy.sh
 # Don't thrash on a transient GHCR/cosign hiccup; the timer will retry.
 TimeoutStartSec=600
 

--- a/deploy/systemd/trail-pull-deploy.service
+++ b/deploy/systemd/trail-pull-deploy.service
@@ -1,0 +1,19 @@
+# Trail pull-based deploy (Option B, phase 2) — DRAFT, not yet enabled.
+# Install to /etc/systemd/system/ (or ~/.config/systemd/user/ for a user unit).
+# Runs on the trail box only. Pairs with trail-pull-deploy.timer.
+[Unit]
+Description=MinaGuard trail: pull, verify (cosign), and deploy signed images
+Wants=network-online.target
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+# MESA_NODE_HOST + ARCHIVE_DB_PASSWORD live here, root-owned 0600. This is the
+# box-local secret home in the pull model — the secret never transits GitHub.
+EnvironmentFile=/etc/minaguard/trail.env
+ExecStart=/home/jason/mina-guard/deploy/trail-pull-deploy.sh
+# Don't thrash on a transient GHCR/cosign hiccup; the timer will retry.
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/trail-pull-deploy.service
+++ b/deploy/systemd/trail-pull-deploy.service
@@ -1,4 +1,4 @@
-# Trail pull-based deploy (Option B, phase 2) — DRAFT, not yet enabled.
+# Trail pull-based deploy (phase 2) — DRAFT, not yet enabled.
 # Install to /etc/systemd/system/ (or ~/.config/systemd/user/ for a user unit).
 # Runs on the trail box only. Pairs with trail-pull-deploy.timer.
 [Unit]

--- a/deploy/systemd/trail-pull-deploy.timer
+++ b/deploy/systemd/trail-pull-deploy.timer
@@ -1,0 +1,13 @@
+# Polls GHCR for a new signed trail image every 2 minutes. The deploy script is
+# a no-op when nothing changed, so this is cheap. Deploys land within one
+# interval of a release — preserving the old deploy-on-merge feel, pull-side.
+[Unit]
+Description=Run trail-pull-deploy every 2 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+AccuracySec=15s
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/trail-pull-deploy.timer
+++ b/deploy/systemd/trail-pull-deploy.timer
@@ -1,3 +1,7 @@
+# systemd USER timer — install alongside the .service in ~/.config/systemd/user/
+# and enable with `systemctl --user enable --now trail-pull-deploy.timer`
+# (plus `sudo loginctl enable-linger "$USER"` so it fires while logged out).
+#
 # Polls GHCR for a new signed trail image every 2 minutes. The deploy script is
 # a no-op when nothing changed, so this is cheap. Deploys land within one
 # interval of a release — preserving the old deploy-on-merge feel, pull-side.

--- a/deploy/trail-pull-deploy.sh
+++ b/deploy/trail-pull-deploy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Trail pull-based deploy — Option B, phase 2.
+#
+# Pulls the latest SIGNED /trail images from GHCR, verifies each with cosign
+# against the release-workflow identity, and redeploys only when a digest
+# actually changed. Nothing pushes to this box; it pulls. Replaces the
+# self-hosted `deploy` runner path (mina-guard-ops architecture.md §10.5).
+# Meant to be run by trail-pull-deploy.timer.
+#
+# ┌─ DRAFT — NOT YET VALIDATED ON THE TRAIL BOX ────────────────────────────┐
+# │ Before enabling: (1) cosign installed, (2) `docker login ghcr.io` with a │
+# │ read:packages token so the private images pull, (3) the images actually  │
+# │ built + signed by trail-release.yml, (4) MESA_NODE_HOST / ARCHIVE_DB_*   │
+# │ present in the systemd unit's EnvironmentFile. See the setup runbook.     │
+# └──────────────────────────────────────────────────────────────────────────┘
+set -euo pipefail
+
+PREFIX="ghcr.io/zksecurity/mina-guard/trail"
+TAG="${TRAIL_TAG:-main}"
+# The image was signed keyless by THIS workflow on THIS ref. Verifying the
+# identity — not a shared key — is the whole point: a rogue build from another
+# branch/workflow has a different identity and fails here.
+IDENTITY="https://github.com/zksecurity/mina-guard/.github/workflows/trail-release.yml@refs/heads/${TAG}"
+ISSUER="https://token.actions.githubusercontent.com"
+REPO_DIR="${TRAIL_REPO_DIR:-$HOME/mina-guard}"
+COMPOSE="${REPO_DIR}/deploy/docker-compose.trail.pull.yml"
+STATE_DIR="${TRAIL_STATE_DIR:-$HOME/.trail-deploy}"
+mkdir -p "$STATE_DIR"
+
+# Runtime config the compose needs (same as the interim deploy).
+: "${MESA_NODE_HOST:?set MESA_NODE_HOST}"
+: "${ARCHIVE_DB_PASSWORD:?set ARCHIVE_DB_PASSWORD}"
+export MESA_NODE_HOST ARCHIVE_DB_PASSWORD
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+changed=0
+for img in backend frontend explorer; do
+  ref="${PREFIX}-${img}:${TAG}"
+  docker pull -q "$ref" >/dev/null
+  # Resolve the concrete digest the tag currently points to.
+  digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$ref" | sed 's/.*@//')
+  pinned="${PREFIX}-${img}@${digest}"
+
+  # Verify the signature on THIS digest came from our release workflow.
+  # Fail closed: a verify failure must never deploy.
+  if ! cosign verify "$pinned" \
+        --certificate-identity="$IDENTITY" \
+        --certificate-oidc-issuer="$ISSUER" >/dev/null 2>&1; then
+    log "FATAL: cosign verify FAILED for ${pinned} — refusing to deploy"
+    exit 1
+  fi
+
+  # Pin the verified digest for compose (env-substituted below).
+  var="TRAIL_$(printf '%s' "$img" | tr '[:lower:]' '[:upper:]')_IMAGE"
+  export "${var}=${pinned}"
+
+  prev="${STATE_DIR}/${img}.digest"
+  if [ ! -f "$prev" ] || [ "$(cat "$prev")" != "$digest" ]; then
+    changed=1
+    printf '%s' "$digest" > "${prev}.pending"
+    log "${img}: new verified digest ${digest}"
+  fi
+done
+
+if [ "$changed" -eq 0 ]; then
+  log "no image changes — nothing to deploy"
+  exit 0
+fi
+
+# NOTE (DB-wipe semantics): the interim deploy used `down -v` because the VK
+# hash changed per PR merge during active dev and the indexer filters discovery
+# by VK. In steady production the VK is stable, so a rolling `up -d` (no wipe)
+# is correct. If a release intentionally changes the VK, wipe + re-index
+# deliberately (docker compose ... down -v) — do NOT wipe on every deploy.
+log "deploying verified images…"
+docker compose -f "$COMPOSE" -p minaguard-trail up -d
+
+# Commit pending digests only after a successful up.
+for img in backend frontend explorer; do
+  [ -f "${STATE_DIR}/${img}.digest.pending" ] && \
+    mv "${STATE_DIR}/${img}.digest.pending" "${STATE_DIR}/${img}.digest"
+done
+log "deploy complete"

--- a/deploy/trail-pull-deploy.sh
+++ b/deploy/trail-pull-deploy.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # Trail pull-based deploy — phase 2.
 #
-# Pulls the latest SIGNED /trail images from GHCR, verifies each with cosign
-# against the release-workflow identity, and redeploys only when a digest
-# actually changed. Verification reaches the PUBLIC Sigstore log
-# (rekor.sigstore.dev) at verify time — an external availability dependency.
-# Nothing pushes to this box; it pulls. Replaces the
-# self-hosted `deploy` runner path — nothing pushes to the box.
+# Pulls the latest /trail images from GHCR, verifies each image's GitHub
+# build-provenance attestation (`gh attestation verify`) against the release-
+# workflow identity, and redeploys only when a digest actually changed.
+# Verification reaches the Sigstore/GitHub attestation services at verify time —
+# an external availability dependency. Nothing pushes to this box; it pulls.
+# Replaces the self-hosted `deploy` runner path.
 # Meant to be run by trail-pull-deploy.timer.
 #
 # ┌─ DRAFT — NOT YET VALIDATED ON THE TRAIL BOX ────────────────────────────┐
-# │ Before enabling: (1) cosign installed, (2) `docker login ghcr.io` with a │
+# │ Before enabling: (1) gh CLI installed + authed, (2) `docker login ghcr.io`│
 # │ read:packages token so the private images pull, (3) the images actually  │
 # │ built + signed by trail-release.yml, (4) MESA_NODE_HOST / ARCHIVE_DB_*   │
 # │ present in the systemd unit's EnvironmentFile. See the setup runbook.     │
@@ -19,11 +19,14 @@ set -euo pipefail
 
 PREFIX="ghcr.io/zksecurity/mina-guard/trail"
 TAG="${TRAIL_TAG:-main}"
-# The image was signed keyless by THIS workflow on THIS ref. Verifying the
-# identity — not a shared key — is the whole point: a rogue build from another
-# branch/workflow has a different identity and fails here.
-IDENTITY="https://github.com/zksecurity/mina-guard/.github/workflows/trail-release.yml@refs/heads/${TAG}"
-ISSUER="https://token.actions.githubusercontent.com"
+# The image's provenance was attested keyless by THIS workflow on THIS ref.
+# Pin BOTH the workflow path AND the ref (@refs/heads/main): a rogue build from
+# another branch/workflow gets a different identity and fails here. (Pinning only
+# the workflow path — e.g. --signer-workflow — would ACCEPT an attacker branch
+# that ships its own trail-release.yml, so the ref pin is load-bearing.)
+SIGNER_REPO="zksecurity/mina-guard"
+CERT_IDENTITY="https://github.com/zksecurity/mina-guard/.github/workflows/trail-release.yml@refs/heads/${TAG}"
+CERT_ISSUER="https://token.actions.githubusercontent.com"
 REPO_DIR="${TRAIL_REPO_DIR:-$HOME/mina-guard}"
 COMPOSE="${REPO_DIR}/deploy/docker-compose.trail.pull.yml"
 STATE_DIR="${TRAIL_STATE_DIR:-$HOME/.trail-deploy}"
@@ -44,12 +47,13 @@ for img in backend frontend explorer; do
   digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$ref" | sed 's/.*@//')
   pinned="${PREFIX}-${img}@${digest}"
 
-  # Verify the signature on THIS digest came from our release workflow.
-  # Fail closed: a verify failure must never deploy.
-  if ! cosign verify "$pinned" \
-        --certificate-identity="$IDENTITY" \
-        --certificate-oidc-issuer="$ISSUER" >/dev/null 2>&1; then
-    log "FATAL: cosign verify FAILED for ${pinned} — refusing to deploy"
+  # Verify the build-provenance attestation on THIS digest came from our release
+  # workflow. Fail closed: a verify failure must never deploy.
+  if ! gh attestation verify "oci://${pinned}" \
+        --repo "$SIGNER_REPO" \
+        --cert-identity "$CERT_IDENTITY" \
+        --cert-oidc-issuer "$CERT_ISSUER" >/dev/null 2>&1; then
+    log "FATAL: attestation verify FAILED for ${pinned} — refusing to deploy"
     exit 1
   fi
 

--- a/deploy/trail-pull-deploy.sh
+++ b/deploy/trail-pull-deploy.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Trail pull-based deploy — Option B, phase 2.
+# Trail pull-based deploy — phase 2.
 #
 # Pulls the latest SIGNED /trail images from GHCR, verifies each with cosign
 # against the release-workflow identity, and redeploys only when a digest
-# actually changed. Nothing pushes to this box; it pulls. Replaces the
-# self-hosted `deploy` runner path (mina-guard-ops architecture.md §10.5).
+# actually changed. Verification reaches the PUBLIC Sigstore log
+# (rekor.sigstore.dev) at verify time — an external availability dependency.
+# Nothing pushes to this box; it pulls. Replaces the
+# self-hosted `deploy` runner path — nothing pushes to the box.
 # Meant to be run by trail-pull-deploy.timer.
 #
 # ┌─ DRAFT — NOT YET VALIDATED ON THE TRAIL BOX ────────────────────────────┐


### PR DESCRIPTION
**Pull-based deploy, phase 2 of 2 — the box-side pull + verify + deploy.** DRAFT: untested on the trail box; do not enable the timer before the validation steps in the setup runbook.

Adds:
- `deploy/trail-pull-deploy.sh` — pulls the `:main` trail images, resolves each digest, **verifies each image's GitHub build-provenance attestation with `gh attestation verify`** against the release-workflow identity (**ref-pinned to `@refs/heads/main`** — pinning only the workflow path would accept an attacker branch shipping its own `trail-release.yml`), and runs `docker compose up` only when a digest changed. Fails closed on a verify failure.
- `deploy/docker-compose.trail.pull.yml` — same services as `docker-compose.trail.yml`, but `image:` (attestation-verified digest) instead of `build:`.
- `deploy/systemd/trail-pull-deploy.{service,timer}` — a systemd **USER unit** (the trail stack runs on the box's rootless daemon), polling GHCR every 2 min; secrets from a **user-owned** `~/.config/minaguard/trail.env`.

**Removes the self-hosted-runner path for the trail box:** nothing pushes to the box, no self-hosted runner, and it only ever runs images attested by the release workflow. Pairs with phase 1 (build + attest).

**External dependency:** `gh attestation verify` reaches the Sigstore/GitHub attestation services at verify time — decide on availability before mainnet (offline verification via a bundled trust root is the mitigation).

Open items in-file / to confirm on the box: the DB-wipe-on-VK-change policy (defaults to no-wipe, correct for a stable prod VK); SHA-pinning the phase-1 actions before it's load-bearing; the exact `gh attestation verify` flag names + `@v2` of the attest action against the box's `gh` version; and the `docker inspect RepoDigests` parse.
