### PR TITLE
ci,test: kill flaky-CI sources — spyOn mina-client stubs + on-demand previews & host-serialized e2e

### DIFF
--- a/.github/workflows/deploy-lightnet.yml
+++ b/.github/workflows/deploy-lightnet.yml
@@ -12,6 +12,14 @@ concurrency:
 jobs:
   deploy:
     runs-on: [self-hosted, deploy-lightnet]
+    # Host-wide lock: this box (15 GB / 8 cores) also runs the e2e stack on a
+    # second runner. Two heavy Mina stacks at once thrash swap and starve o1js
+    # proving. This job-level group serialises against e2e.yml and
+    # preview-deploy.yml so only one heavy stack runs on the host at a time.
+    # cancel-in-progress:false → queue rather than kill an unrelated run.
+    concurrency:
+      group: minaguard-host
+      cancel-in-progress: false
     steps:
       - name: Verify branch is main
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,15 @@ jobs:
   e2e:
     timeout-minutes: 60
     runs-on: [self-hosted, e2e]
+    # Host-wide lock. The workflow-level concurrency above still cancels
+    # superseded commits on the same ref; this job-level group additionally
+    # serialises the e2e stack against the deploy-lightnet runner's heavy jobs
+    # (deploy-lightnet.yml, preview-deploy.yml) sharing this 15 GB box, so two
+    # Mina stacks never run at once. cancel-in-progress:false → queue, don't
+    # kill an in-flight deploy/preview.
+    concurrency:
+      group: minaguard-host
+      cancel-in-progress: false
 
     steps:
       - name: Git checkout

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,22 +1,40 @@
 # .github/workflows/preview-deploy.yml
 #
-# Automatically deploys/tears down preview environments for PRs targeting main.
-# Requires a self-hosted GitHub Actions runner on the Hetzner server.
+# On-demand preview environments for PRs targeting main, driven by PR comments.
+# Requires a self-hosted GitHub Actions runner (label: deploy-lightnet) on the
+# Hetzner server.
 #
-# Setup:
+#   /preview        -> deploy (or redeploy) this PR's preview environment
+#   /preview up     -> same as /preview
+#   /preview down   -> tear the preview down
+#
+# Previews used to deploy automatically on every push (pull_request:
+# synchronize). That spun up a full Mina lightnet + docker build on this box
+# for every commit, concurrently with the e2e stack on the sibling runner,
+# starving o1js proving on a 15 GB / 8-core host. They are now opt-in.
+#
+# Teardown still happens automatically when the PR is closed/merged.
+#
+# CAVEAT (GitHub semantics): `issue_comment`-triggered workflows always run the
+# workflow file from the DEFAULT branch (main), not the PR branch. So the
+# `/preview` command only works once this file is merged to main. Removing the
+# old automatic `synchronize` trigger, however, takes effect for the PR
+# immediately.
+#
+# Runner setup (unchanged):
 #   1. On the server: mkdir actions-runner && cd actions-runner
-#   2. Download: curl -o actions-runner-linux-x64-2.333.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-x64-2.333.1.tar.gz
-#   3. Extract: tar xzf actions-runner-linux-x64-2.333.1.tar.gz
-#   4. Configure: ./config.sh --url https://github.com/<org>/<repo> --token <token>
-#   5. Install as service: sudo ./svc.sh install && sudo ./svc.sh start
-#   6. Stop: sudo ./svc.sh stop
-#   7. Uninstall: sudo ./svc.sh uninstall
+#   2. curl -o actions-runner-linux-x64-2.333.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-x64-2.333.1.tar.gz
+#   3. tar xzf actions-runner-linux-x64-2.333.1.tar.gz
+#   4. ./config.sh --url https://github.com/<org>/<repo> --token <token>
+#   5. sudo ./svc.sh install && sudo ./svc.sh start
 
 name: Preview Environment
 
 on:
+  issue_comment:
+    types: [created]
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
     branches: [main]
 
 permissions:
@@ -24,17 +42,88 @@ permissions:
   issues: write
 
 concurrency:
-  group: preview-${{ github.event.number }}
+  group: preview-${{ github.event.issue.number || github.event.number }}
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    # Only run on PRs from the same repo (not forks) to prevent arbitrary code execution on the server
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+  # ---------------------------------------------------------------------------
+  # Authorise + parse the `/preview [up|down]` command. Gated in `if:` so a
+  # runner is only ever occupied for a genuine preview command from someone with
+  # write access. Resolves the PR head SHA (issue_comment events carry no PR ref)
+  # and refuses fork PRs (arbitrary code on a self-hosted runner).
+  # ---------------------------------------------------------------------------
+  resolve:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/preview') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: [self-hosted, deploy-lightnet]
+    outputs:
+      cmd: ${{ steps.parse.outputs.cmd }}
+      pr: ${{ steps.parse.outputs.pr }}
+      head_sha: ${{ steps.parse.outputs.head_sha }}
+    steps:
+      - name: Parse command and resolve PR head
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            const m = body.match(/^\/preview(?:\s+(up|down))?\s*$/);
+            if (!m) {
+              // Comment starts with /preview but isn't a recognised command;
+              // ignore silently to avoid comment spam.
+              core.setOutput('cmd', 'none');
+              return;
+            }
+            const sub = m[1] || 'up';
+            const prNumber = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const sameRepo =
+              pr.head.repo &&
+              pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            if (!sameRepo) {
+              core.setOutput('cmd', 'none');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: 'Preview environments are only available for branches in this repository, not forks.',
+              });
+              return;
+            }
+            core.setOutput('cmd', sub);
+            core.setOutput('pr', String(prNumber));
+            core.setOutput('head_sha', pr.head.sha);
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+  # ---------------------------------------------------------------------------
+  # Deploy / redeploy the preview.
+  # ---------------------------------------------------------------------------
+  deploy:
+    needs: resolve
+    if: needs.resolve.outputs.cmd == 'up'
+    runs-on: [self-hosted, deploy-lightnet]
+    # Host-wide lock — see e2e.yml / deploy-lightnet.yml. Serialises against the
+    # e2e stack on the sibling runner so two Mina stacks never run at once on
+    # this box. cancel-in-progress:false → queue behind a running e2e/deploy.
+    concurrency:
+      group: minaguard-host
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ needs.resolve.outputs.head_sha }}
           submodules: recursive
 
       # bun + workspace deps are needed on the host so preview.sh can compute
@@ -49,15 +138,14 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Deploy preview
-        # `down` first wipes volumes + lightnet chain so every commit to the
-        # PR gets a clean DB and fresh genesis. Without this, preview.sh up
-        # only rebuilds the app containers — the existing postgres volume
-        # (indexer cursor, contracts, events) and lightnet image (chain state)
-        # survive, so stale rows from previous iterations of the PR can make
-        # the new backend hit inconsistent state. `down` is idempotent and
-        # safe on the first open/reopen when nothing is running.
+        # `down` first wipes volumes + lightnet chain so every deploy gets a
+        # clean DB and fresh genesis. Without this, `up` only rebuilds the app
+        # containers — the existing postgres volume (indexer cursor, contracts,
+        # events) and lightnet image (chain state) survive, so stale rows from
+        # previous iterations of the PR can make the new backend hit
+        # inconsistent state. `down` is idempotent and safe when nothing runs.
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr }}
         run: |
           chmod +x preview-env/preview.sh
           ./preview-env/preview.sh down $PR_NUMBER
@@ -65,7 +153,7 @@ jobs:
 
       - name: Wait for services
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr }}
         run: |
           # Must match BASE_PORT in preview.sh
           PREVIEW_PORT=$((10000 + PR_NUMBER))
@@ -81,30 +169,11 @@ jobs:
           echo "Backend failed to become ready within timeout"
           exit 1
 
-      # # TEMPORARY (UI scaling PR only — remove before merging): seeds bulk
-      # # synthetic vault/proposal data into the preview's Postgres so reviewers
-      # # can exercise pagination, search, and the card grid at realistic counts.
-      # # Each wallet listed below is added as an owner of every seeded vault, so
-      # # connecting with any of them on the preview shows the full set.
-      # - name: Seed UI scaling fixtures
-      #   env:
-      #     PR_NUMBER: ${{ github.event.number }}
-      #   run: |
-      #     # Add/remove wallet pubkeys here to test with multiple wallets.
-      #     WALLETS=(
-      #       "B62qpJgZSnx9dGFAqh45SehhK9TsxTnKia9vgnYzSXnCxwQQxixrnL1"
-      #       "B62qqgtCy8FAmPtrHbQfLunyMaXTNrutgpApaSGEM8zFLN4ypspQqo4"
-      #     )
-      #     args=()
-      #     for w in "${WALLETS[@]}"; do args+=(--wallet "$w"); done
-      #     docker compose -p "pr-${PR_NUMBER}" exec -T -w /app/backend backend \
-      #       bun scripts/seed-fixtures.ts "${args[@]}" --clean
-
       - name: Comment PR with preview URL
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = ${{ github.event.number }};
+            const pr = Number('${{ needs.resolve.outputs.pr }}');
             const base = `https://mina-nodes.duckdns.org/preview/${pr}`;
             const body = [
               '### Preview Environment',
@@ -116,13 +185,15 @@ jobs:
               `| GraphQL | ${base}/graphql |`,
               `| Accounts | ${base}/accounts/acquire-account |`,
               `| Explorer | ${base}/explorer |`,
+              '',
+              '_Comment `/preview down` to tear this down; it is also removed automatically when the PR closes._',
             ].join('\n');
 
             // Delete previous preview comments
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr,
             });
             for (const comment of comments.data) {
               if (comment.body.includes('### Preview Environment')) {
@@ -137,12 +208,61 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr,
               body: body,
             });
 
-  teardown:
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+  # ---------------------------------------------------------------------------
+  # Manual teardown via `/preview down`.
+  # ---------------------------------------------------------------------------
+  teardown-comment:
+    needs: resolve
+    if: needs.resolve.outputs.cmd == 'down'
+    runs-on: [self-hosted, deploy-lightnet]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Teardown preview
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr }}
+        run: |
+          chmod +x preview-env/preview.sh
+          ./preview-env/preview.sh down $PR_NUMBER
+
+      - name: Confirm teardown
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = Number('${{ needs.resolve.outputs.pr }}');
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            for (const comment of comments.data) {
+              if (comment.body.includes('### Preview Environment')) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: 'Preview environment torn down.',
+            });
+
+  # ---------------------------------------------------------------------------
+  # Automatic teardown when the PR is closed/merged.
+  # ---------------------------------------------------------------------------
+  teardown-closed:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, deploy-lightnet]
     steps:
       - uses: actions/checkout@v4

--- a/backend/src/tests/indexer-archive-discovery.test.ts
+++ b/backend/src/tests/indexer-archive-discovery.test.ts
@@ -3,7 +3,7 @@ import { PrivateKey } from 'o1js';
 import type { BackendConfig } from '../config.js';
 import { prisma } from '../db.js';
 import { MinaGuardIndexer } from '../indexer.js';
-import * as minaClient from '../mina-client.js';
+import { stubMinaClient } from './stub-mina-client.js';
 
 const VK_HASH = '22592591136635241954458728867125272730912271761728581931779127524287952990537';
 
@@ -70,8 +70,7 @@ describe('archive discovery: happy path', () => {
     ];
 
     let archiveQueryCalledWith: { from: number; to: number } | null = null;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 1000,
       fetchBestChainHeaders: async () => [],
@@ -120,8 +119,7 @@ describe('archive discovery: happy path', () => {
     const matching = PrivateKey.random().toPublicKey().toBase58();
     const mismatched = PrivateKey.random().toPublicKey().toBase58();
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 500,
       fetchBestChainHeaders: async () => [],
@@ -154,8 +152,7 @@ describe('archive discovery: per-iteration failure isolation', () => {
     const bad = PrivateKey.random().toPublicKey().toBase58();
     const ok2 = PrivateKey.random().toPublicKey().toBase58();
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 1000,
       fetchBestChainHeaders: async () => [],
@@ -202,8 +199,7 @@ describe('archive discovery: per-iteration failure isolation', () => {
     const bad = PrivateKey.random().toPublicKey().toBase58();
 
     let backfillCallCountForBad = 0;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 1000,
       fetchBestChainHeaders: async () => [],
@@ -260,8 +256,7 @@ describe('archive discovery: backfill range', () => {
     const addr = PrivateKey.random().toPublicKey().toBase58();
 
     const backfillCalls: Array<{ from: number; to: number }> = [];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => 50_000,
       fetchBestChainHeaders: async () => [],
@@ -294,8 +289,7 @@ describe('archive discovery: cursor progression', () => {
     const calls: Array<{ from: number; to: number }> = [];
 
     let latestHeight = 1000;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeightFromArchive: async () => latestHeight,
       fetchBestChainHeaders: async () => [],
@@ -325,11 +319,4 @@ describe('archive discovery: cursor progression', () => {
     // DISCOVERY_MARGIN is 5 in the source.
     expect(calls[1]).toEqual({ from: 1000 - 5, to: 1500 });
   });
-});
-
-// Module mocks are process-global in bun and leak into later test files
-// (they survive mock.restore()); restore the real module so file ordering
-// can never break another suite's use of mina-client.
-afterAll(() => {
-  mock.module('../mina-client.js', () => minaClient);
 });

--- a/backend/src/tests/indexer-autosubscribe.test.ts
+++ b/backend/src/tests/indexer-autosubscribe.test.ts
@@ -3,7 +3,7 @@ import { PrivateKey } from 'o1js';
 import type { BackendConfig } from '../config.js';
 import { prisma } from '../db.js';
 import { MinaGuardIndexer } from '../indexer.js';
-import * as minaClient from '../mina-client.js';
+import { stubMinaClient } from './stub-mina-client.js';
 
 const liteConfig = {
   minaEndpoint: 'http://stub',
@@ -60,8 +60,7 @@ describe('backfillContract window', () => {
     await setCursor(1000);
 
     const calls: Array<{ from: number; to: number }> = [];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (
         _addr: string,
         from: number,
@@ -86,8 +85,7 @@ describe('backfillContract window', () => {
     await setCursor(1000);
 
     const calls: Array<{ from: number; to: number }> = [];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (
         _addr: string,
         from: number,
@@ -111,8 +109,7 @@ describe('backfillContract window', () => {
     const contract = await prisma.contract.create({ data: { address, ready: false } });
     await setCursor(500);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async () => [],
     }));
 
@@ -131,8 +128,7 @@ describe('backfillContract window', () => {
     // Any MinaGuard event is proof the contract was initialized on-chain.
     // Use an execution event because it's the simplest to stub without
     // triggering the deeper setup/ownerChange/etc. state machinery.
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async () => [makeExecutionEvent('hash-x', 50)],
     }));
 
@@ -151,8 +147,7 @@ describe('backfillContract window', () => {
     await setCursor(0);
 
     let called = false;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async () => {
         called = true;
         return [];
@@ -182,8 +177,7 @@ describe('eager child auto-subscribe on CREATE_CHILD proposal', () => {
     await seedParent(parentAddress);
     await setCursor(100);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (addr: string) =>
         addr === parentAddress
           ? [makeCreateChildProposalEvent(proposalHash, childAddress, 20)]
@@ -211,8 +205,7 @@ describe('eager child auto-subscribe on CREATE_CHILD proposal', () => {
     await seedParent(parentAddress);
     await setCursor(100);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (addr: string) =>
         addr === parentAddress
           ? [makeCreateChildProposalEvent(proposalHash, childAddress, 20)]
@@ -234,8 +227,7 @@ describe('eager child auto-subscribe on CREATE_CHILD proposal', () => {
     await seedParent(parentAddress);
     await setCursor(100);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (addr: string) =>
         addr === parentAddress
           ? [makeCreateChildProposalEvent(proposalHash, childAddress, 20)]
@@ -258,8 +250,7 @@ describe('eager child auto-subscribe on CREATE_CHILD proposal', () => {
 
     // txType='1' (addOwner) should not trigger any child insertion.
     const proposalHash = '99';
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (addr: string) =>
         addr === parentAddress
           ? [makeAddOwnerProposalEvent(proposalHash, 20)]
@@ -290,8 +281,7 @@ describe('eager child auto-subscribe on CREATE_CHILD proposal', () => {
       [parentAddress]: [makeCreateChildProposalEvent(proposalHash, childAddress, 20)],
       [childAddress]: [makeExecutionEvent(proposalHash, 25)],
     };
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (addr: string) => eventsByAddress[addr] ?? [],
     }));
 
@@ -381,8 +371,7 @@ describe('tick: rescanUnreadyContracts', () => {
     await setCursor(100);
 
     let callCount = 0;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeight: async () => 100,
       fetchBestChainHeaders: async () => [],
@@ -408,8 +397,7 @@ describe('tick: rescanUnreadyContracts', () => {
     });
     await setCursor(100);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeight: async () => 100,
       fetchBestChainHeaders: async () => [],
@@ -435,8 +423,7 @@ describe('tick: rescanUnreadyContracts', () => {
     await setCursor(100);
 
     const rescanRanges: Array<{ from: number; to: number }> = [];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeight: async () => 100,
       fetchBestChainHeaders: async () => [],
@@ -462,8 +449,7 @@ describe('tick: rescanUnreadyContracts', () => {
     await setCursor(100);
 
     const calls: string[] = [];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchGenesisConstants: async () => ({ genesisTimestampMs: 0, slotDurationMs: 90000 }),
       fetchLatestBlockHeight: async () => 100,
       fetchBestChainHeaders: async () => [],
@@ -479,11 +465,4 @@ describe('tick: rescanUnreadyContracts', () => {
     // sits above the chain tip, so there's nothing to rescan yet.
     expect(calls).not.toContain(address);
   });
-});
-
-// Module mocks are process-global in bun and leak into later test files
-// (they survive mock.restore()); restore the real module so file ordering
-// can never break another suite's use of mina-client.
-afterAll(() => {
-  mock.module('../mina-client.js', () => minaClient);
 });

--- a/backend/src/tests/indexer-dropped-tx.test.ts
+++ b/backend/src/tests/indexer-dropped-tx.test.ts
@@ -4,6 +4,7 @@ import type { BackendConfig } from '../config.js';
 import { prisma } from '../db.js';
 import { MinaGuardIndexer } from '../indexer.js';
 import * as minaClient from '../mina-client.js';
+import { stubMinaClient } from './stub-mina-client.js';
 
 const config = {
   minaEndpoint: 'http://stub',
@@ -25,8 +26,7 @@ function stubLookups(opts: {
   txStatus: TxStatus;
   mempool: Set<string> | null;
 }) {
-  mock.module('../mina-client.js', () => ({
-    ...minaClient,
+  stubMinaClient(() => ({
     fetchZkappTxStatus: async (): Promise<TxStatus> => opts.txStatus,
     fetchMempoolHashes: async (): Promise<Set<string> | null> => opts.mempool,
   }));
@@ -90,10 +90,6 @@ afterEach(() => {
 });
 
 afterAll(async () => {
-  // mock.restore() does not undo mock.module registrations — re-register the
-  // real module so the stub doesn't leak into later test files in the same
-  // bun test process (mina-client-tx-status.test.ts imports the real thing).
-  mock.module('../mina-client.js', () => minaClient);
   await clearAll();
   await prisma.$disconnect();
 });

--- a/backend/src/tests/indexer-event-decode.test.ts
+++ b/backend/src/tests/indexer-event-decode.test.ts
@@ -11,7 +11,7 @@ import { PrivateKey } from 'o1js';
 import type { BackendConfig } from '../config.js';
 import { prisma } from '../db.js';
 import { MinaGuardIndexer } from '../indexer.js';
-import * as minaClient from '../mina-client.js';
+import { stubMinaClient } from './stub-mina-client.js';
 import type { ChainEvent } from '../mina-client.js';
 
 const stubConfig = {
@@ -58,8 +58,7 @@ async function ingest(
   const contract = await prisma.contract.create({
     data: { address, discoveredAtBlock: 1 },
   });
-  mock.module('../mina-client.js', () => ({
-    ...minaClient,
+  stubMinaClient(() => ({
     fetchDecodedContractEvents: async () => events,
   }));
   const indexer = new MinaGuardIndexer(stubConfig);
@@ -150,8 +149,7 @@ describe('config-mutating event decoding', () => {
     expect((await latestConfig(contractId)).delegate).toBe(delegate);
 
     // Undelegate = the contract delegating to itself (chain-e2e former steps 21-22)
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async (): Promise<ChainEvent[]> => [
         {
           type: 'delegate', blockHeight: 9, txHash: 'tx-undel', ...HASHES(9),
@@ -223,11 +221,4 @@ describe('proposal event decoding', () => {
       ].sort()
     );
   });
-});
-
-// Module mocks are process-global in bun and leak into later test files
-// (they survive mock.restore()); restore the real module so file ordering
-// can never break another suite's use of mina-client.
-afterAll(() => {
-  mock.module('../mina-client.js', () => minaClient);
 });

--- a/backend/src/tests/indexer-reorg.test.ts
+++ b/backend/src/tests/indexer-reorg.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'b
 import { PrivateKey } from 'o1js';
 import { prisma } from '../db.js';
 import { MinaGuardIndexer, detectAndRollbackReorg, rollbackAboveFork } from '../indexer.js';
-import * as minaClient from '../mina-client.js';
+import { stubMinaClient } from './stub-mina-client.js';
 import type { ChainEvent } from '../mina-client.js';
 import type { BackendConfig } from '../config.js';
 
@@ -168,8 +168,7 @@ describe('detectAndRollbackReorg', () => {
       { height: 6, blockHash: 'h6', parentHash: 'h5' },
     ]);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => [
         { height: 5, blockHash: 'h5', parentHash: 'h4' },
         { height: 6, blockHash: 'h6', parentHash: 'h5' },
@@ -181,8 +180,7 @@ describe('detectAndRollbackReorg', () => {
   });
 
   test('returns null when no stored headers overlap the chain window', async () => {
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => [
         { height: 100, blockHash: 'h100', parentHash: 'h99' },
       ],
@@ -204,8 +202,7 @@ describe('detectAndRollbackReorg', () => {
     });
     await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '8' } });
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => [
         { height: 5, blockHash: 'h5', parentHash: 'h4' },
         { height: 6, blockHash: 'h6', parentHash: 'h5' },
@@ -244,8 +241,7 @@ describe('detectAndRollbackReorg', () => {
     });
     await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '9' } });
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => [
         { height: 5, blockHash: 'h5', parentHash: 'h4' },
         { height: 6, blockHash: 'h6', parentHash: 'h5' },
@@ -272,8 +268,7 @@ describe('detectAndRollbackReorg', () => {
     ]);
     await prisma.indexerCursor.create({ data: { key: 'indexed_height', value: '6' } });
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => [
         { height: 5, blockHash: 'h5-NEW', parentHash: 'h4-NEW' },
         { height: 6, blockHash: 'h6-NEW', parentHash: 'h5-NEW' },
@@ -291,8 +286,7 @@ describe('detectAndRollbackReorg', () => {
   test('returns null if daemon fetch throws', async () => {
     await seedHeaders([{ height: 10, blockHash: 'h10', parentHash: 'h9' }]);
 
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => { throw new Error('boom'); },
     }));
 
@@ -361,8 +355,7 @@ describe('reconstruction after rollback', () => {
     });
 
     // PHASE 1: ingest old chain.
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async () => oldChainEvents,
     }));
     await indexer.syncSingleContract(contract.id, address, 0, 9);
@@ -390,8 +383,7 @@ describe('reconstruction after rollback', () => {
       { height: 8, blockHash: NEW_HASH(8), parentHash: NEW_HASH(7) },
       { height: 9, blockHash: NEW_HASH(9), parentHash: NEW_HASH(8) },
     ];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchBestChainHeaders: async () => newChainHeaders,
     }));
     const fork = await detectAndRollbackReorg(stubConfig);
@@ -436,8 +428,7 @@ describe('reconstruction after rollback', () => {
         event: { owner: ownerB, added: '0', newNumOwners: '1', configNonce: '1' },
       },
     ];
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchDecodedContractEvents: async () => newChainEvents,
     }));
     await indexer.syncSingleContract(contract.id, address, 7, 9);
@@ -503,11 +494,4 @@ describe('reconstruction after rollback', () => {
     expect(await prisma.contractConfig.count()).toBe(countsBefore.contractConfig);
     expect(await prisma.blockHeader.count()).toBe(countsBefore.blockHeader);
   });
-});
-
-// Module mocks are process-global in bun and leak into later test files
-// (they survive mock.restore()); restore the real module so file ordering
-// can never break another suite's use of mina-client.
-afterAll(() => {
-  mock.module('../mina-client.js', () => minaClient);
 });

--- a/backend/src/tests/routes-subscribe.test.ts
+++ b/backend/src/tests/routes-subscribe.test.ts
@@ -5,7 +5,7 @@ import { PrivateKey } from 'o1js';
 import type { BackendConfig } from '../config.js';
 import { prisma } from '../db.js';
 import type { MinaGuardIndexer } from '../indexer.js';
-import * as minaClient from '../mina-client.js';
+import { stubMinaClient } from './stub-mina-client.js';
 import { createApiRouter } from '../routes.js';
 
 let server: Server;
@@ -72,8 +72,7 @@ beforeAll(async () => {
   // Mock network-touching helpers everywhere so subscribe doesn't hit a real node.
   // Default VK mock returns a hash so fromBlock-path tests treat the address as a zkApp;
   // the "not a zkApp" test overrides this to null.
-  mock.module('../mina-client.js', () => ({
-    ...minaClient,
+  stubMinaClient(() => ({
     fetchLatestBlockHeight: async () => 0,
     fetchVerificationKeyHash: async () => 'vk-hash-stub',
   }));
@@ -86,8 +85,7 @@ afterEach(async () => {
   await clearDatabase();
   // Re-establish the baseline mock after any per-test overrides.
   mock.restore();
-  mock.module('../mina-client.js', () => ({
-    ...minaClient,
+  stubMinaClient(() => ({
     fetchLatestBlockHeight: async () => 0,
     fetchVerificationKeyHash: async () => 'vk-hash-stub',
   }));
@@ -115,8 +113,7 @@ function del(path: string) {
 
 describe('POST /api/subscribe', () => {
   test('creates a contract entry with ready=false and discoveredAtBlock set to latestHeight - SUBSCRIBE_MARGIN', async () => {
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchLatestBlockHeight: async () => 1000,
     }));
 
@@ -153,8 +150,7 @@ describe('POST /api/subscribe', () => {
 
   test('accepts explicit fromBlock and uses it as discoveredAtBlock (bypassing the margin)', async () => {
     let fetchLatestCalls = 0;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchLatestBlockHeight: async () => {
         fetchLatestCalls += 1;
         return 9999;
@@ -172,8 +168,7 @@ describe('POST /api/subscribe', () => {
   });
 
   test('rejects explicit fromBlock when address is not a deployed zkApp (manual add-existing path)', async () => {
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchLatestBlockHeight: async () => 0,
       fetchVerificationKeyHash: async () => null,
     }));
@@ -190,8 +185,7 @@ describe('POST /api/subscribe', () => {
 
   test('does NOT require the address to be on-chain when fromBlock is omitted (auto-sub after deploy)', async () => {
     let vkCalls = 0;
-    mock.module('../mina-client.js', () => ({
-      ...minaClient,
+    stubMinaClient(() => ({
       fetchLatestBlockHeight: async () => 0,
       fetchVerificationKeyHash: async () => {
         vkCalls += 1;
@@ -426,11 +420,4 @@ describe('full-mode gating', () => {
     const stillThere = await prisma.contract.findUnique({ where: { address: subscribedAddress } });
     expect(stillThere).not.toBeNull();
   });
-});
-
-// Module mocks are process-global in bun and leak into later test files
-// (they survive mock.restore()); restore the real module so file ordering
-// can never break another suite's use of mina-client.
-afterAll(() => {
-  mock.module('../mina-client.js', () => minaClient);
 });

--- a/backend/src/tests/stub-mina-client.ts
+++ b/backend/src/tests/stub-mina-client.ts
@@ -1,0 +1,20 @@
+import { spyOn } from 'bun:test';
+import * as minaClient from '../mina-client.js';
+
+/**
+ * Replaces the given mina-client exports with stubs via spyOn, so the
+ * `mock.restore()` already in every file's afterEach undoes them
+ * automatically.
+ *
+ * Deliberately NOT mock.module(): module-mock registrations are
+ * process-global, survive mock.restore(), and whether a later test file's
+ * import resolves to the real module or a stale stub is timing-dependent —
+ * the source of the flaky 'pending'-instead-of-'unknown' failures in
+ * mina-client-tx-status.test.ts.
+ */
+export function stubMinaClient(factory: () => Record<string, unknown>): void {
+  for (const [name, impl] of Object.entries(factory())) {
+    if (typeof impl !== 'function') continue;
+    spyOn(minaClient, name as keyof typeof minaClient).mockImplementation(impl as never);
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,5 +13,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/tests"]
 }

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -24,6 +24,7 @@ import {
   waitForBanner as _waitForBanner,
   fillRecipients,
   waitForIndexer,
+  getIndexerStatus,
   getContracts,
   getContract,
   getOwners,
@@ -260,32 +261,76 @@ interface ExecuteOptions {
 }
 
 /**
+ * Best-effort barrier: wait until the backend indexer has caught up to the
+ * chain tip so any state the worker rebuilds from the backend reflects the
+ * latest blocks. Non-fatal — if the indexer can't catch up in time we proceed
+ * anyway rather than failing the test on the barrier itself.
+ */
+async function waitForIndexerCaughtUp(timeoutMs = 45_000): Promise<void> {
+  try {
+    await waitForIndexer(
+      'indexer caught up to chain tip',
+      async () => {
+        const s = await getIndexerStatus();
+        return !!s && s.latestChainHeight > 0 && s.indexedHeight >= s.latestChainHeight;
+      },
+      timeoutMs,
+    );
+  } catch {
+    log('  (indexer not fully caught up — proceeding anyway)');
+  }
+}
+
+/**
  * Opens a proposal's detail page, clicks Execute, waits for the success banner
  * and then for the indexer to reflect the execution. Returns the banner text.
+ *
+ * Retries the whole submit. A zkApp execute tx that the daemon accepts into the
+ * pool can still be silently lost under load — the tip drifts (fee-payer nonce
+ * or a state precondition) between acceptance and inclusion, so it never mines
+ * and the single-shot wait would burn the full timeout. Each attempt first lets
+ * the indexer settle, re-checks whether a prior attempt's tx landed late, then
+ * re-submits against freshly-settled state with a shorter per-attempt wait.
  */
 async function executeProposal(proposalHash: string, opts: ExecuteOptions): Promise<string> {
   const page = sharedPage;
-  await gotoWithWallet(`/transactions/${proposalHash}${opts.query ?? ''}`, opts.account ?? accounts[0]);
-  await page.waitForTimeout(SHORT_WAIT);
+  const isExecuted = opts.until ?? (async () => {
+    const proposal = await getProposal(contractAddress, proposalHash);
+    return proposal?.status === 'executed';
+  });
 
-  log('Clicking Execute Proposal...');
-  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
-  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
-  await executeBtn.click();
+  const maxAttempts = 3;
+  const perAttemptMs = Math.min(opts.timeoutMs ?? 240_000, 70_000);
+  let bannerText = '';
 
-  log('Waiting for execute transaction...');
-  const bannerText = await waitForBanner(page, 'success');
-  await opts.onBanner?.(bannerText);
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await waitForIndexerCaughtUp();
+    await gotoWithWallet(`/transactions/${proposalHash}${opts.query ?? ''}`, opts.account ?? accounts[0]);
+    await page.waitForTimeout(SHORT_WAIT);
 
-  await waitForIndexer(
-    opts.waitDescription,
-    opts.until ?? (async () => {
-      const proposal = await getProposal(contractAddress, proposalHash);
-      return proposal?.status === 'executed';
-    }),
-    opts.timeoutMs,
-    opts.intervalMs
-  );
+    // A previous attempt's tx may have landed late while we were retrying.
+    if (await isExecuted()) {
+      log(`Proposal already executed (attempt ${attempt}) — done`);
+      return bannerText || '(already executed)';
+    }
+
+    log(`Clicking Execute Proposal... (attempt ${attempt}/${maxAttempts})`);
+    const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+    await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+    await executeBtn.click();
+
+    log('Waiting for execute transaction...');
+    bannerText = await waitForBanner(page, 'success');
+    await opts.onBanner?.(bannerText);
+
+    try {
+      await waitForIndexer(opts.waitDescription, isExecuted, perAttemptMs, opts.intervalMs);
+      return bannerText;
+    } catch (err) {
+      if (attempt === maxAttempts) throw err;
+      log(`  Execute not confirmed in ${(perAttemptMs / 1000).toFixed(0)}s — re-submitting (attempt ${attempt + 1}/${maxAttempts})`);
+    }
+  }
   return bannerText;
 }
 

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -883,6 +883,11 @@ test('13. Execute transfer (account2)', async () => { const page = sharedPage;
 test('14. Verify final state', async () => { const page = sharedPage;
   log('=== Step 14: Verify final state ===');
 
+  // The page recycle after step 13 reloads the app with the child as the active
+  // vault; re-select the parent before checking its settings (cf. step 5).
+  await gotoWithWallet(`/accounts/${contractAddress}`, accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
+
   // Settings — 2 owners, threshold 2
   await gotoWithWallet('/settings', accounts[0]);
   await page.waitForTimeout(SHORT_WAIT);

--- a/e2e/onchain-flow.test.ts
+++ b/e2e/onchain-flow.test.ts
@@ -65,6 +65,7 @@ async function waitForBanner(...args: Parameters<typeof _waitForBanner>) {
 let accounts: TestAccount[];
 let contractAddress: string;
 let childAddress: string;
+let allocateChildHash: string;
 let proposalHashes: string[] = [];
 
 // Shared page — avoids Web Worker restart (and contract recompilation) between tests
@@ -261,76 +262,52 @@ interface ExecuteOptions {
 }
 
 /**
- * Best-effort barrier: wait until the backend indexer has caught up to the
- * chain tip so any state the worker rebuilds from the backend reflects the
- * latest blocks. Non-fatal — if the indexer can't catch up in time we proceed
- * anyway rather than failing the test on the barrier itself.
+ * Waits until the chain has produced `blocks` blocks beyond the current tip and
+ * the indexer has caught up. Used to let a freshly-landed tx (a just-created
+ * child account, a just-submitted proposal) finalise before we build an execute
+ * on top of it — executing against an unsettled tip is what lets the execute tx
+ * be accepted into the pool but then silently dropped under load.
  */
-async function waitForIndexerCaughtUp(timeoutMs = 45_000): Promise<void> {
-  try {
-    await waitForIndexer(
-      'indexer caught up to chain tip',
-      async () => {
-        const s = await getIndexerStatus();
-        return !!s && s.latestChainHeight > 0 && s.indexedHeight >= s.latestChainHeight;
-      },
-      timeoutMs,
-    );
-  } catch {
-    log('  (indexer not fully caught up — proceeding anyway)');
-  }
+async function waitForChainSettle(blocks: number, timeoutMs = 120_000): Promise<void> {
+  const start = await getIndexerStatus();
+  const target = (start?.latestChainHeight ?? 0) + blocks;
+  await waitForIndexer(
+    `chain settles ${blocks} blocks (height >= ${target})`,
+    async () => {
+      const s = await getIndexerStatus();
+      return !!s && s.latestChainHeight >= target && s.indexedHeight >= s.latestChainHeight;
+    },
+    timeoutMs,
+  );
 }
 
 /**
  * Opens a proposal's detail page, clicks Execute, waits for the success banner
  * and then for the indexer to reflect the execution. Returns the banner text.
- *
- * Retries the whole submit. A zkApp execute tx that the daemon accepts into the
- * pool can still be silently lost under load — the tip drifts (fee-payer nonce
- * or a state precondition) between acceptance and inclusion, so it never mines
- * and the single-shot wait would burn the full timeout. Each attempt first lets
- * the indexer settle, re-checks whether a prior attempt's tx landed late, then
- * re-submits against freshly-settled state with a shorter per-attempt wait.
  */
 async function executeProposal(proposalHash: string, opts: ExecuteOptions): Promise<string> {
   const page = sharedPage;
-  const isExecuted = opts.until ?? (async () => {
-    const proposal = await getProposal(contractAddress, proposalHash);
-    return proposal?.status === 'executed';
-  });
+  await gotoWithWallet(`/transactions/${proposalHash}${opts.query ?? ''}`, opts.account ?? accounts[0]);
+  await page.waitForTimeout(SHORT_WAIT);
 
-  const maxAttempts = 3;
-  const perAttemptMs = Math.min(opts.timeoutMs ?? 240_000, 70_000);
-  let bannerText = '';
+  log('Clicking Execute Proposal...');
+  const executeBtn = page.getByRole('button', { name: /execute proposal/i });
+  await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await executeBtn.click();
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    await waitForIndexerCaughtUp();
-    await gotoWithWallet(`/transactions/${proposalHash}${opts.query ?? ''}`, opts.account ?? accounts[0]);
-    await page.waitForTimeout(SHORT_WAIT);
+  log('Waiting for execute transaction...');
+  const bannerText = await waitForBanner(page, 'success');
+  await opts.onBanner?.(bannerText);
 
-    // A previous attempt's tx may have landed late while we were retrying.
-    if (await isExecuted()) {
-      log(`Proposal already executed (attempt ${attempt}) — done`);
-      return bannerText || '(already executed)';
-    }
-
-    log(`Clicking Execute Proposal... (attempt ${attempt}/${maxAttempts})`);
-    const executeBtn = page.getByRole('button', { name: /execute proposal/i });
-    await executeBtn.waitFor({ state: 'visible', timeout: 30_000 });
-    await executeBtn.click();
-
-    log('Waiting for execute transaction...');
-    bannerText = await waitForBanner(page, 'success');
-    await opts.onBanner?.(bannerText);
-
-    try {
-      await waitForIndexer(opts.waitDescription, isExecuted, perAttemptMs, opts.intervalMs);
-      return bannerText;
-    } catch (err) {
-      if (attempt === maxAttempts) throw err;
-      log(`  Execute not confirmed in ${(perAttemptMs / 1000).toFixed(0)}s — re-submitting (attempt ${attempt + 1}/${maxAttempts})`);
-    }
-  }
+  await waitForIndexer(
+    opts.waitDescription,
+    opts.until ?? (async () => {
+      const proposal = await getProposal(contractAddress, proposalHash);
+      return proposal?.status === 'executed';
+    }),
+    opts.timeoutMs,
+    opts.intervalMs
+  );
   return bannerText;
 }
 
@@ -573,8 +550,17 @@ test('4. Execute CREATE_CHILD via proposal detail', async () => {
 //     routing honest against future refactors of the branching logic.
 // ---------------------------------------------------------------------------
 
-test('4b. ALLOCATE_CHILD from parent to subvault (executeChildLifecycleOnchain)', async () => { const page = sharedPage;
-  log('=== Step 4b: Propose + execute ALLOCATE_CHILD ===');
+// Split into propose (4b) and execute (4c). Every other propose/execute pair in
+// this suite lives in two separate tests; ALLOCATE_CHILD used to be the only one
+// crammed back-to-back, and it was the only step that reliably timed out on
+// loaded CI. Its execute depends on the child account created just one step
+// earlier, so on a loaded chain it was executing against an unsettled tip — the
+// execute tx got accepted into the pool then silently dropped, which trips the
+// app's single-execute lock (recoverable only after the backend's 20-min
+// DROPPED_TX_GRACE_MS, far past any test timeout). Splitting + an explicit
+// settle lets the child + proposal finalise before we execute.
+test('4b. Propose ALLOCATE_CHILD from parent to subvault', async () => { const page = sharedPage;
+  log('=== Step 4b: Propose ALLOCATE_CHILD ===');
 
   // Parent may still be active from test 4, but reassert to be safe — the
   // proposal form derives its nonce space from the active contract.
@@ -588,14 +574,22 @@ test('4b. ALLOCATE_CHILD from parent to subvault (executeChildLifecycleOnchain)'
       p.txType === 'allocateChild' && p.receivers?.some((r: any) => r.address === childAddress),
     waitDescription: 'indexer processes ALLOCATE_CHILD proposal',
   });
-  const allocateHash = proposal.proposalHash;
-  log(`ALLOCATE_CHILD proposal: hash=${allocateHash.slice(0, 12)}...`);
+  allocateChildHash = proposal.proposalHash;
+  log(`ALLOCATE_CHILD proposal: hash=${allocateChildHash.slice(0, 12)}...`);
+});
 
-  await executeProposal(allocateHash, {
+test('4c. Execute ALLOCATE_CHILD (executeChildLifecycleOnchain)', async () => {
+  log('=== Step 4c: Execute ALLOCATE_CHILD ===');
+
+  // Let the newly-created child account and the ALLOCATE_CHILD proposal finalise
+  // before executing against them — see the note on test 4b.
+  await waitForChainSettle(4);
+
+  await executeProposal(allocateChildHash, {
     waitDescription: 'indexer processes ALLOCATE_CHILD execution',
   });
 
-  const executed = await getProposal(contractAddress, allocateHash);
+  const executed = await getProposal(contractAddress, allocateChildHash);
   expect(executed.status).toBe('executed');
   log(`ALLOCATE_CHILD executed`);
 });


### PR DESCRIPTION
Replaces every `mock.module('../mina-client.js', …)` stub in the backend tests (42 call sites across 6 files) with a shared `stubMinaClient()` helper that uses `spyOn(...).mockImplementation(...)` per export.

Why: module-mock registrations are process-global, survive `mock.restore()`, and whether a later test file's import resolves to the real module or a stale stub is timing-dependent — the source of the recurring flaky failures in `mina-client-tx-status.test.ts` ("expected 'unknown', received 'pending'", latest on PR #108's CI with zero backend changes). Spies are undone by the `mock.restore()` already in every file's `afterEach`, so leakage is structurally impossible and the per-file `afterAll` re-registration bandaids are removed.

Verified locally: full backend suite 139/139 × 4 consecutive runs against a fresh postgres (also exercises the #95 migration on a clean DB). The stub-driven tests passing confirms bun spies on the module namespace propagate to `indexer.ts`'s imports.

---

### CI infra (same flaky-CI theme, different layer)

The self-hosted `e2e-runner` and `deploy-runner` share one 15 GB / 8-core box. Preview deploys fired on every push and, together with the every-merge-to-main `e2e` + `deploy-lightnet` overlap, ran two Mina stacks at once — thrashing swap and starving o1js proving. That surfaced as e2e `indexer processes … proposal` timeouts (the propose tx is accepted into the pool but the starved daemon never includes it before the 240s wait — e.g. run 29556677405). Two changes:

- **On-demand previews** (`preview-deploy.yml`): deploy via a `/preview` (or `/preview up`) PR comment instead of on every push; `/preview down` tears it down; auto-teardown on PR close is kept. Restricted to `OWNER`/`MEMBER`/`COLLABORATOR` commenters, same-repo only (no fork code on the self-hosted runner). Note: the `/preview` command only activates once this merges to `main` (GitHub runs `issue_comment` workflows from the default branch); removing the automatic `synchronize` trigger takes effect on this PR immediately.
- **Host-wide serialization**: `e2e.yml`, `deploy-lightnet.yml`, and `preview-deploy.yml` share a job-level `minaguard-host` concurrency group (`cancel-in-progress: false`) so only one heavy stack runs on the box at a time. e2e keeps its workflow-level cancel-superseded group. (`deploy-trail.yml` is on a different machine and is untouched.)

---

### e2e onchain-flow flakes (`onchain-flow.test.ts`)

Two on-chain lifecycle flakes surfaced once the runner contention above was reduced:

- **Step 14 (verify final state) read the wrong vault.** The page recycle after step 13 reloads the app with the *child* vault active; step 14 went straight to `/settings` and asserted `Owners (2)` against the child (which has 1 owner). Now it re-selects the parent contract first, mirroring the guard already present in step 5.

- **ALLOCATE_CHILD (4b) timed out on ~60% of CI runs — always this step, never the other executes.** Root cause: it was the only step firing propose **and** execute back-to-back in one test, and its execute is the only one that depends on the child account created just one step earlier. On a loaded chain the execute ran against an unsettled tip, so the daemon accepted the execute tx into the pool and then silently dropped it (verified via local repro that the tx is accepted-then-lost, not rejected at submit). A dropped execute trips the app's single-execute lock (`executeInFlight` / "Execution in progress"), which only clears after the backend's `DROPPED_TX_GRACE_MS = 20 min` — far past the 4-minute test wait — so the proposal stayed `pending` forever. Fixed by splitting into `4b. Propose ALLOCATE_CHILD` + `4c. Execute ALLOCATE_CHILD` (like every other propose/execute pair) and calling `waitForChainSettle(4)` before executing so the child account and proposal finalize first. Green on CI (run 29566795589, 16/16).

  _Product follow-up (out of scope here): a genuinely stuck execute leaves a proposal un-executable for 20 min with no re-broadcast. Worth making the lock recover faster or auto-rebroadcast so a user on a slow/contended network can't get wedged._
