### PR TITLE
fix(indexer): apply events in canonical block order, not by event type

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -434,30 +434,10 @@ export class MinaGuardIndexer {
     // otherwise multi-receiver transfer proposals have receivers stored in
     // reversed idx, which breaks the proposal-hash recomputation on the UI
     // side and causes "Proposal not found" errors on approve.
-    const events = reverseEventsWithinEachTx(rawEvents);
-
-    // Stable sort so 'proposal' events are processed before 'approval' /
-    // 'receiver' / 'execution' within the same batch. The per-tx reversal
-    // above already aligned receiver events with their emission order; the
-    // stable sort preserves that ordering since all receivers share a type.
-    const eventOrder: Record<string, number> = {
-      deployed: 0,
-      setup: 1,
-      setupOwner: 2,
-      proposal: 3,
-      approval: 4,
-      receiver: 5,
-      execution: 6,
-      ownerChange: 7,
-      thresholdChange: 8,
-      delegate: 9,
-      createChild: 10,
-      reclaimChild: 11,
-      enableChildMultiSig: 12,
-      createChildConfig: 13,
-      createChildOwner: 14,
-    };
-    events.sort((a, b) => (eventOrder[a.type] ?? 99) - (eventOrder[b.type] ?? 99));
+    // Apply events in canonical chain order: ascending block height, then the
+    // per-tx emission order restored by reverseEventsWithinEachTx. See
+    // orderEventsForApply for why the previous type-priority sort was unsafe.
+    const events = orderEventsForApply(reverseEventsWithinEachTx(rawEvents));
 
     let ingested = false;
     for (let seq = 0; seq < events.length; seq++) {
@@ -1300,6 +1280,32 @@ export function describeThrown(value: unknown): string {
   } catch {
     return Object.prototype.toString.call(value);
   }
+}
+
+/**
+ * Orders a batch of decoded events into canonical chain-application order:
+ * ascending block height, preserving the input order (archive tx order plus the
+ * per-tx emission order restored by reverseEventsWithinEachTx) for events that
+ * share a block.
+ *
+ * Replaces a previous global sort by a hardcoded event-type priority. That sort
+ * discarded block height entirely, so in a multi-block sync batch a later
+ * block's execution (low type rank) was applied before an earlier block's
+ * ownerChange/thresholdChange (high type rank). Because appendContractConfigSnapshot
+ * copies unchanged fields from whatever config is "latest" at apply time, that
+ * misordering wrote stale or future state into the wrong ContractConfig snapshot
+ * (e.g. a config with the new numOwners but the pre-change ownersCommitment).
+ * A proposal is always emitted before its approvals/execution on-chain, so
+ * canonical block order already yields the proposal-before-approval processing
+ * the old type sort was reaching for.
+ *
+ * The explicit index tiebreak keeps the sort stable regardless of engine.
+ */
+export function orderEventsForApply(events: ChainEvent[]): ChainEvent[] {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => a.event.blockHeight - b.event.blockHeight || a.index - b.index)
+    .map(({ event }) => event);
 }
 
 /** Converts unknown values into nullable string form for DB persistence. */

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -1283,28 +1283,59 @@ export function describeThrown(value: unknown): string {
 }
 
 /**
- * Orders a batch of decoded events into canonical chain-application order:
- * ascending block height, preserving the input order (archive tx order plus the
- * per-tx emission order restored by reverseEventsWithinEachTx) for events that
- * share a block.
+/**
+ * Within-block processing order, applied only AFTER block height. o1js gives no
+ * ordering guarantee for events, so when the archive returns a single block's
+ * events across multiple txs in an unspecified order, this lifecycle rank keeps
+ * a dependent event (approval/execution) from being applied before the event it
+ * depends on (its proposal) and permanently dropped. Same-type events (notably a
+ * proposal's receiver slots) tie here and fall through to the input-order
+ * tiebreak, preserving the per-tx emission order restored by
+ * reverseEventsWithinEachTx.
+ */
+const EVENT_TYPE_ORDER: Record<string, number> = {
+  deployed: 0,
+  setup: 1,
+  setupOwner: 2,
+  proposal: 3,
+  approval: 4,
+  receiver: 5,
+  execution: 6,
+  ownerChange: 7,
+  thresholdChange: 8,
+  delegate: 9,
+  createChild: 10,
+  reclaimChild: 11,
+  enableChildMultiSig: 12,
+  createChildConfig: 13,
+  createChildOwner: 14,
+};
+
+/**
+ * Orders a batch of decoded events into canonical chain-application order by
+ * three keys: ascending block height (primary), the within-block lifecycle rank
+ * above (secondary), then the input order restored by reverseEventsWithinEachTx
+ * (tiebreak, keeping the sort stable regardless of engine).
  *
- * Replaces a previous global sort by a hardcoded event-type priority. That sort
- * discarded block height entirely, so in a multi-block sync batch a later
- * block's execution (low type rank) was applied before an earlier block's
- * ownerChange/thresholdChange (high type rank). Because appendContractConfigSnapshot
- * copies unchanged fields from whatever config is "latest" at apply time, that
- * misordering wrote stale or future state into the wrong ContractConfig snapshot
- * (e.g. a config with the new numOwners but the pre-change ownersCommitment).
- * A proposal is always emitted before its approvals/execution on-chain, so
- * canonical block order already yields the proposal-before-approval processing
- * the old type sort was reaching for.
- *
- * The explicit index tiebreak keeps the sort stable regardless of engine.
+ * Replaces a previous GLOBAL sort by event-type priority that discarded block
+ * height entirely, so in a multi-block sync batch a later block's execution (low
+ * type rank) was applied before an earlier block's ownerChange/thresholdChange
+ * (high type rank). Because appendContractConfigSnapshot copies unchanged fields
+ * from whatever config is "latest" at apply time, that misordering wrote stale
+ * or future state into the wrong ContractConfig snapshot (e.g. a config with the
+ * new numOwners but the pre-change ownersCommitment). Making block height the
+ * primary key fixes that while the secondary type rank preserves the
+ * proposal-before-approval processing the old sort provided within a block.
  */
 export function orderEventsForApply(events: ChainEvent[]): ChainEvent[] {
   return events
     .map((event, index) => ({ event, index }))
-    .sort((a, b) => a.event.blockHeight - b.event.blockHeight || a.index - b.index)
+    .sort(
+      (a, b) =>
+        a.event.blockHeight - b.event.blockHeight ||
+        (EVENT_TYPE_ORDER[a.event.type] ?? 99) - (EVENT_TYPE_ORDER[b.event.type] ?? 99) ||
+        a.index - b.index,
+    )
     .map(({ event }) => event);
 }
 

--- a/backend/src/tests/indexer-ordering.test.ts
+++ b/backend/src/tests/indexer-ordering.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from 'bun:test';
 import { orderEventsForApply } from '../indexer.js';
 import type { ChainEvent } from '../mina-client.js';
 
-function ev(type: string, blockHeight: number, txHash: string): ChainEvent {
+function ev(type: string, blockHeight: number, txHash: string, slot?: string): ChainEvent {
   return {
     type,
-    event: {},
+    event: slot ? { slot } : {},
     blockHeight,
     blockHash: `hash-${blockHeight}`,
     parentHash: `hash-${blockHeight - 1}`,
@@ -35,12 +35,26 @@ describe('orderEventsForApply', () => {
     expect(ordered.map((e) => e.blockHeight)).toEqual([5, 12, 20]);
   });
 
-  test('is stable: events in the same block keep their input (emission) order', () => {
+  test('orders same-block events by lifecycle type so a dependency precedes its dependent', () => {
+    // Same block, different txs, returned by the archive out of order: the
+    // approval and execution must still be applied after their proposal, or the
+    // dependent event is dropped (and, once fingerprinted, dropped for good).
     const ordered = orderEventsForApply([
-      ev('proposal', 9, 'tx-1'),
-      ev('receiver', 9, 'tx-1'),
-      ev('approval', 9, 'tx-2'),
+      ev('approval', 9, 'tx-appr'),
+      ev('execution', 9, 'tx-exec'),
+      ev('proposal', 9, 'tx-prop'),
     ]);
-    expect(ordered.map((e) => e.type)).toEqual(['proposal', 'receiver', 'approval']);
+    expect(ordered.map((e) => e.type)).toEqual(['proposal', 'approval', 'execution']);
+  });
+
+  test('preserves input order for same-type same-block events (receiver slots)', () => {
+    // Same block, same tx, same type: the type key ties, so the input order
+    // restored by reverseEventsWithinEachTx must survive (receiver slot order).
+    const ordered = orderEventsForApply([
+      ev('receiver', 9, 'tx-1', 'r0'),
+      ev('receiver', 9, 'tx-1', 'r1'),
+      ev('receiver', 9, 'tx-1', 'r2'),
+    ]);
+    expect(ordered.map((e) => (e.event as { slot: string }).slot)).toEqual(['r0', 'r1', 'r2']);
   });
 });

--- a/backend/src/tests/indexer-ordering.test.ts
+++ b/backend/src/tests/indexer-ordering.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { orderEventsForApply } from '../indexer.js';
+import type { ChainEvent } from '../mina-client.js';
+
+function ev(type: string, blockHeight: number, txHash: string): ChainEvent {
+  return {
+    type,
+    event: {},
+    blockHeight,
+    blockHash: `hash-${blockHeight}`,
+    parentHash: `hash-${blockHeight - 1}`,
+    txHash,
+    txMemo: null,
+  };
+}
+
+describe('orderEventsForApply', () => {
+  test('applies events in ascending block order regardless of event type', () => {
+    // An ownerChange in an earlier block must be applied before an execution in
+    // a later block. The old type-priority sort ranked execution above
+    // ownerChange and would have inverted these across the block boundary.
+    const ordered = orderEventsForApply([
+      ev('execution', 12, 'tx-exec'),
+      ev('ownerChange', 11, 'tx-owner'),
+    ]);
+    expect(ordered.map((e) => e.type)).toEqual(['ownerChange', 'execution']);
+  });
+
+  test('never lets a higher-block event precede a lower-block event', () => {
+    const ordered = orderEventsForApply([
+      ev('thresholdChange', 20, 'tx-a'),
+      ev('proposal', 5, 'tx-b'),
+      ev('execution', 12, 'tx-c'),
+    ]);
+    expect(ordered.map((e) => e.blockHeight)).toEqual([5, 12, 20]);
+  });
+
+  test('is stable: events in the same block keep their input (emission) order', () => {
+    const ordered = orderEventsForApply([
+      ev('proposal', 9, 'tx-1'),
+      ev('receiver', 9, 'tx-1'),
+      ev('approval', 9, 'tx-2'),
+    ]);
+    expect(ordered.map((e) => e.type)).toEqual(['proposal', 'receiver', 'approval']);
+  });
+});


### PR DESCRIPTION
## What

`syncSingleContract` sorted each sync batch by a hardcoded event-type priority (`proposal` < `approval` < ... < `ownerChange` < `thresholdChange`), which discards block height entirely. In a batch spanning multiple blocks, a later block's `execution` (low type rank) was applied before an earlier block's `ownerChange` / `thresholdChange` (high type rank).

Because `appendContractConfigSnapshot` copies unchanged fields from whatever config is "latest" at apply time, this misordering wrote stale or future state into the wrong `ContractConfig` snapshot: e.g. a snapshot carrying a post-change `numOwners` but the pre-change `ownersCommitment`, or config copied from a block that is later in chain order but was processed earlier. Reorg reprocessing inherited the same poison.

## Fix

Replace the type-priority sort with `orderEventsForApply`: a stable sort by ascending block height that preserves the per-tx emission order already restored by `reverseEventsWithinEachTx`. A proposal is always emitted before its approvals/execution on-chain, so canonical block order yields the proposal-before-approval processing the old sort was reaching for, without inverting cross-block state.

Adds a pure unit test (`indexer-ordering.test.ts`) covering the cross-block scenario and same-block stability.

## Notes

- Backend-only; no contract/VK impact.
- Residual (separate, lower severity): the persisted `eventOrder` is still batch-local, so it only orders same-block events within one batch. `getLatestConfig` orders by `validFromBlock` first, so this matters only for multiple same-block events split across batches (reorg reprocessing). Worth a follow-up if we want globally monotonic ordering.
