### PR TITLE
ci(preview): warn on the PR when /preview is queued behind the host lock

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -40,6 +40,7 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  actions: read # resolve job reads in-progress runs to warn when a preview will queue
 
 concurrency:
   group: preview-${{ github.event.issue.number || github.event.number }}
@@ -106,6 +107,62 @@ jobs:
               comment_id: context.payload.comment.id,
               content: 'rocket',
             });
+
+            // The deploy job shares the single-slot `minaguard-host` lock. If
+            // the host is busy the deploy will queue — and GitHub keeps only one
+            // pending run per group, so a newer CI run can silently evict it.
+            // We can't comment from the evicted deploy job (a job cancelled while
+            // pending runs no steps), so warn up front from here (resolve always
+            // runs — it's not in the lock). Best-effort; never fail the command.
+            if (sub === 'up') {
+              const QUEUE_MARKER = '<!-- preview-queued -->';
+              try {
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                });
+                for (const c of comments) {
+                  if (c.body && c.body.includes(QUEUE_MARKER)) {
+                    await github.rest.issues.deleteComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: c.id,
+                    });
+                  }
+                }
+                // Workflows that contend for the host lock (see minaguard-host).
+                const HOST_WORKFLOWS = ['E2E tests', 'Deploy lightnet (/app)', 'Preview Environment'];
+                const { data: running } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  status: 'in_progress',
+                  per_page: 50,
+                });
+                const blockers = running.workflow_runs.filter(
+                  (r) => r.id !== context.runId && HOST_WORKFLOWS.includes(r.name),
+                );
+                if (blockers.length) {
+                  const b = blockers[0];
+                  const body = [
+                    QUEUE_MARKER,
+                    `⏳ **Preview queued** behind [${b.name} #${b.run_number}](${b.html_url}) (\`${b.head_branch}\`).`,
+                    '',
+                    'It shares a single-slot host lock, so it will build once that run finishes.',
+                    'Heads-up: if newer CI runs pile up they can bump this queued build out of the slot — ' +
+                      "if you don't get a preview URL in a few minutes, just re-comment `/preview` to requeue.",
+                  ].join('\n');
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body,
+                  });
+                }
+              } catch (e) {
+                core.warning(`queue-status check failed: ${e.message}`);
+              }
+            }
 
   # ---------------------------------------------------------------------------
   # Deploy / redeploy the preview.
@@ -196,7 +253,7 @@ jobs:
               issue_number: pr,
             });
             for (const comment of comments.data) {
-              if (comment.body.includes('### Preview Environment')) {
+              if (comment.body.includes('### Preview Environment') || comment.body.includes('<!-- preview-queued -->')) {
                 await github.rest.issues.deleteComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -240,7 +297,7 @@ jobs:
               issue_number: pr,
             });
             for (const comment of comments.data) {
-              if (comment.body.includes('### Preview Environment')) {
+              if (comment.body.includes('### Preview Environment') || comment.body.includes('<!-- preview-queued -->')) {
                 await github.rest.issues.deleteComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
Follow-up to #110. On-demand `/preview` shares the single-slot `minaguard-host` concurrency group with `E2E tests` and `Deploy lightnet (/app)`. When one of those is running, a `/preview` deploy **queues** — and since GitHub keeps only one pending run per group (`cancel-in-progress: false`), a newer CI run can **silently evict** the queued preview. A job cancelled while pending runs no steps, so the deploy job can't report its own eviction.

This adds an up-front heads-up from the `resolve` job (which always runs — it's not in the lock): when `/preview` is received and a host-lock run is in progress, it posts a comment naming the blocker + link and telling the user to re-comment `/preview` if it gets bumped:

> ⏳ **Preview queued** behind [E2E tests #123](…) (`some-branch`).
> It shares a single-slot host lock, so it will build once that run finishes.
> Heads-up: if newer CI runs pile up they can bump this queued build out of the slot — if you don't get a preview URL in a few minutes, just re-comment `/preview` to requeue.

Details:
- Best-effort — wrapped in try/catch, never fails the command.
- Adds `actions: read` (needed to list in-progress runs).
- Stale queued notes (`<!-- preview-queued -->` marker) are cleaned up by the deploy URL-comment and teardown steps.

Does **not** change the eviction behavior itself (GitHub's queue depth is hard-capped at 1) — it just makes it visible instead of silent. The no-eviction alternative (a host `flock` instead of the concurrency group) is noted in the #110 discussion if we want to go further later.