### PR TITLE
Harden desktop app security

### DIFF
--- a/desktop/src/config-ipc.ts
+++ b/desktop/src/config-ipc.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import { assertMainWindow } from './ipc-security.js';
 import type { UserConfig } from './config-store.js';
 
 export interface ConfigIpcContext {
@@ -71,7 +72,8 @@ export function registerConfigIpc(ctx: ConfigIpcContext): void {
     ctx.onSetupCancel();
   });
 
-  ipcMain.handle('config:set-endpoints', async (_event, cfg) => {
+  ipcMain.handle('config:set-endpoints', async (event, cfg) => {
+    assertMainWindow(event);
     const parsed = parseEndpointsPayload(cfg);
     await ctx.onChangeEndpoints(parsed);
   });

--- a/desktop/src/ipc-security.ts
+++ b/desktop/src/ipc-security.ts
@@ -1,0 +1,20 @@
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+
+const PORT = 5050;
+const MAIN_ORIGIN = `http://127.0.0.1:${PORT}`;
+
+type IpcEvent = IpcMainEvent | IpcMainInvokeEvent;
+
+// Defense in depth behind the navigation lock: only the main frame can send
+// IPC and it is pinned to the local origin, this catches a regression of that.
+export function assertMainWindow(event: IpcEvent): void {
+  let origin = '';
+  try {
+    origin = new URL(event.senderFrame?.url ?? '').origin;
+  } catch {
+    // no or malformed sender url, treat as untrusted
+  }
+  if (origin !== MAIN_ORIGIN) {
+    throw new Error('Rejected IPC from untrusted sender');
+  }
+}

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { ipcMain, shell } from 'electron';
+import { assertMainWindow } from './ipc-security.js';
 
 const REQUEST_TIMEOUT_MS = 120_000;
 const PORT = 5050;
@@ -85,19 +86,23 @@ function handleAuroRequest(method: string, payload: unknown): Promise<unknown> {
 }
 
 export function registerIpcHandlers(): void {
-  ipcMain.handle('auro:request-accounts', () => {
+  ipcMain.handle('auro:request-accounts', (event) => {
+    assertMainWindow(event);
     return handleAuroRequest('requestAccounts', {});
   });
 
-  ipcMain.handle('auro:sign-fields', (_event, params) => {
+  ipcMain.handle('auro:sign-fields', (event, params) => {
+    assertMainWindow(event);
     return handleAuroRequest('signFields', params);
   });
 
-  ipcMain.handle('auro:sign-message', (_event, params) => {
+  ipcMain.handle('auro:sign-message', (event, params) => {
+    assertMainWindow(event);
     return handleAuroRequest('signMessage', params);
   });
 
-  ipcMain.handle('auro:send-transaction', (_event, params) => {
+  ipcMain.handle('auro:send-transaction', (event, params) => {
+    assertMainWindow(event);
     return handleAuroRequest('sendTransaction', params);
   });
 }

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -154,6 +154,45 @@ async function startServices(config: UserConfig): Promise<void> {
   await startHttpServer(backend);
 }
 
+/** Locks a window to the trusted app: denies new-window creation (external
+ *  links go to the OS browser) and blocks in-frame navigation off
+ *  `allowedOrigin`. Omit `allowedOrigin` to block all navigation, for static
+ *  loadFile windows that never navigate. */
+function hardenWindow(win: BrowserWindow, allowedOrigin?: string): void {
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    // External URLs must not open in-app, a window inherits the preload and
+    // exposes the privileged bridge. Route http(s) to the OS browser, deny all.
+    let protocol = '';
+    try {
+      protocol = new URL(url).protocol;
+    } catch {
+      // malformed url, fall through to deny
+    }
+    if (protocol === 'http:' || protocol === 'https:') {
+      void shell.openExternal(url).catch((err) => {
+        console.error('[desktop] failed to open external url:', err.message);
+      });
+    }
+    return { action: 'deny' };
+  });
+
+  // Keep the frame on the trusted origin, or block all navigation when no
+  // origin is allowed. Covers main frame and subframes, not loadFile/loadURL
+  // or in-page routing.
+  win.webContents.on('will-frame-navigate', (details) => {
+    let origin = '';
+    try {
+      origin = new URL(details.url).origin;
+    } catch {
+      // malformed url, block it
+    }
+    if (allowedOrigin === undefined || origin !== allowedOrigin) {
+      details.preventDefault();
+      console.warn(`[desktop] blocked navigation to ${details.url}`);
+    }
+  });
+}
+
 /** Runs the setup flow: on first run seeded with defaults, and as the recovery
  *  path — seeded with the saved endpoints plus the startup error — when the
  *  app failed to start. Saving verifies the endpoints, persists them, and
@@ -179,6 +218,9 @@ function runSetupFlow(
       title: 'MinaGuard Setup',
       webPreferences: { preload: setupPreloadPath },
     });
+
+    // Static setup page, no navigation is ever legitimate, block all of it.
+    hardenWindow(win);
 
     let settled = false;
     const settle = (value: { config: UserConfig; close: () => void } | null) => {
@@ -375,22 +417,9 @@ function openMainWindow(closeSetupWindow: (() => void) | null): void {
     event.preventDefault();
   });
 
-  // External URLs must never open in-app, an Electron window would inherit the
-  // preload and expose window.mina. Route http(s) to the OS browser, deny all.
-  win.webContents.setWindowOpenHandler(({ url }) => {
-    let protocol = '';
-    try {
-      protocol = new URL(url).protocol;
-    } catch {
-      // malformed url, fall through to deny
-    }
-    if (protocol === 'http:' || protocol === 'https:') {
-      void shell.openExternal(url).catch((err) => {
-        console.error('[desktop] failed to open external url:', err.message);
-      });
-    }
-    return { action: 'deny' };
-  });
+  // Treat the renderer as untrusted: pin it to the local origin and send
+  // external links to the OS browser, not preload-carrying windows.
+  hardenWindow(win, `http://127.0.0.1:${PORT}`);
 
   // Keep setup window alive until the main window has a content to show, then
   // close it. `did-finish-load` fires after the initial navigation completes.

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -91,6 +91,34 @@ function startNextStandalone(): Promise<void> {
   });
 }
 
+// CSP for the app window that holds window.mina. o1js proving forces
+// 'unsafe-eval' + blob workers, so this is a remote-content and exfil lock,
+// not XSS prevention. connect-src must allow the configured Mina/archive nodes.
+function contentSecurityPolicy(): string {
+  const connect = new Set<string>(["'self'"]);
+  for (const ep of [currentConfig?.minaEndpoint, currentConfig?.archiveEndpoint]) {
+    if (!ep) continue;
+    try {
+      connect.add(new URL(ep).origin);
+    } catch {
+      // skip an unparseable endpoint
+    }
+  }
+  return [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'",
+    "worker-src 'self' blob:",
+    `connect-src ${[...connect].join(' ')}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "object-src 'none'",
+    "frame-src 'none'",
+    "base-uri 'none'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ');
+}
+
 async function startHttpServer(
   backendHandle: EmbeddedBackendHandle,
 ): Promise<void> {
@@ -102,6 +130,8 @@ async function startHttpServer(
       return;
     }
     if (handleAuroRoute(req, res)) return;
+    // CSP on the app + api responses, not the Auro pages handled above.
+    res.setHeader('Content-Security-Policy', contentSecurityPolicy());
     // Express app is itself a (req, res, next) handler. If no /api/* or /health
     // route matches, Express calls next() and we fall through to the Next
     // standalone server via the proxy below.

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,7 +1,7 @@
 import { fork, type ChildProcess } from 'node:child_process';
 import { createServer, request as httpRequest } from 'node:http';
 import { join } from 'node:path';
-import { app, BrowserWindow, dialog, Menu } from 'electron';
+import { app, BrowserWindow, dialog, Menu, shell } from 'electron';
 import { registerIpcHandlers } from './ipc.js';
 import { registerConfigIpc } from './config-ipc.js';
 import { handleAuroRoute } from './auro/router.js';
@@ -373,6 +373,23 @@ function openMainWindow(closeSetupWindow: (() => void) | null): void {
   // replace the window title on every navigation. Pin it to "MinaGuard".
   win.on('page-title-updated', (event) => {
     event.preventDefault();
+  });
+
+  // External URLs must never open in-app, an Electron window would inherit the
+  // preload and expose window.mina. Route http(s) to the OS browser, deny all.
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    let protocol = '';
+    try {
+      protocol = new URL(url).protocol;
+    } catch {
+      // malformed url, fall through to deny
+    }
+    if (protocol === 'http:' || protocol === 'https:') {
+      void shell.openExternal(url).catch((err) => {
+        console.error('[desktop] failed to open external url:', err.message);
+      });
+    }
+    return { action: 'deny' };
   });
 
   // Keep setup window alive until the main window has a content to show, then

--- a/docs/desktop-audit-guide.md
+++ b/docs/desktop-audit-guide.md
@@ -57,11 +57,14 @@ On launch (`src/main.ts`):
    after a **Host-header allowlist check** (`127.0.0.1:5050`/`localhost:5050`,
    else 403 — the DNS-rebinding defense, see focus point 2), `/auro/*` → the
    Auro signing bridge; `/api/*` and `/health` → the embedded backend;
-   everything else → reverse-proxied to the Next child.
+   everything else → reverse-proxied to the Next child. App and API responses
+   (not the Auro pages) carry a **Content-Security-Policy** header (focus point 7).
 5. The **main window** loads `http://127.0.0.1:5050` with a preload script
    that injects a `window.mina` implementation (backed by IPC, see below) and
    the runtime endpoint config (`window.__minaGuardConfig`, which
    `ui/lib/endpoints.ts` prefers over its build-time `NEXT_PUBLIC_*` values).
+   The window is locked to that origin: new windows are denied and in-frame
+   navigation is pinned (focus point 1).
 
 If startup with a saved config fails (endpoint moved, typo persisted), the
 setup window reopens seeded with the saved values and the error, instead of the
@@ -92,8 +95,10 @@ Signing inside the shell:
 │                      /auro/*          → auro/router.ts  (signing bridge)      │
 │                      /api/*, /health  → backend middleware                    │
 │                      everything else  → proxy → Next standalone child :5051   │
+│                      CSP header       → app+api responses (not /auro/*)       │
 │  ipc.ts            pending-request map (UUIDv4 ids, 120 s timeout)            │
 │  config-ipc.ts     validated config IPC (setup save / change endpoints)       │
+│  ipc-security.ts   assertMainWindow: rejects IPC from untrusted senders       │
 └────────▲──────────────────────────▲──────────────────────────────▲───────────┘
          │ IPC via contextBridge    │ HTTP (loopback)              │ GraphQL
 ┌────────┴───────────┐   ┌──────────┴──────────┐          ┌────────┴──────────┐
@@ -141,8 +146,10 @@ the real Auro extension living in the user's normal browser:
 ```
 
 Bridged methods: `requestAccounts`, `signFields`, `signMessage`,
-`sendTransaction` (`src/ipc.ts:88-103`). Two are answered locally without ever
-reaching Auro: `getAccounts` (stub, returns `[]`) and `requestNetwork`, which
+`sendTransaction` (`src/ipc.ts:88-108`); each handler first rejects IPC from any
+non-main-window sender (`assertMainWindow`, focus point 1). Two are answered
+locally without ever reaching Auro: `getAccounts` (stub, returns `[]`) and
+`requestNetwork`, which
 returns `mina:<networkId>` **from the persisted desktop config**, not from
 Auro (`src/preload.js:28-31`) — see focus point 6.
 
@@ -165,7 +172,7 @@ Deliberate design details worth knowing before auditing them:
 
 ## Ledger over WebHID
 
-`main.ts:390-413` wires the three handlers Electron needs for WebHID:
+`main.ts:466-489` wires the three handlers Electron needs for WebHID:
 
 - `select-hid-device` — intercepted; a picker overlay is injected into the page
   via `executeJavaScript` (`src/hid-picker.ts`) and the chosen `deviceId` is
@@ -195,7 +202,9 @@ macOS, `%APPDATA%\MinaGuard` on Windows):
 - **Validation is main-process-side.** The setup form and the in-app settings
   modal validate for UX only; the IPC layer re-validates the payload shape
   strictly (exact two string fields, http/https URLs —
-  `src/config-ipc.ts:25-54`) because the renderer is not trusted.
+  `src/config-ipc.ts:26-55`) because the renderer is not trusted, and
+  `config:set-endpoints` also rejects any non-main-window sender
+  (`assertMainWindow`, focus point 1).
 - **Endpoints are probed before persisting** (`verifyEndpoints`,
   `src/config-store.ts:93-115`): both must answer a real GraphQL POST within
   10 s. The network id is taken from the node's `networkID` field; only if the
@@ -205,7 +214,7 @@ macOS, `%APPDATA%\MinaGuard` on Windows):
   sharing testnet) is rejected at save time — the bundled circuit can only
   prove against one domain.
 - **Changing endpoints wipes the local DB and relaunches**
-  (`changeEndpointsAndRelaunch`, `src/main.ts:277-291`): the local index is
+  (`changeEndpointsAndRelaunch`, `src/main.ts:349-363`): the local index is
   only meaningful for the chain it was built against. The same policy applies
   in the setup-recovery flow. A failed save never overwrites a working config.
 - Config writes are atomic (tmp file + rename); DB deletion also removes
@@ -274,17 +283,22 @@ indexer could online.
 
 #### Suggested focus points
 
-**1. The renderer bridge × navigation policy (`src/preload.js`, `src/main.ts`).**
+**1. The renderer trust boundary (`src/main.ts`, `src/ipc-security.ts`, `src/preload.js`).**
 The preload exposes `window.mina` (signing triggers) and
 `minaGuardConfig.setEndpoints` (endpoint rewrite + DB wipe + relaunch) to
-whatever document the main window loads, and `main.ts` sets no `will-navigate`
-handler or `setWindowOpenHandler`, so any document that loads there inherits
-both.
+whatever document the main window loads. Three origin-based layers gate that
+bridge. `hardenWindow` (`main.ts:191-224`) denies new-window creation
+(`setWindowOpenHandler`; http(s) links are routed to the OS browser via
+`shell.openExternal`) and pins in-frame navigation to `http://127.0.0.1:5050`
+(`will-frame-navigate`; the setup window blocks *all* navigation, being a static
+`file://` page). `assertMainWindow` (`src/ipc-security.ts`) rejects any
+`auro:*` / `config:set-endpoints` IPC whose `senderFrame` origin isn't the local
+origin (`nodeIntegrationInSubFrames` is off, so only the main frame sends IPC).
 
 **2. The loopback HTTP surface (`127.0.0.1:5050`).**
 Reachable by every local process and, within limits, by web pages the user
 visits. Its defenses: a Host-header allowlist (`main.ts:26`, checked first at
-`100-103`) against DNS rebinding, no CORS headers anywhere (so no cross-origin
+`128-131`) against DNS rebinding, no CORS headers anywhere (so no cross-origin
 reads), and the UUIDv4 request id as the per-request token. Cross-origin
 "simple" POSTs (`/auro/callback`, subscribe/unsubscribe) satisfy the
 allowlist, and the id rides a URL handed to the OS browser
@@ -303,7 +317,9 @@ settings-modal and setup-window IPC.
 **4. Electron hardening posture (`src/main.ts`).**
 The windows rely on modern Electron defaults (context isolation on, node
 integration off, sandboxed renderers) rather than explicit settings, so the
-posture tracks the pinned major (`electron ^43`, Dependabot-grouped).
+posture tracks the pinned major (`electron ^43`, Dependabot-grouped). Navigation
+and new-window creation are the exception — hardened explicitly via
+`hardenWindow` (focus point 1) rather than left to defaults.
 Deliberate loosenings: `setPermissionCheckHandler(() => true)`,
 `setDevicePermissionHandler` granting every non-HID device type, dev-only
 `electron --no-sandbox`, and ad-hoc-only macOS signing
@@ -324,6 +340,16 @@ is answered locally from config, while `sendTransaction` broadcasts through
 Auro's node. The per-network VK and the fee-payer signature domain are what
 constrain a mismatch.
 
+**7. Content-Security-Policy on the app surface (`src/main.ts`).**
+`contentSecurityPolicy` (`97-120`) is set on every app + API response (not the
+`/auro/*` pages, which run in the external browser) via `res.setHeader`.
+`connect-src` is built dynamically from `currentConfig` — the configured
+Mina/archive origins plus `'self'`, since the o1js worker broadcasts to them
+directly, and `'self'` only before the first save. `script-src` allows
+`'unsafe-eval'`/`'wasm-unsafe-eval'` and `worker-src` allows `blob:`, both
+required by o1js proving; `default-src 'self'` with
+`object-src`/`frame-src`/`frame-ancestors 'none'` cover the rest.
+
 ---
 
 ## File tree
@@ -332,13 +358,18 @@ constrain a mismatch.
 desktop/
 ├── src/
 │   ├── main.ts              # Entry: boot order, setup-window flow, front server
-│   │                        #   (5050), Next child (5051), main window, HID handlers
-│   ├── ipc.ts               # auro:* IPC handlers + pending-request map (UUID ids,
-│   │                        #   120 s timeout); opens the external browser
+│   │                        #   (5050), Next child (5051), main window, HID handlers,
+│   │                        #   window nav lockdown (hardenWindow) + CSP header
+│   ├── ipc.ts               # auro:* IPC handlers (sender-origin checked) +
+│   │                        #   pending-request map (UUID ids, 120 s timeout);
+│   │                        #   opens the external browser
+│   ├── ipc-security.ts      # assertMainWindow: rejects IPC whose sender
+│   │                        #   frame origin isn't the local app origin
 │   ├── preload.js           # Main window bridge: window.mina mock (→ IPC),
 │   │                        #   window.__minaGuardConfig, minaGuardConfig.setEndpoints
 │   ├── preload-setup.js     # Setup window bridge: getState/save/cancel
-│   ├── config-ipc.ts        # Strict payload validation for all config IPC
+│   ├── config-ipc.ts        # Strict payload validation for all config IPC;
+│   │                        #   set-endpoints sender-origin checked
 │   ├── config-store.ts      # config.json read/write, endpoint probing, network-id
 │   │                        #   detection, DB deletion
 │   ├── backend-embed.ts     # Boots the bundled backend in-process (SQLite, lite


### PR DESCRIPTION
  Hardens the Electron shell so untrusted content can't reach the Auro signing bridge (window.mina) or config IPC (zkao finding).

  - Deny new-window creation; external links open in the OS browser
  - Lock navigation to the local origin; same guard on the setup window (shared hardenWindow helper)
  - Reject auro:* and config:set-endpoints IPC from non-main-window senders (assertMainWindow)
  - CSP on app responses: no remote content, connect-src limited to self + the configured Mina/archive nodes