### PR TITLE
fix(ui): don't warn that a pending setDelegate invalidates proposals

### DIFF
--- a/ui/app/transactions/new/page.tsx
+++ b/ui/app/transactions/new/page.tsx
@@ -280,7 +280,11 @@ function NewTransactionPageInner() {
                   (p) =>
                     p.status === 'pending' &&
                     p.txType &&
-                    ['addOwner', 'removeOwner', 'changeThreshold', 'setDelegate'].includes(p.txType)
+                    // Only owner-set / threshold changes bump the config nonce and thus
+                    // invalidate other pending proposals (MinaGuard.executeOwnerChange /
+                    // executeThresholdChange). setDelegate does NOT bump it, so a pending
+                    // setDelegate invalidates nothing and must not trigger this warning.
+                    ['addOwner', 'removeOwner', 'changeThreshold'].includes(p.txType)
                 ) && (
                   <div className="rounded-lg px-4 py-3 text-xs bg-yellow-400/10 text-yellow-400 border border-yellow-400/30">
                     There are pending governance proposals. If one executes before this proposal, the config nonce will change and this proposal will be invalidated.


### PR DESCRIPTION
## Summary

The new-proposal form shows *"There are pending governance proposals. If one executes before this proposal, the config nonce will change and this proposal will be invalidated"* whenever a pending proposal is classified as governance. That classification (`ui/app/transactions/new/page.tsx:283`) wrongly includes `setDelegate`.

`setDelegate` does **not** bump the config nonce — only owner-set and threshold changes do (`MinaGuard.executeOwnerChange` at `MinaGuard.ts:1233` and `executeThresholdChange` at `1298`; the contract even documents *"Does not bump configNonce"* on the delegate path, `MinaGuard.ts:1315`). So a pending `setDelegate` proposal invalidates nothing, and the banner is a false alarm.

## Fix

Remove `'setDelegate'` from the governance classification, leaving `addOwner` / `removeOwner` / `changeThreshold`.

## Impact

Display-only — no safety or on-chain behavior change. The contract already enforces config-nonce invalidation correctly; this only stops the UI from raising a misleading warning when a delegate change is pending.
