### PR TITLE
fix(ui): remove the Ledger network dropdown (network is per-deployment)

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -28,14 +28,8 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   const {
     wallet, isLoading: walletLoading, error: walletError, clearError: clearWalletError,
     auroInstalled, ledgerSupported,
-    connect, connectAuro, connectLedger, disconnect, setNetwork,
+    connect, connectAuro, connectLedger, disconnect,
   } = useWallet();
-
-  // The Ledger signing network is fixed at build time (see ledgerWallet.ts), so
-  // the network selector only updates the displayed app network, not signing.
-  const setWalletNetwork = useCallback((network: string) => {
-    setNetwork(network);
-  }, [setNetwork]);
 
   const {
     state: multisig,
@@ -154,7 +148,6 @@ function AppProvider({ children }: { children: React.ReactNode }) {
         clearBanner,
         startOperation,
         ledgerSigning,
-        setWalletNetwork,
       }}
     >
       <div className="flex flex-col min-h-screen">
@@ -170,7 +163,6 @@ function AppProvider({ children }: { children: React.ReactNode }) {
           onConnectAuro={connectAuro}
           onConnectLedger={connectLedger}
           onDisconnect={async () => { await disconnect(); clearBanner(); router.push('/'); }}
-          onNetworkChange={setWalletNetwork}
         />
         <div className="flex flex-1 min-h-0">
           {pathname !== '/' && pathname !== '/accounts/new' && (

--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -18,7 +18,6 @@ interface HeaderProps {
   onConnectAuro: () => void;
   onConnectLedger: (accountIndex?: number) => void;
   onDisconnect: () => void;
-  onNetworkChange?: (network: string, ledgerNetworkId: number) => void;
 }
 
 export default function Header({
@@ -33,7 +32,6 @@ export default function Header({
   onConnectAuro,
   onConnectLedger,
   onDisconnect,
-  onNetworkChange,
 }: HeaderProps) {
   return (
     <header className="flex items-center justify-between px-6 py-4 border-b border-safe-border">
@@ -70,7 +68,6 @@ export default function Header({
           onConnectAuro={onConnectAuro}
           onConnectLedger={onConnectLedger}
           onDisconnect={onDisconnect}
-          onNetworkChange={onNetworkChange}
         />
       </div>
     </header>

--- a/ui/components/WalletConnect.tsx
+++ b/ui/components/WalletConnect.tsx
@@ -4,12 +4,6 @@ import { useState, useRef, useEffect } from 'react';
 import { truncateAddress, type WalletType } from '@/lib/types';
 import LedgerConnectModal from './LedgerConnectModal';
 
-const LEDGER_NETWORKS = [
-  { label: 'Testnet', id: 0 },
-  { label: 'Devnet', id: 0 },
-  { label: 'Mainnet', id: 1 },
-] as const;
-
 interface WalletConnectProps {
   address: string | null;
   connected: boolean;
@@ -22,7 +16,6 @@ interface WalletConnectProps {
   onConnectAuro: () => void;
   onConnectLedger: (accountIndex?: number) => void;
   onDisconnect: () => void;
-  onNetworkChange?: (network: string, ledgerNetworkId: number) => void;
 }
 
 export default function WalletConnect({
@@ -37,29 +30,23 @@ export default function WalletConnect({
   onConnectAuro,
   onConnectLedger,
   onDisconnect,
-  onNetworkChange,
 }: WalletConnectProps) {
   const [copied, setCopied] = useState(false);
   const [showLedgerModal, setShowLedgerModal] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
-  const [showWalletMenu, setShowWalletMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  const walletMenuRef = useRef<HTMLDivElement>(null);
 
-  // Close dropdowns on outside click
+  // Close the wallet menu on outside click
   useEffect(() => {
-    if (!showMenu && !showWalletMenu) return;
+    if (!showMenu) return;
     const handler = (e: MouseEvent) => {
-      if (showMenu && menuRef.current && !menuRef.current.contains(e.target as Node)) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setShowMenu(false);
-      }
-      if (showWalletMenu && walletMenuRef.current && !walletMenuRef.current.contains(e.target as Node)) {
-        setShowWalletMenu(false);
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [showMenu, showWalletMenu]);
+  }, [showMenu]);
 
   const handleCopy = () => {
     if (!address) return;
@@ -75,53 +62,13 @@ export default function WalletConnect({
   if (connected && address) {
     return (
       <div className="flex items-center gap-3">
-        {walletType === 'ledger' && onNetworkChange ? (
-          <div className="relative" ref={menuRef}>
-            <button
-              onClick={() => setShowMenu((prev) => !prev)}
-              className="text-sm font-medium text-safe-text hover:text-white transition-colors flex items-center gap-1"
-            >
-              {networkLabel}
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-              </svg>
-            </button>
-            {showMenu && (
-              <div className="absolute right-0 top-full mt-1 bg-safe-dark border border-safe-border rounded-lg py-1 min-w-[140px] z-50 shadow-lg">
-                {LEDGER_NETWORKS.map(({ label, id }) => (
-                  <button
-                    key={label}
-                    onClick={() => {
-                      onNetworkChange(label.toLowerCase(), id);
-                      setShowMenu(false);
-                    }}
-                    className={`w-full text-left text-xs px-3 py-1.5 transition-colors ${
-                      networkLabel === label
-                        ? 'text-safe-green'
-                        : 'text-safe-text hover:text-white hover:bg-safe-hover'
-                    }`}
-                  >
-                    {label}
-                    {networkLabel === label && ' ✓'}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        ) : (
-          <span className="text-sm font-medium text-safe-text">
-            {networkLabel}
-          </span>
-        )}
-        <div className="relative" ref={walletType === 'ledger' && onNetworkChange ? walletMenuRef : menuRef}>
+        {/* Network is fixed by the deployment (see getMinaGuardConfig); read-only. */}
+        <span className="text-sm font-medium text-safe-text">
+          {networkLabel}
+        </span>
+        <div className="relative" ref={menuRef}>
           <button
-            onClick={() => {
-              if (walletType === 'ledger' && onNetworkChange) {
-                setShowWalletMenu((prev) => !prev);
-              } else {
-                setShowMenu((prev) => !prev);
-              }
-            }}
+            onClick={() => setShowMenu((prev) => !prev)}
             className="flex items-center gap-2 bg-safe-gray border border-safe-border rounded-lg px-3 py-2 hover:bg-safe-hover transition-colors cursor-pointer"
           >
             <div className="w-2 h-2 rounded-full bg-safe-green" />
@@ -135,13 +82,12 @@ export default function WalletConnect({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
           </button>
-          {(walletType === 'ledger' && onNetworkChange ? showWalletMenu : showMenu) && (
+          {showMenu && (
             <div className="absolute right-0 top-full mt-1 bg-safe-dark border border-safe-border rounded-lg py-1 min-w-[160px] z-50 shadow-lg">
               <button
                 onClick={() => {
                   handleCopy();
                   setShowMenu(false);
-                  setShowWalletMenu(false);
                 }}
                 className="w-full text-left text-xs px-3 py-1.5 text-safe-text hover:text-white hover:bg-safe-hover transition-colors flex items-center gap-2"
               >
@@ -165,7 +111,6 @@ export default function WalletConnect({
               <button
                 onClick={() => {
                   setShowMenu(false);
-                  setShowWalletMenu(false);
                   onDisconnect();
                 }}
                 className="w-full text-left text-xs px-3 py-1.5 text-red-400 hover:text-red-300 hover:bg-safe-hover transition-colors flex items-center gap-2"

--- a/ui/hooks/useWallet.ts
+++ b/ui/hooks/useWallet.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/ledgerWallet';
 import { WalletState } from '@/lib/types';
 import { setLedgerSigning } from '@/lib/multisigClient';
+import { getMinaGuardConfig } from '@/lib/endpoints';
 
 const EMPTY_WALLET: WalletState = {
   connected: false,
@@ -136,13 +137,15 @@ export function useWallet() {
     try {
       const address = await getLedgerAddress(idx);
       localStorage.setItem('wallet-type', 'ledger');
-      setWallet((prev) => ({
+      setWallet({
         connected: true,
         address,
-        network: prev.network ?? 'testnet',
+        // A Ledger has no network of its own; the deployment fixes it. Use the
+        // same config the worker signs/broadcasts with (was the removed dropdown).
+        network: getMinaGuardConfig().networkId,
         type: 'ledger',
         ledgerAccountIndex: idx,
-      }));
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Ledger connection failed');
     } finally {
@@ -164,10 +167,6 @@ export function useWallet() {
 
   const clearError = useCallback(() => setError(null), []);
 
-  const setNetwork = useCallback((network: string) => {
-    setWallet((prev) => ({ ...prev, network }));
-  }, []);
-
   return {
     wallet,
     isLoading,
@@ -178,7 +177,6 @@ export function useWallet() {
     connectAuro,
     connectLedger,
     disconnect,
-    setNetwork,
     /** Backward-compatible alias for connectAuro. */
     connect: connectAuro,
   };

--- a/ui/lib/app-context.ts
+++ b/ui/lib/app-context.ts
@@ -53,8 +53,6 @@ export interface AppContextType {
   startOperation: (label: string, fn: (onProgress: (step: string) => void) => Promise<string | null>) => Promise<void>;
   /** Whether the Ledger device is currently awaiting user interaction. */
   ledgerSigning: boolean;
-  /** Updates the wallet network label and Ledger signing network ID. */
-  setWalletNetwork: (network: string, ledgerNetworkId: number) => void;
 }
 
 export const AppContext = createContext<AppContextType>({
@@ -84,7 +82,6 @@ export const AppContext = createContext<AppContextType>({
   clearBanner: () => {},
   startOperation: async () => {},
   ledgerSigning: false,
-  setWalletNetwork: () => {},
 });
 
 /** Hook wrapper for typed context consumption in client components. */


### PR DESCRIPTION
## Stacked on #114

Base is `fix/ledger-signing-network` (PR #114), not `main`, so this diff shows only the dropdown removal. Merge/rebase after #114 lands.

## What

The header network selector only ever rendered for **Ledger** (Auro reports its own connected network). It let the user pick a Ledger signing network id, which was the source of the wrong-domain signatures fixed in #114. After #114 it no longer affects signing or broadcast at all: those come from `getMinaGuardConfig()`. So the control is now a footgun that can only mislead (display a network the app isn't on).

## Change

- Remove the selector and its plumbing: `onNetworkChange` through `Header` -> `layout` -> `app-context`, plus `setWalletNetwork`, `setNetwork`, and `LEDGER_NETWORKS`.
- Collapse `WalletConnect`'s dual menu state/refs (`showMenu`/`menuRef` + `showWalletMenu`/`walletMenuRef`) to a single menu, since Ledger no longer has a second dropdown.
- A connected Ledger's displayed network now comes from `getMinaGuardConfig().networkId` (set in `connectLedger`), the same source the worker signs/broadcasts with. The header shows a read-only network label for both wallet types.

Network selection is now purely per-deployment (one build per network), which is already how `getMinaGuardConfig()` resolves it.

## Desktop

On the Electron app the network is runtime-detected (`window.__minaGuardConfig`), and `Header` already renders `NodeEndpointsChip` for that. `connectLedger` reads `getMinaGuardConfig()` at connect time (client-only, user-initiated), so it picks up the runtime config with no SSR/hydration concern. The removed selector was redundant with `NodeEndpointsChip` on desktop anyway.

## Notes

- Client-only; no contract/VK impact. `tsc --noEmit` clean.
- **Separate follow-up:** warn when a connected **Auro** wallet's network differs from the deployment (Auro approvals signed on the wrong network are rejected in-circuit). Pre-existing and unaffected by this change; Auro's network comes from Auro, never from the removed dropdown.
