### PR TITLE
fix(preview-env): fail the backend build when the VK-hash compile fails

### DIFF
--- a/preview-env/Dockerfile.backend
+++ b/preview-env/Dockerfile.backend
@@ -39,7 +39,11 @@ RUN if [ "$MINAGUARD_VK_HASH" = "skip" ]; then \
       echo "$MINAGUARD_VK_HASH" > /app/.vk-hash; \
     else \
       echo "MINAGUARD_VK_HASH build arg not set — compiling circuit (memory-heavy)..."; \
-      bun run dev-helpers/cli.ts vk-hash compile 2>&1 | awk '/^vkHash:/{print $2}' > /app/.vk-hash; \
+      vk_output="$(bun run dev-helpers/cli.ts vk-hash compile 2>&1)" || { echo "$vk_output" >&2; echo "ERROR: VK hash compile failed — refusing to build with an empty VK filter (the indexer would accept ALL contracts as MinaGuard vaults)" >&2; exit 1; }; \
+      echo "$vk_output"; \
+      vk_hash="$(printf '%s\n' "$vk_output" | awk '/vkHash/{print $NF; exit}')"; \
+      if [ -z "$vk_hash" ]; then echo "ERROR: no VK hash found in compile output — refusing to build with an empty VK filter" >&2; exit 1; fi; \
+      printf '%s\n' "$vk_hash" > /app/.vk-hash; \
     fi
 
 # Generate Prisma client

--- a/preview-env/Dockerfile.backend
+++ b/preview-env/Dockerfile.backend
@@ -41,8 +41,8 @@ RUN if [ "$MINAGUARD_VK_HASH" = "skip" ]; then \
       echo "MINAGUARD_VK_HASH build arg not set — compiling circuit (memory-heavy)..."; \
       vk_output="$(bun run dev-helpers/cli.ts vk-hash compile 2>&1)" || { echo "$vk_output" >&2; echo "ERROR: VK hash compile failed — refusing to build with an empty VK filter (the indexer would accept ALL contracts as MinaGuard vaults)" >&2; exit 1; }; \
       echo "$vk_output"; \
-      vk_hash="$(printf '%s\n' "$vk_output" | awk '/vkHash/{print $NF; exit}')"; \
-      if [ -z "$vk_hash" ]; then echo "ERROR: no VK hash found in compile output — refusing to build with an empty VK filter" >&2; exit 1; fi; \
+      vk_hash="$(printf '%s\n' "$vk_output" | awk '/^vkHash/{print $NF; exit}')"; \
+      case "$vk_hash" in ''|*[!0-9]*) echo "ERROR: no decimal VK hash found in compile output — refusing to build with an empty VK filter" >&2; exit 1;; esac; \
       printf '%s\n' "$vk_hash" > /app/.vk-hash; \
     fi
 


### PR DESCRIPTION
Fixes a zkao finding: a failed VK-hash compile silently produced a backend that trusts every contract on chain.

## The problem

```dockerfile
bun run dev-helpers/cli.ts vk-hash compile 2>&1 | awk '/^vkHash:/{print $2}' > /app/.vk-hash
```

Two defects, either of which yields an **empty** `/app/.vk-hash`:

1. The compile is the left side of a pipe, so its exit status is discarded. An OOM-killed circuit compile (the very failure the surrounding comment warns about) is masked by `awk`'s exit 0 and the build succeeds.
2. The pattern never matched. `vk-hash compile` prints `vkHash[<network>]: <hash>`, not `vkHash: <hash>`, so this branch wrote an empty file even on a fully successful compile.

`entrypoint-backend.sh` then exports `MINAGUARD_VK_HASH=$(cat /app/.vk-hash)`, i.e. the empty string, and both VK checks are written as `config?.minaguardVkHash && verificationKeyHash !== config.minaguardVkHash` (`indexer.ts:312`, `routes.ts:598`). An empty string is falsy, so the guard becomes a **no-op** and the indexer accepts any contract at any address as a genuine MinaGuard vault. The failure mode is fail-open and silent.

## The change

- Capture the compile output instead of piping it, and fail the build on a non-zero exit, echoing the captured output so the real error is visible in the build log.
- Fix the `awk` pattern to the format actually printed, anchored at line start so an incidental `vkHash` mention elsewhere in the output cannot be picked up.
- Fail the build unless the extracted value is all digits (a VK hash is a decimal `Field`), so a wrong token cannot become a silently-wrong filter.
- Only write `/app/.vk-hash` once a hash is in hand.

The explicit `MINAGUARD_VK_HASH=skip` escape hatch is unchanged: opting out of the filter stays possible, it just has to be deliberate rather than the accidental result of a crashed compile.

## Verification

The extraction logic was exercised against the real compile output plus four failure shapes (empty output, OOM with no hash line, the legacy `vkHash: <h>` format, and a decoy mid-line `vkHash` mention): the real hash is extracted in the success cases and the build is rejected in the failure cases. `sh -n` clean on the generated `RUN` block.
