### PR TITLE
fix(ui,offline-cli): verify recomputed proposal hash matches the selected proposal

### DIFF
--- a/offline-cli/src/build-tx.ts
+++ b/offline-cli/src/build-tx.ts
@@ -370,6 +370,29 @@ function buildProposalStruct(
   });
 }
 
+/**
+ * Ties a rebuilt proposal to the one named in the bundle. handleApprove/
+ * handleExecute reconstruct TransactionProposal from the bundle's mutable
+ * fields and sign/act on the recomputed hash, so a bundle whose fields describe
+ * a different proposal than its declared proposalHash would silently redirect
+ * the signature/execution. A mismatch aborts before signing. handlePropose
+ * mints a new proposal with no prior identity and does not call this.
+ */
+function assertRecomputedProposalHash(
+  recomputed: InstanceType<typeof Field>,
+  expectedProposalHash: string,
+  action: string,
+): void {
+  const recomputedStr = recomputed.toString();
+  if (recomputedStr !== expectedProposalHash) {
+    throw new Error(
+      `Refusing to ${action}: the bundle's proposal fields hash to ${recomputedStr}, ` +
+        `which does not match its declared proposal ${expectedProposalHash}. ` +
+        `The bundle may have been tampered with.`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Store rebuilding from bundled events
 // ---------------------------------------------------------------------------
@@ -903,6 +926,7 @@ export async function handleApprove(
 
   const proposalHash = proposalStruct.hash();
   const hashStr = proposalHash.toString();
+  assertRecomputedProposalHash(proposalHash, bundle.proposal.proposalHash, 'approve this proposal');
   log(`Proposal hash: ${hashStr}`);
 
   // Sign the proposal hash.
@@ -996,6 +1020,7 @@ export async function handleExecute(
 
   const proposalHash = proposalStruct.hash();
   const hashStr = proposalHash.toString();
+  assertRecomputedProposalHash(proposalHash, bundle.proposal.proposalHash, 'execute this proposal');
   log(`Proposal hash: ${hashStr}`);
 
   const approvalWitness = approvalStore.getWitness(proposalHash);

--- a/ui/lib/multisigClient.worker.ts
+++ b/ui/lib/multisigClient.worker.ts
@@ -572,6 +572,31 @@ function buildProposalStruct(
   });
 }
 
+/**
+ * Ties a rebuilt proposal to the one the user selected. The approve/execute
+ * flows reconstruct TransactionProposal from mutable fields and then sign or act
+ * on the recomputed hash, so if a tampered backend/bundle supplies a different
+ * proposal's fields under the selected proposalHash, the signature or execution
+ * silently redirects to that other proposal. Comparing the recomputed hash to
+ * the selected identity closes that gap; a mismatch aborts the operation. The
+ * propose flow mints a new proposal with no prior identity and does not call
+ * this.
+ */
+function assertRecomputedProposalHash(
+  recomputed: InstanceType<typeof Field>,
+  expectedProposalHash: string,
+  action: string
+): void {
+  const recomputedStr = recomputed.toString();
+  if (recomputedStr !== expectedProposalHash) {
+    throw new Error(
+      `Refusing to ${action}: the proposal data hashes to ${recomputedStr}, ` +
+        `which does not match the selected proposal ${expectedProposalHash}. ` +
+        `The proposal fields may have been tampered with.`
+    );
+  }
+}
+
 /** Safely serializes tx.toJSON() regardless of whether it returns a string or object. */
 function serializeTx(tx: Awaited<ReturnType<typeof Mina.transaction>>): string {
   const json = tx.toJSON();
@@ -1028,6 +1053,7 @@ const workerApi = {
 
     const proposalHash = proposalStruct.hash();
     const hashStr = proposalHash.toString();
+    assertRecomputedProposalHash(proposalHash, params.proposal.proposalHash, 'approve this proposal');
 
     progressFn(testPrivateKey ? 'Signing proposal hash...' : 'Awaiting wallet signature...');
     const signature = await signProposalHash(hashStr, signFn);
@@ -1098,6 +1124,7 @@ const workerApi = {
     }, params.contractAddress);
 
     const proposalHash = proposalStruct.hash();
+    assertRecomputedProposalHash(proposalHash, params.proposal.proposalHash, 'execute this proposal');
     const approvalWitness = approvalStore.getWitness(proposalHash);
     const approvalCount = approvalStore.getCount(proposalHash);
 
@@ -1232,6 +1259,7 @@ const workerApi = {
       destination: 'remote',
     }, params.parentAddress);
     const proposalHash = proposalStruct.hash();
+    assertRecomputedProposalHash(proposalHash, params.proposal.proposalHash, 'set up this child');
     const approvalWitness = approvalStore.getWitness(proposalHash);
     const approvalCount = approvalStore.getCount(proposalHash);
 
@@ -1316,6 +1344,7 @@ const workerApi = {
       childAccount: params.proposal.childAccount ?? params.childAddress,
     }, params.parentAddress);
     const proposalHash = proposalStruct.hash();
+    assertRecomputedProposalHash(proposalHash, params.proposal.proposalHash, 'execute this child action');
     const approvalWitness = approvalStore.getWitness(proposalHash);
     const approvalCount = approvalStore.getCount(proposalHash);
     const childExecutionWitness = childExecutionMap.getWitness(proposalHash);


### PR DESCRIPTION
## What

The approve and execute flows rebuild `TransactionProposal` from the proposal's mutable fields (`buildProposalStruct`) and then sign or act on the recomputed `proposal.hash()`, but never check that the recomputed hash equals the `proposalHash` the user selected. So a tampered backend response or offline bundle can keep proposal A's identity on screen while supplying proposal B's fields: the owner signs/executes B while believing it is A. If it is the final approval, B reaches threshold and executes.

The contract is correct (it verifies the signature and approval witness for whatever `proposal.hash()` it is given); the gap is entirely client-side, and it puts an untrusted backend back inside the multisig's trust boundary.

## Fix

Add `assertRecomputedProposalHash(recomputed, expected, action)`: the recomputed hash must equal the selected/declared `proposalHash`, else the operation throws before signing. Wired into:

- Worker (`ui/lib/multisigClient.worker.ts`): `approveProposalOnchain`, `executeProposalOnchain`, `executeSetupChildOnchain`, `executeChildLifecycleOnchain`.
- Offline CLI (`offline-cli/src/build-tx.ts`): `handleApprove`, `handleExecute` (compared against `bundle.proposal.proposalHash`).

The `propose` paths mint a new proposal with no prior identity, so they are deliberately left unguarded.

## Notes

- Client-side only; no contract/circuit change, no VK impact.
- Complements the offline broadcast-time guard added in #76 (which checks the uploaded bundle against the page) by also refusing at signing time.
- I could not run the ui/offline-cli typecheck locally (worktree without deps); the change is a small, strictly-typed helper. Please let CI confirm.

Addresses a HIGH audit finding (previously partially addressed: offline broadcast guarded, online worker + CLI signing unguarded).
