### PR TITLE
fix: offline CLI confirmation no TTY

### DIFF
--- a/docs/offline-audit-guide.md
+++ b/docs/offline-audit-guide.md
@@ -101,8 +101,10 @@ Progress goes to stderr; stdout stays pure JSON. The flow
    compile/prove/sign work or key use*, `renderBundleSummary` renders
    everything the proposal hash covers (action, contract, fee payer, fee,
    nonce, memo, expiry, the per-type body, a `*** MAINNET ***` banner when
-   applicable) and asks for `y`; `--yes` / `MINA_GUARD_ASSUME_YES=1` — or no
-   attached TTY — skips the prompt (see focus point 7).
+   applicable) and asks for `y` on the controlling terminal (`/dev/tty`, so
+   redirecting stdout/stderr cannot hide it); only `--yes` /
+   `MINA_GUARD_ASSUME_YES=1` skips the prompt, and with no terminal at all the
+   CLI aborts (see focus point 7).
 2. **Offline chain state** — an o1js network with dummy endpoints (the CLI
    never dials out), the bundled account snapshots injected into o1js's
    account cache, and the Merkle stores rebuilt by replaying the bundled
@@ -316,9 +318,13 @@ against real chain state at broadcast.
 `749-758`).** Unlike the web UI's compile-time-gated test hooks, this ships in
 every binary and is enabled by an env var.
 
-**7. Confirmation policy (`confirmOrExit`).** No attached TTY ⇒ proceed
-without prompting (with a log line); `--yes`/`MINA_GUARD_ASSUME_YES` skip it;
-an unreadable `/dev/tty` despite a TTY also proceeds.
+**7. Confirmation policy (`confirmOrExit`).** The summary and prompt go to
+`/dev/tty` rather than stderr, so `> signed.json 2>log` still prompts — an
+operator who redirected a stream is still sitting at a terminal. Every path
+other than an explicit `y`/`yes` fails closed with exit 1: an unopenable
+`/dev/tty` (Windows, detached, no controlling terminal), a failed read, EOF, or
+any other answer. `--yes` / `MINA_GUARD_ASSUME_YES=1` is the only way to sign
+without a human in the loop.
 
 **8. Upload validation (`UploadSignedResponse`).** The binding checks compare
 the response's `contractAddress`/`proposalHash` against the open

--- a/offline-cli/src/index.ts
+++ b/offline-cli/src/index.ts
@@ -57,8 +57,8 @@ if (!bundlePath || !rawKey) {
     '\n' +
     '  bundle.json        Path to the request bundle exported from the Mina Guard UI\n' +
     '  MINA_PRIVATE_KEY   Mina private key (base58, starts with EKE...)\n' +
-    '  --yes, -y          Skip the interactive sign confirmation\n' +
-    '                     (also via MINA_GUARD_ASSUME_YES=1)\n' +
+    '  --yes, -y          Skip the interactive sign confirmation; required when\n' +
+    '                     running without a terminal (also MINA_GUARD_ASSUME_YES=1)\n' +
     '\n' +
     'Output (signed transaction JSON) is written to stdout.\n' +
     'Redirect to a file:  ... mina-guard-cli bundle.json > signed.json',
@@ -91,7 +91,7 @@ async function main() {
   // terminal) require explicit confirmation — before any expensive
   // compile/prove/sign work and before touching the private key.
   const summary = renderBundleSummary(bundle);
-  confirmOrExit(summary, { assumeYes, stderrIsTty: !!process.stderr.isTTY }, log);
+  confirmOrExit(summary, { assumeYes }, log);
 
   let result: unknown;
 

--- a/offline-cli/src/summary.ts
+++ b/offline-cli/src/summary.ts
@@ -6,14 +6,17 @@
 // plaintext description of exactly what is about to be signed and (on a real
 // terminal) require an explicit y/N confirmation.
 //
-// Everything here writes to STDERR — stdout must stay pure signed-tx JSON.
+// stdout must stay pure signed-tx JSON, so nothing here writes to it. The
+// interactive prompt goes to the controlling terminal (/dev/tty) rather than
+// stderr, so that redirecting stderr cannot hide it; the non-interactive paths
+// write to stderr.
 //
 // Self-contained by convention (mirrors decodeTxMemo / normalizeTxType in
 // build-tx.ts): format helpers are duplicated from ui/lib/types.ts rather than
 // imported, so the CLI has no dependency on the web app.
 // ---------------------------------------------------------------------------
 
-import { openSync, readSync, closeSync } from 'fs';
+import { openSync, readSync, writeSync, closeSync } from 'fs';
 import {
   normalizeTxType,
   EMPTY_PUBKEY_B58,
@@ -275,11 +278,22 @@ export function renderBundleSummary(bundle: OfflineBundle): string {
 
 type LogFn = (msg: string) => void;
 
-/** Reads a single line from the controlling terminal (/dev/tty). */
-function readLineFromTty(): string | null {
-  let fd: number | null = null;
+/** Opens the controlling terminal for reading and writing, or returns null when
+ *  the process has none (Windows, detached, or a container with no tty). This
+ *  is deliberately independent of whether stdout/stderr are redirected: an
+ *  operator running `... > signed.json 2>log` still has a terminal, and it is
+ *  the only channel guaranteed to reach them. */
+function openTty(): number | null {
   try {
-    fd = openSync('/dev/tty', 'rs');
+    return openSync('/dev/tty', 'r+');
+  } catch {
+    return null;
+  }
+}
+
+/** Reads a single line from an open terminal fd. Returns null on read error. */
+function readLineFromFd(fd: number): string | null {
+  try {
     const buf = Buffer.alloc(1);
     let input = '';
     while (true) {
@@ -292,50 +306,60 @@ function readLineFromTty(): string | null {
     }
     return input;
   } catch {
-    return null; // no controlling terminal (e.g. Windows / detached)
-  } finally {
-    if (fd != null) {
-      try { closeSync(fd); } catch { /* ignore */ }
-    }
+    return null;
   }
 }
 
 /**
- * Prints the summary to stderr and, on a real terminal, requires explicit y/N
- * confirmation. Exits the process (code 1) if the user declines.
+ * Shows the operator exactly what is about to be signed and requires an
+ * explicit y/N confirmation before any key use. Exits (code 1) on anything
+ * other than an explicit yes.
  *
- * Non-interactive policy: when no TTY is attached (piped/CI/scripts) or when the
- * caller passes assumeYes, the summary is shown and signing proceeds without a
- * prompt. Only an attached terminal blocks for confirmation.
+ * The summary and prompt go to /dev/tty, not stderr, so redirecting stderr
+ * cannot silently skip the checkpoint — the operator is still at a terminal.
+ * When there is genuinely no terminal to ask, this fails closed rather than
+ * treating the absence of a prompt as approval: signing without a human in the
+ * loop has to be requested explicitly with --yes / MINA_GUARD_ASSUME_YES=1.
  */
 export function confirmOrExit(
   summary: string,
-  opts: { assumeYes: boolean; stderrIsTty: boolean },
+  opts: { assumeYes: boolean },
   log: LogFn,
 ): void {
-  process.stderr.write(summary + '\n');
-
   if (opts.assumeYes) {
+    process.stderr.write(summary + '\n');
     log('Confirmation bypassed (--yes / MINA_GUARD_ASSUME_YES).');
     return;
   }
-  if (!opts.stderrIsTty) {
-    log('No terminal attached — proceeding without interactive confirmation.');
-    return;
+
+  const fd = openTty();
+  if (fd == null) {
+    process.stderr.write(summary + '\n');
+    process.stderr.write(
+      '\nNo terminal available to confirm this signature.\n'
+      + 'Re-run from an interactive terminal, or pass --yes (or set\n'
+      + 'MINA_GUARD_ASSUME_YES=1) to sign without confirmation.\n'
+      + 'Aborted. No transaction was signed.\n',
+    );
+    process.exit(1);
   }
 
-  process.stderr.write('\nSign this transaction? [y/N]: ');
-  const answer = readLineFromTty();
-  if (answer == null) {
-    // Could not open /dev/tty despite isTTY — fall back to auto-proceed rather
-    // than deadlock, but make it visible.
-    log('Could not read from terminal — proceeding without confirmation.');
-    return;
+  let approved = false;
+  try {
+    writeSync(fd, summary + '\n');
+    writeSync(fd, '\nSign this transaction? [y/N]: ');
+    const answer = readLineFromFd(fd);
+    // A failed read (null) is not consent — fall through to abort.
+    const normalized = (answer ?? '').trim().toLowerCase();
+    approved = normalized === 'y' || normalized === 'yes';
+    if (!approved) writeSync(fd, 'Aborted. No transaction was signed.\n');
+  } catch {
+    // Any terminal I/O failure means we never got a confirmation.
+    approved = false;
+  } finally {
+    try { closeSync(fd); } catch { /* ignore */ }
   }
-  const normalized = answer.trim().toLowerCase();
-  if (normalized === 'y' || normalized === 'yes') {
-    return;
-  }
-  process.stderr.write('Aborted. No transaction was signed.\n');
+
+  if (approved) return;
   process.exit(1);
 }

--- a/offline-cli/src/tests/offline-cli-e2e.test.ts
+++ b/offline-cli/src/tests/offline-cli-e2e.test.ts
@@ -61,7 +61,9 @@ function runCLI(
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve) => {
     const proc = spawn('bun', ['run', CLI_PATH, bundlePath], {
-      env: { ...process.env, MINA_PRIVATE_KEY: privateKey, ...(process.env.SKIP_PROOFS ? { SKIP_PROOFS: process.env.SKIP_PROOFS } : {}), ...extraEnv },
+      // No controlling terminal under test — opt into non-interactive signing
+      // explicitly, as any non-interactive caller must.
+      env: { ...process.env, MINA_PRIVATE_KEY: privateKey, MINA_GUARD_ASSUME_YES: '1', ...(process.env.SKIP_PROOFS ? { SKIP_PROOFS: process.env.SKIP_PROOFS } : {}), ...extraEnv },
       cwd: join(import.meta.dirname, '..', '..'),
     });
     let stdout = '';
@@ -88,7 +90,7 @@ function runBinary(
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve) => {
     const proc = spawn(binaryPath, [bundlePath], {
-      env: { MINA_PRIVATE_KEY: privateKey, SKIP_PROOFS: '1' },
+      env: { MINA_PRIVATE_KEY: privateKey, SKIP_PROOFS: '1', MINA_GUARD_ASSUME_YES: '1' },
       cwd,
     });
     let stdout = '';

--- a/offline-cli/src/tests/offline-cli.test.ts
+++ b/offline-cli/src/tests/offline-cli.test.ts
@@ -37,10 +37,23 @@ function toFixedOwners(pubs: PublicKey[]): PublicKey[] {
   return padded.slice(0, MAX_OWNERS);
 }
 
-function runCLI(bundlePath: string, privateKey: string): Promise<{ stdout: string; stderr: string; code: number }> {
+function runCLI(
+  bundlePath: string,
+  privateKey: string,
+  opts: { assumeYes?: boolean } = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  // A spawned CLI has no controlling terminal, so it aborts at the confirmation
+  // gate unless the caller explicitly opts into non-interactive signing.
+  const assumeYes = opts.assumeYes ?? true;
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    MINA_PRIVATE_KEY: privateKey,
+  };
+  if (assumeYes) env.MINA_GUARD_ASSUME_YES = '1';
+  else delete env.MINA_GUARD_ASSUME_YES;
   return new Promise((resolve) => {
     const proc = spawn('bun', ['run', CLI_PATH, bundlePath], {
-      env: { ...process.env, MINA_PRIVATE_KEY: privateKey },
+      env,
       cwd: join(import.meta.dirname, '..', '..'),
     });
     let stdout = '';
@@ -99,6 +112,33 @@ describe('offline-cli', () => {
     const result = await runCLI(bundlePath, key);
     expect(result.code).not.toBe(0);
     expect(result.stderr).toContain('childPrivateKey');
+  }, 30_000);
+
+  it('aborts without touching the key when there is no terminal and no --yes', async () => {
+    // Same bundle as the case above, which with MINA_GUARD_ASSUME_YES gets far
+    // enough into signing to fail on the missing child key. Without it, the
+    // confirmation gate must stop it first: a run with no terminal attached is
+    // not consent, and nothing may be signed.
+    const bundlePath = join(tmpDir, 'no-tty-abort.json');
+    writeFileSync(bundlePath, JSON.stringify({
+      version: 1,
+      action: 'propose',
+      minaNetwork: 'testnet',
+      contractAddress: 'B62qiTKpEPjGTSHZrtM8uXiKgn8So916pLmNJKDhKeyBQL9TDb3nvBG',
+      feePayerAddress: 'B62qiTKpEPjGTSHZrtM8uXiKgn8So916pLmNJKDhKeyBQL9TDb3nvBG',
+      accounts: {},
+      events: [],
+      input: { txType: 'createChild', nonce: 1 },
+      configNonce: 0,
+      networkId: '1',
+    }));
+    const key = PrivateKey.random().toBase58();
+    const result = await runCLI(bundlePath, key, { assumeYes: false });
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('No terminal available to confirm');
+    // Stopped before any key use — never reached the child-key check.
+    expect(result.stderr).not.toContain('childPrivateKey');
+    expect(result.stdout).toBe('');
   }, 30_000);
 
   // -- Store rebuilding (in-process, uses internal logic) --


### PR DESCRIPTION
`confirmOrExit` gated on `process.stderr.isTTY` but read the answer from `/dev/tty`. That mismatch left two fail-open paths: redirecting stderr (`... > signed.json 2>log`) skipped the prompt and signed, and on Windows — where `/dev/tty` never opens — every run auto-approved after printing the prompt.

The summary and prompt now go to `/dev/tty` directly, so redirecting a stream can't hide the checkpoint, and every path other than an explicit `y` exits 1. `--yes` / `MINA_GUARD_ASSUME_YES=1` is the only bypass.

**Breaking:** non-interactive callers (scripts, CI) must pass `--yes` or they now exit 1 instead of signing.