### PR TITLE
fix(ui): pin Ledger signing networks by purpose instead of a mutable dropdown

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -10,7 +10,6 @@ import { useMultisig } from '@/hooks/useMultisig';
 import { useTransactions } from '@/hooks/useTransactions';
 import { AppContext, type OperationBanner } from '@/lib/app-context';
 import { warmupWorker, onLedgerSigningChange, type LedgerSigningContext } from '@/lib/multisigClient';
-import { setLedgerNetworkId } from '@/lib/ledgerWallet';
 import LedgerSigningModal from '@/components/LedgerSigningModal';
 
 /** Root-level provider that wires wallet state with backend-indexed contract data. */
@@ -32,9 +31,10 @@ function AppProvider({ children }: { children: React.ReactNode }) {
     connect, connectAuro, connectLedger, disconnect, setNetwork,
   } = useWallet();
 
-  const setWalletNetwork = useCallback((network: string, ledgerNetId: number) => {
+  // The Ledger signing network is fixed at build time (see ledgerWallet.ts), so
+  // the network selector only updates the displayed app network, not signing.
+  const setWalletNetwork = useCallback((network: string) => {
     setNetwork(network);
-    setLedgerNetworkId(ledgerNetId);
   }, [setNetwork]);
 
   const {

--- a/ui/lib/ledgerWallet.ts
+++ b/ui/lib/ledgerWallet.ts
@@ -7,13 +7,27 @@ import { MinaApp } from '@zondax/ledger-mina-js';
 let transport: Transport | null = null;
 let app: MinaApp | null = null;
 
-/** Ledger network ID: 1 = mainnet, 0 = testnet/devnet. Defaults to testnet. */
-let ledgerNetworkId = 0;
+// Ledger signing network IDs are FIXED, not user-selectable. The two Ledger
+// signing purposes need OPPOSITE networks, and the previous single mutable id
+// (set from a UI dropdown) was wrong for at least one of them in every config:
+//
+//  - Fee-payer / tx-commitment signatures (signFeePayer) are verified by the
+//    Mina node, so they must use the deployment's network. A mainnet build that
+//    signed with the testnet id produced signatures the mainnet node rejects.
+//  - Owner-approval signatures over the proposal hash (signFields) are verified
+//    IN-CIRCUIT by o1js Signature.verify, which always uses the 'devnet' prefix
+//    (network id 0) regardless of the deployment. Signing these with the mainnet
+//    id produced approvals the contract rejects.
+//
+// NEXT_PUBLIC_MINA_NETWORK is the same source the worker uses to build and
+// broadcast the transaction, so a fee-payer signature can never disagree with
+// the network the tx is actually sent to.
 
-/** Updates the network ID used for Ledger signing at runtime. */
-export function setLedgerNetworkId(id: number): void {
-  ledgerNetworkId = id;
-}
+/** Network id for fee-payer / tx signatures the Mina node verifies: the build network. */
+const LEDGER_TX_NETWORK_ID = process.env.NEXT_PUBLIC_MINA_NETWORK === 'mainnet' ? 1 : 0;
+
+/** Network id for owner-approval signatures verified in-circuit: always devnet (0). */
+const LEDGER_APPROVAL_NETWORK_ID = 0;
 
 const LEDGER_SUCCESS = 9000;
 
@@ -167,7 +181,8 @@ export async function signFeePayer(
   const bytes = fieldToBytes(BigInt(commitment));
   let result;
   try {
-    result = await ledger.signFieldElement(accountIndex, ledgerNetworkId, bytes);
+    // Fee-payer signature: the Mina node verifies it, so use the build network.
+    result = await ledger.signFieldElement(accountIndex, LEDGER_TX_NETWORK_ID, bytes);
   } catch (err) {
     throw toLedgerError(err);
   }
@@ -189,7 +204,10 @@ export async function signFields(
 
   let result;
   try {
-    result = await ledger.signFieldElement(accountIndex, ledgerNetworkId, bytes);
+    // Owner-approval signature over the proposal hash: verified in-circuit by
+    // o1js Signature.verify, which always uses the devnet prefix. Must be signed
+    // with the devnet id regardless of the deployment network.
+    result = await ledger.signFieldElement(accountIndex, LEDGER_APPROVAL_NETWORK_ID, bytes);
   } catch (err) {
     throw toLedgerError(err);
   }

--- a/ui/lib/ledgerWallet.ts
+++ b/ui/lib/ledgerWallet.ts
@@ -3,31 +3,36 @@
 import TransportWebHID from '@ledgerhq/hw-transport-webhid';
 import type Transport from '@ledgerhq/hw-transport';
 import { MinaApp } from '@zondax/ledger-mina-js';
+import { getMinaGuardConfig } from '@/lib/endpoints';
 
 let transport: Transport | null = null;
 let app: MinaApp | null = null;
 
-// Ledger signing network IDs are FIXED, not user-selectable. The two Ledger
-// signing purposes need OPPOSITE networks, and the previous single mutable id
-// (set from a UI dropdown) was wrong for at least one of them in every config:
+// Ledger signing network IDs are FIXED by the deployment, not user-selectable.
+// The two Ledger signing purposes need OPPOSITE networks, and the previous
+// single mutable id (set from a UI dropdown) was wrong for at least one of them
+// in every config:
 //
 //  - Fee-payer / tx-commitment signatures (signFeePayer) are verified by the
 //    Mina node, so they must use the deployment's network. A mainnet build that
 //    signed with the testnet id produced signatures the mainnet node rejects.
+//    The id comes from getMinaGuardConfig() at sign time: the SAME source the
+//    worker uses to build and broadcast the tx (the Electron runtime config when
+//    present, else NEXT_PUBLIC_* env), so a fee-payer signature can never
+//    disagree with the network the tx is actually sent to.
 //  - Owner-approval signatures over the proposal hash (signFields) are verified
 //    IN-CIRCUIT by o1js Signature.verify, which always uses the 'devnet' prefix
 //    (network id 0) regardless of the deployment. Signing these with the mainnet
 //    id produced approvals the contract rejects.
-//
-// NEXT_PUBLIC_MINA_NETWORK is the same source the worker uses to build and
-// broadcast the transaction, so a fee-payer signature can never disagree with
-// the network the tx is actually sent to.
-
-/** Network id for fee-payer / tx signatures the Mina node verifies: the build network. */
-const LEDGER_TX_NETWORK_ID = process.env.NEXT_PUBLIC_MINA_NETWORK === 'mainnet' ? 1 : 0;
 
 /** Network id for owner-approval signatures verified in-circuit: always devnet (0). */
 const LEDGER_APPROVAL_NETWORK_ID = 0;
+
+/** Network id for fee-payer / tx signatures the Mina node verifies. Resolved at
+ *  sign time from the same config the worker broadcasts with, so the two agree. */
+function ledgerTxNetworkId(): number {
+  return getMinaGuardConfig().networkId === 'mainnet' ? 1 : 0;
+}
 
 const LEDGER_SUCCESS = 9000;
 
@@ -181,8 +186,9 @@ export async function signFeePayer(
   const bytes = fieldToBytes(BigInt(commitment));
   let result;
   try {
-    // Fee-payer signature: the Mina node verifies it, so use the build network.
-    result = await ledger.signFieldElement(accountIndex, LEDGER_TX_NETWORK_ID, bytes);
+    // Fee-payer signature: the Mina node verifies it, so use the deployment
+    // network (same source the worker broadcasts with).
+    result = await ledger.signFieldElement(accountIndex, ledgerTxNetworkId(), bytes);
   } catch (err) {
     throw toLedgerError(err);
   }


### PR DESCRIPTION
## What

The UI Ledger path used a single mutable network id (`ledgerNetworkId`, default `0`/testnet) set from a wallet dropdown, for **both** Ledger signing purposes. The two need opposite networks, so one was always wrong:

- **Fee-payer / tx-commitment signatures** (`signFeePayer`) are verified by the Mina node, so they must use the deployment's network. A mainnet build signing with the testnet id produces signatures the mainnet node rejects. This is the reported finding.
- **Owner-approval signatures** over the proposal hash (`signFields`) are verified **in-circuit** by o1js `Signature.verify`, which always uses the `devnet` prefix regardless of network. Signing them with the mainnet id produces approvals the contract rejects (the related medium `cmpzr0dqu005q`).

The network was also user-selectable, so it could diverge from the network the worker actually builds and broadcasts to.

## Fix

- `signFeePayer` derives its network from `NEXT_PUBLIC_MINA_NETWORK` (the same source the worker's signer client uses to build/broadcast), so the fee-payer signature can never disagree with the tx's target network.
- `signFields` is pinned to devnet (`0`), matching the in-circuit `Signature.verify` prefix.
- Removed `setLedgerNetworkId` and its dropdown wiring in `app/layout.tsx`; the network selector now only updates the displayed app network, not signing.

## Notes

- Client-only; no contract/circuit change, no VK impact. `tsc --noEmit` is clean.
- Closes the UI half of a partially-fixed finding: the offline-CLI half was already fixed upstream (#74/#93). Also closes the related medium `cmpzr0dqu005q`.
- Optional follow-up (defense-in-depth, not included): a `verifyZkappCommandSignature(signedTx, network)` post-sign check in `broadcastWithLedgerSig` before `sendZkapp`. With the network now build-time-fixed rather than user-mutable, a mismatch can no longer be introduced, so this is belt-and-suspenders against an o1js/mina-signer version skew.
