### PR TITLE
docs(contracts): require atomic deploy+setup/reserve to close the front-run window

### DIFF
--- a/contracts/src/MinaGuard.ts
+++ b/contracts/src/MinaGuard.ts
@@ -276,7 +276,20 @@ export class MinaGuard extends SmartContract {
     createChildOwner: CreateChildOwnerEvent,
   };
 
-  /** Configures account permissions and emits a deploy discovery event. */
+  /**
+   * Configures account permissions and emits a deploy discovery event.
+   *
+   * SECURITY, initialize atomically: deploy() only publishes the account and its
+   * proof-authorized permissions; it does NOT set governance. Between deploy()
+   * and setup()/reserveForParent() the guard is uninitialized, and those init
+   * methods are authorized by proof alone with no deployer binding, so anyone
+   * can front-run initialization: call setup() with their own owner set, or
+   * reserveForParent() to bind the address to an attacker parent (which then
+   * permanently blocks the legitimate setup()). Callers MUST include deploy()
+   * and setup()/reserveForParent() in the SAME transaction, so no uninitialized
+   * on-chain window exists. Never deploy a guard in one transaction and
+   * initialize it in a later one.
+   */
   async deploy() {
     await super.deploy();
     this.account.permissions.set({
@@ -706,6 +719,10 @@ export class MinaGuard extends SmartContract {
    * The owners commitment is computed on-chain from `initialOwners` (see
    * initializeState), so the deployer cannot store a commitment that disagrees
    * with the owner set — no client-side cross-check is required.
+   *
+   * MUST be called in the SAME transaction as deploy() (see deploy()): this
+   * method is authorized by proof alone with no deployer binding, so a guard
+   * left deployed-but-uninitialized can be front-run and set up by anyone.
    */
   @method async setup(
     threshold: Field,
@@ -732,6 +749,11 @@ export class MinaGuard extends SmartContract {
    * executeSetupChild (which verifies the parent) can initialize the child.
    *
    * Can only be called once (parent must be empty).
+   *
+   * SECURITY: this MUST share the deploy() transaction (see deploy()). It is
+   * authorized by proof alone with no deployer binding, so a child left
+   * deployed-but-unreserved can be front-run: an attacker reserves it to their
+   * own parent, permanently bricking the intended child address.
    */
   @method async reserveForParent(
     parentAddress: PublicKey,


### PR DESCRIPTION
## What

Documents the atomic-initialization requirement for MinaGuard, closing out the recorded remediation for the "deployed-but-uninitialized guards can be taken over" finding.

`setup()` and `reserveForParent()` are proof-authorized with no deployer/zkApp-key binding, so a guard deployed in one transaction and initialized in a later one has an on-chain window where anyone can front-run initialization: call `setup()` with their own owner set, or `reserveForParent()` to bind the address to an attacker parent (which then permanently blocks the legitimate `setup()`). The app already avoids this by bundling deploy + setup atomically (`deployAndSetupContract`), but the contract itself didn't state the requirement.

## Change

Comments only, on `deploy()`, `setup()`, and `reserveForParent()`, stating that deploy and initialization MUST share a single transaction and why. No circuit change, no VK impact.

## Scope / follow-up

This is the documentation remediation, not on-chain enforcement: the contract still permits a standalone (non-atomic) `setup`/`reserve`, so any integrator who ignores the guidance remains exposed. If we later want defense-in-depth, an on-chain fix that requires the deploy key's signature in `setup()`/`reserveForParent()` is drafted on a separate WIP branch (`fix/authenticate-guard-initialization`); it is VK-breaking and, because `deploy()` sets `setVerificationKey: impossibleDuringCurrentVersion()`, would protect only newly deployed vaults.
