### PR TITLE
feat(ui): warn and block when the Auro wallet is on the wrong network

### DIFF
--- a/e2e/wallet-mock.ts
+++ b/e2e/wallet-mock.ts
@@ -19,7 +19,10 @@ export const MOCK_WALLET_SCRIPT = `
       );
     },
     requestNetwork() {
-      return Promise.resolve({ chainId: 'testnet', name: 'testnet' });
+      // Real Auro returns { networkID: 'mina:<net>' }; getAuroNetwork parses
+      // networkID. Without it, getAuroNetwork returns null and the app's
+      // network-mismatch gate blocks signing.
+      return Promise.resolve({ networkID: 'mina:testnet', chainId: 'testnet', name: 'testnet' });
     },
     sendTransaction() {
       // In test mode the worker signs and sends directly; this is a no-op fallback.

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -31,7 +31,7 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   const {
     wallet, isLoading: walletLoading, error: walletError, clearError: clearWalletError,
     auroInstalled, ledgerSupported,
-    connect, connectAuro, connectLedger, disconnect, networkMismatch,
+    connect, connectAuro, connectLedger, disconnect, networkMismatch, assertSigningNetwork,
   } = useWallet();
 
   const {
@@ -65,9 +65,6 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   const [operationBanner, setOperationBanner] = useState<OperationBanner | null>(null);
   const refreshRef = useRef(refreshMultisig);
   refreshRef.current = refreshMultisig;
-  // Read the latest mismatch inside startOperation without recreating it.
-  const networkMismatchRef = useRef(networkMismatch);
-  networkMismatchRef.current = networkMismatch;
   const currentLabelRef = useRef('');
 
   const clearBanner = useCallback(() => setOperationBanner(null), []);
@@ -84,15 +81,12 @@ function AppProvider({ children }: { children: React.ReactNode }) {
 
   const startOperation = useCallback(
     async (label: string, fn: (onProgress: (step: string) => void) => Promise<string | null>) => {
-      // Block signing when the connected Auro wallet is on the wrong network:
-      // approvals would fail the in-circuit verify and broadcasts hit the wrong
-      // chain. The user must switch networks in Auro first.
-      const mismatch = networkMismatchRef.current;
-      if (mismatch) {
-        setOperationBanner({
-          type: 'error',
-          message: `Your Auro wallet is on ${capNetwork(mismatch.walletNetwork)}, but this app runs on ${capNetwork(mismatch.deploymentNetwork)}. Switch networks in Auro, then reconnect.`,
-        });
+      // Fail-closed network gate: re-query the connected wallet's network live and
+      // block if it can't be confirmed or is on the wrong chain, so no
+      // wrong-network approval or broadcast is ever attempted.
+      const blockMessage = await assertSigningNetwork();
+      if (blockMessage) {
+        setOperationBanner({ type: 'error', message: blockMessage });
         return;
       }
       setIsOperating(true);
@@ -133,7 +127,7 @@ function AppProvider({ children }: { children: React.ReactNode }) {
         setIsOperating(false);
       }
     },
-    []
+    [assertSigningNetwork]
   );
 
   return (

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -12,6 +12,9 @@ import { AppContext, type OperationBanner } from '@/lib/app-context';
 import { warmupWorker, onLedgerSigningChange, type LedgerSigningContext } from '@/lib/multisigClient';
 import LedgerSigningModal from '@/components/LedgerSigningModal';
 
+/** Capitalizes a network name for display (e.g. "mainnet" -> "Mainnet"). */
+const capNetwork = (n: string) => n.charAt(0).toUpperCase() + n.slice(1);
+
 /** Root-level provider that wires wallet state with backend-indexed contract data. */
 function AppProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -28,7 +31,7 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   const {
     wallet, isLoading: walletLoading, error: walletError, clearError: clearWalletError,
     auroInstalled, ledgerSupported,
-    connect, connectAuro, connectLedger, disconnect,
+    connect, connectAuro, connectLedger, disconnect, networkMismatch,
   } = useWallet();
 
   const {
@@ -62,6 +65,9 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   const [operationBanner, setOperationBanner] = useState<OperationBanner | null>(null);
   const refreshRef = useRef(refreshMultisig);
   refreshRef.current = refreshMultisig;
+  // Read the latest mismatch inside startOperation without recreating it.
+  const networkMismatchRef = useRef(networkMismatch);
+  networkMismatchRef.current = networkMismatch;
   const currentLabelRef = useRef('');
 
   const clearBanner = useCallback(() => setOperationBanner(null), []);
@@ -78,6 +84,17 @@ function AppProvider({ children }: { children: React.ReactNode }) {
 
   const startOperation = useCallback(
     async (label: string, fn: (onProgress: (step: string) => void) => Promise<string | null>) => {
+      // Block signing when the connected Auro wallet is on the wrong network:
+      // approvals would fail the in-circuit verify and broadcasts hit the wrong
+      // chain. The user must switch networks in Auro first.
+      const mismatch = networkMismatchRef.current;
+      if (mismatch) {
+        setOperationBanner({
+          type: 'error',
+          message: `Your Auro wallet is on ${capNetwork(mismatch.walletNetwork)}, but this app runs on ${capNetwork(mismatch.deploymentNetwork)}. Switch networks in Auro, then reconnect.`,
+        });
+        return;
+      }
       setIsOperating(true);
       setOperationLabel(label);
       setCompletedSteps([]);
@@ -164,6 +181,17 @@ function AppProvider({ children }: { children: React.ReactNode }) {
           onConnectLedger={connectLedger}
           onDisconnect={async () => { await disconnect(); clearBanner(); router.push('/'); }}
         />
+        {networkMismatch && (
+          <div className="flex items-center gap-2 bg-amber-500/15 border-b border-amber-500/40 px-6 py-2.5 text-sm text-amber-300">
+            <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+            <span>
+              Your Auro wallet is on <b>{capNetwork(networkMismatch.walletNetwork)}</b>, but this app runs on{' '}
+              <b>{capNetwork(networkMismatch.deploymentNetwork)}</b>. Switch networks in Auro to sign or broadcast.
+            </span>
+          </div>
+        )}
         <div className="flex flex-1 min-h-0">
           {pathname !== '/' && pathname !== '/accounts/new' && (
             <Sidebar

--- a/ui/hooks/useWallet.ts
+++ b/ui/hooks/useWallet.ts
@@ -18,6 +18,9 @@ import { WalletState } from '@/lib/types';
 import { setLedgerSigning } from '@/lib/multisigClient';
 import { getMinaGuardConfig } from '@/lib/endpoints';
 
+/** Capitalizes a network name for display (e.g. "mainnet" -> "Mainnet"). */
+const capNet = (n: string) => n.charAt(0).toUpperCase() + n.slice(1);
+
 const EMPTY_WALLET: WalletState = {
   connected: false,
   address: null,
@@ -167,12 +170,18 @@ export function useWallet() {
 
   const clearError = useCallback(() => setError(null), []);
 
-  // Warn when a connected Auro wallet sits on a different proof domain than this
-  // deployment. Auro signs approvals/txs on its OWN network, so a mainnet-vs-not
-  // mismatch makes owner approvals fail the in-circuit verify (which always uses
-  // the devnet prefix) and sends broadcasts to the wrong chain. Only mainnet vs
-  // not matters (devnet/testnet share the domain). Ledger has no network of its
-  // own (its id is pinned to the deployment), so this applies only to Auro.
+  // Latest wallet snapshot, so the stable assertSigningNetwork callback can read
+  // current state without being recreated.
+  const walletRef = useRef(wallet);
+  walletRef.current = wallet;
+
+  // Proactive WARNING banner: derived from the cached Auro network. A connected
+  // Auro wallet on a different proof domain than this deployment makes owner
+  // approvals fail the in-circuit verify (which always uses the devnet prefix)
+  // and sends broadcasts to the wrong chain. Only mainnet vs not matters
+  // (devnet/testnet share the domain). Ledger's id is pinned to the deployment,
+  // so this applies only to Auro. Null cache => no banner (see the fail-closed
+  // enforcement below, which does not trust the cache).
   const networkMismatch = useMemo(() => {
     if (!wallet.connected || wallet.type !== 'auro' || !wallet.network) return null;
     const deploymentNetwork = getMinaGuardConfig().networkId;
@@ -180,9 +189,29 @@ export function useWallet() {
     return { walletNetwork: wallet.network, deploymentNetwork };
   }, [wallet.connected, wallet.type, wallet.network]);
 
+  // Fail-CLOSED enforcement: re-query Auro's network LIVE right before signing.
+  // The cached wallet.network can be null (Auro injects window.mina async, so
+  // requestNetwork races on first load/reconnect) or stale (a missed
+  // chainChanged), and trusting it would let a wrong-network approval/broadcast
+  // through. Returns a block message, or null when signing may proceed.
+  const assertSigningNetwork = useCallback(async (): Promise<string | null> => {
+    const w = walletRef.current;
+    if (!w.connected || w.type !== 'auro') return null;
+    const auroNetwork = await getAuroNetwork();
+    const deploymentNetwork = getMinaGuardConfig().networkId;
+    if (!auroNetwork) {
+      return `Can't confirm your Auro wallet's network. Unlock Auro and set it to ${capNet(deploymentNetwork)}, then retry.`;
+    }
+    if ((auroNetwork === 'mainnet') !== (deploymentNetwork === 'mainnet')) {
+      return `Your Auro wallet is on ${capNet(auroNetwork)}, but this app runs on ${capNet(deploymentNetwork)}. Switch networks in Auro, then retry.`;
+    }
+    return null;
+  }, []);
+
   return {
     wallet,
     networkMismatch,
+    assertSigningNetwork,
     isLoading,
     error,
     clearError,

--- a/ui/hooks/useWallet.ts
+++ b/ui/hooks/useWallet.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import {
   isAuroInstalled,
   connectAuro as connectAuroWallet,
@@ -167,8 +167,22 @@ export function useWallet() {
 
   const clearError = useCallback(() => setError(null), []);
 
+  // Warn when a connected Auro wallet sits on a different proof domain than this
+  // deployment. Auro signs approvals/txs on its OWN network, so a mainnet-vs-not
+  // mismatch makes owner approvals fail the in-circuit verify (which always uses
+  // the devnet prefix) and sends broadcasts to the wrong chain. Only mainnet vs
+  // not matters (devnet/testnet share the domain). Ledger has no network of its
+  // own (its id is pinned to the deployment), so this applies only to Auro.
+  const networkMismatch = useMemo(() => {
+    if (!wallet.connected || wallet.type !== 'auro' || !wallet.network) return null;
+    const deploymentNetwork = getMinaGuardConfig().networkId;
+    if ((wallet.network === 'mainnet') === (deploymentNetwork === 'mainnet')) return null;
+    return { walletNetwork: wallet.network, deploymentNetwork };
+  }, [wallet.connected, wallet.type, wallet.network]);
+
   return {
     wallet,
+    networkMismatch,
     isLoading,
     error,
     clearError,


### PR DESCRIPTION
## Stacked on #115 (which is stacked on #114)

Base is `fix/remove-network-dropdown` (#115), so this diff shows only the Auro change. Rebase down the stack as each lands.

## Why

Unlike Ledger (whose signing network id we now pin to the deployment), **Auro owns its own network** — the user picks it inside the extension and we can only read it (`getAuroNetwork`). If the connected Auro wallet is on a different proof domain than the deployment:

- **Owner approvals fail.** The contract verifies approval signatures in-circuit with the devnet prefix always; a mainnet-Auro signature is mainnet-prefixed and gets rejected.
- **Broadcasts hit the wrong chain.** Auro sends to its own network's node.

Today this surfaces as cryptic in-circuit / broadcast errors.

## Change

- `useWallet` computes `networkMismatch` for a connected **Auro** wallet: non-null only when Auro is `mainnet` and the deployment isn't, or vice versa. Only mainnet-vs-not matters (devnet/testnet share the signing domain), so a devnet-vs-testnet difference does not false-positive.
- A persistent amber warning banner under the header names both networks and tells the user to switch in Auro.
- `startOperation` (the single choke point every propose/approve/execute/deploy goes through) is blocked with a clear error banner while mismatched, so no wrong-network signature or broadcast is attempted.

Ledger is unaffected (its id is pinned to the deployment in #114).

## Notes

- Client-only; no contract/VK impact. `tsc --noEmit` clean.
- Detection is via `getMinaGuardConfig()` inside a `useMemo` gated on `connected && type==='auro'`, so it never runs during SSR/first render (no hydration mismatch); it re-evaluates when Auro's network changes (existing `onNetworkChange` listener updates `wallet.network`).
